### PR TITLE
Restructure attributes

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -59,13 +59,13 @@ assert.equal(page.text, 'A text');
 There are many special attributes you can use defined under the PO namespace
 that simplify common patterns, i.e.
 
-```
+```js
 var page = PO.build({
-  title: PO.text('.title)
+  title: PO.text('.title')
 });
 ```
 
-The following is a comprehensive documentation of the available PO attribute
+The following is a comprehensive documentation of the available `PO` attribute
 helpers.
 
 ## Predicates

--- a/test-support/page-object.js
+++ b/test-support/page-object.js
@@ -11,7 +11,11 @@ import {
   textAttribute,
   valueAttribute
 } from './page-object/queries';
-import { clickable, fillable, visitable } from './page-object/actions';
+import {
+  clickableAttribute,
+  fillableAttribute,
+  visitableAttribute
+} from './page-object/actions';
 import { collection } from './page-object/collection';
 
 function component(definition) {
@@ -29,16 +33,16 @@ function component(definition) {
 export default {
   attribute:   attributeAttribute,
   build,
-  clickable,
+  clickable:   clickableAttribute,
   collection,
   component,
   count:       countAttribute,
-  fillable,
+  fillable:    fillableAttribute,
   hasClass:    hasClassAttribute,
   isHidden:    isHiddenAttribute,
   isVisible:   isVisibleAttribute,
   notHasClass: notHasClassAttribute,
   text:        textAttribute,
   value:       valueAttribute,
-  visitable
+  visitable:   visitableAttribute
 };

--- a/test-support/page-object.js
+++ b/test-support/page-object.js
@@ -1,6 +1,16 @@
 import { build } from './page-object/build';
-import { hasClass, notHasClass, isVisible, isHidden } from './page-object/predicates';
-import { attribute, count, text, value } from './page-object/queries';
+import {
+  hasClassAttribute,
+  notHasClassAttribute,
+  isVisibleAttribute,
+  isHiddenAttribute
+} from './page-object/predicates';
+import {
+  attributeAttribute,
+  countAttribute,
+  textAttribute,
+  valueAttribute
+} from './page-object/queries';
 import { clickable, fillable, visitable } from './page-object/actions';
 import { collection } from './page-object/collection';
 
@@ -17,18 +27,18 @@ function component(definition) {
 }
 
 export default {
-  attribute,
+  attribute:   attributeAttribute,
   build,
   clickable,
   collection,
   component,
-  count,
+  count:       countAttribute,
   fillable,
-  hasClass,
-  isHidden,
-  isVisible,
-  notHasClass,
-  text,
-  value,
+  hasClass:    hasClassAttribute,
+  isHidden:    isHiddenAttribute,
+  isVisible:   isVisibleAttribute,
+  notHasClass: notHasClassAttribute,
+  text:        textAttribute,
+  value:       valueAttribute,
   visitable
 };

--- a/test-support/page-object/actions.js
+++ b/test-support/page-object/actions.js
@@ -1,42 +1,33 @@
 /* global visit, fillIn, click */
 
-import { qualifySelector } from './helpers';
+import Attribute from './attribute';
 
-function action(fn) {
-  return function(selector, options = {}) {
-    return {
-      build: function(key, page) {
-        return function(...args) {
-          let qualifiedSelector = qualifySelector(options.scope || page.scope, selector);
+function visitable() {
+  this.page.lastPromise = visit(this.path);
 
-          page.lastPromise = fn(qualifiedSelector, ...args);
-
-          return page;
-        };
-      }
-    };
-  };
+  return this.page;
 }
 
-export function visitable(path) {
-  return {
-    build: function(key, page) {
-      return function() {
-        page.lastPromise = visit(path);
+function clickable() {
+  this.page.lastPromise = click(this.qualifiedSelector());
 
-        return page;
-      };
-    }
-  };
+  return this.page;
 }
 
-export var fillable = action((selector, text) => fillIn(selector, text));
-export var clickable = action((selector) => click(selector));
+function fillable(text) {
+  this.page.lastPromise = fillIn(this.qualifiedSelector(), text);
 
-// function clickableByText(selector, scope) {
-//   var qualifiedSelector = qualifySelector(scope, selector);
-// 
-//   return function(text) {
-//     return click('%@ :contains("%@"):last'.fmt(qualifiedSelector, text));
-//   };
-// }
+  return this.page;
+}
+
+export function visitableAttribute(path) {
+  return new Attribute(visitable, null, null, { path });
+}
+
+export function clickableAttribute(selector, options = {}) {
+  return new Attribute(clickable, selector, options);
+}
+
+export function fillableAttribute(selector, options = {}) {
+  return new Attribute(fillable, selector, options);
+}

--- a/test-support/page-object/attribute.js
+++ b/test-support/page-object/attribute.js
@@ -1,0 +1,27 @@
+import { qualifySelector } from './helpers';
+
+function qualifiedSelector() {
+  return qualifySelector(this.options.scope || this.page.scope, this.selector);
+}
+
+function Attribute(fn, selector = null, options = null, extraArgs = {}) {
+  this.fn = fn;
+  this.context = $.extend({ selector, options }, extraArgs);
+  this.context.qualifiedSelector = qualifiedSelector;
+}
+
+Attribute.prototype = {
+  build: function(key, page) {
+    var fn = this.fn,
+        context = this.context;
+
+    this.context.key = key;
+    this.context.page = page;
+
+    return function(...args) {
+      return fn.apply(context, args);
+    }
+  }
+};
+
+export default Attribute;

--- a/test-support/page-object/attribute.js
+++ b/test-support/page-object/attribute.js
@@ -1,13 +1,28 @@
+/* global findWithAssert, find */
+
 import { qualifySelector } from './helpers';
 
 function qualifiedSelector() {
   return qualifySelector(this.options.scope || this.page.scope, this.selector);
 }
 
+function findElementWithAssert() {
+  return findWithAssert(this.qualifiedSelector());
+}
+
+function findElement() {
+  return find(this.qualifiedSelector());
+}
+
 function Attribute(fn, selector = null, options = null, extraArgs = {}) {
   this.fn = fn;
-  this.context = $.extend({ selector, options }, extraArgs);
-  this.context.qualifiedSelector = qualifiedSelector;
+  this.context = $.extend({
+    element: findElement,
+    elementOrRaise: findElementWithAssert,
+    options,
+    qualifiedSelector,
+    selector
+  }, extraArgs);
 }
 
 Attribute.prototype = {

--- a/test-support/page-object/collection.js
+++ b/test-support/page-object/collection.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import { build } from './build';
-import { count } from './queries';
+import { countAttribute } from './queries';
 
 let extend = Ember.$.extend;
 
@@ -23,7 +23,7 @@ export function collection(definition) {
 
       // Add count attribute
       if (definition.count === undefined) {
-        definition.count = count(itemScope);
+        definition.count = countAttribute(itemScope);
       }
 
       collectionComponent = build(definition);

--- a/test-support/page-object/predicates.js
+++ b/test-support/page-object/predicates.js
@@ -3,25 +3,19 @@
 import Attribute from './attribute';
 
 function hasClass() {
-  let element = findWithAssert(this.qualifiedSelector());
-
-  return element.hasClass(this.cssClass);
+  return this.elementOrRaise().hasClass(this.cssClass);
 }
 
 function notHasClass() {
-  let element = findWithAssert(this.qualifiedSelector());
-
-  return !element.hasClass(this.cssClass);
+  return !this.elementOrRaise().hasClass(this.cssClass);
 }
 
 function isVisible() {
-  let element = findWithAssert(this.qualifiedSelector());
-
-  return element.is(':visible');
+  return this.elementOrRaise().is(':visible');
 }
 
 function isHidden() {
-  let element = find(this.qualifiedSelector());
+  let element = this.element();
 
   return (element.length > 0) ? element.is(':hidden') : true;
 }

--- a/test-support/page-object/predicates.js
+++ b/test-support/page-object/predicates.js
@@ -1,55 +1,43 @@
 /* global find, findWithAssert */
 
-import { qualifySelector } from './helpers';
+import Attribute from './attribute';
 
-export function hasClass(cssClass, selector, options = {}) {
-  return {
-    build: function(key, page) {
-      return function() {
-        let qualifiedSelector = qualifySelector(options.scope || page.scope, selector),
-            element = findWithAssert(qualifiedSelector);
+function hasClass() {
+  let element = findWithAssert(this.qualifiedSelector());
 
-        return element.hasClass(cssClass);
-      };
-    }
-  };
+  return element.hasClass(this.cssClass);
 }
 
-export function notHasClass(cssClass, selector, options = {}) {
-  return {
-    build: function(key, page) {
-      return function() {
-        let qualifiedSelector = qualifySelector(options.scope || page.scope, selector),
-            element = findWithAssert(qualifiedSelector);
+function notHasClass() {
+  let element = findWithAssert(this.qualifiedSelector());
 
-        return !element.hasClass(cssClass);
-      };
-    }
-  };
+  return !element.hasClass(this.cssClass);
 }
 
-export function isVisible(selector, options = {}) {
-  return {
-    build: function(key, page) {
-      return function() {
-        let qualifiedSelector = qualifySelector(options.scope || page.scope, selector),
-            element = findWithAssert(qualifiedSelector);
+function isVisible() {
+  let element = findWithAssert(this.qualifiedSelector());
 
-        return element.is(':visible');
-      };
-    }
-  };
+  return element.is(':visible');
 }
 
-export function isHidden(selector, options = {}) {
-  return {
-    build: function(key, page) {
-      return function() {
-        let qualifiedSelector = qualifySelector(options.scope || page.scope, selector),
-            element = find(qualifiedSelector);
+function isHidden() {
+  let element = find(this.qualifiedSelector());
 
-        return (element.length > 0) ? element.is(':hidden') : true;
-      };
-    }
-  };
+  return (element.length > 0) ? element.is(':hidden') : true;
+}
+
+export function notHasClassAttribute(cssClass, selector, options = {}) {
+  return new Attribute(notHasClass, selector, options, { cssClass });
+}
+
+export function hasClassAttribute(cssClass, selector, options = {}) {
+  return new Attribute(hasClass, selector, options, { cssClass });
+}
+
+export function isVisibleAttribute(selector, options = {}) {
+  return new Attribute(isVisible, selector, options);
+}
+
+export function isHiddenAttribute(selector, options = {}) {
+  return new Attribute(isHidden, selector, options);
 }

--- a/test-support/page-object/queries.js
+++ b/test-support/page-object/queries.js
@@ -1,43 +1,44 @@
 /* global findWithAssert */
 
-import { qualifySelector, trim } from './helpers';
+import { trim } from './helpers';
+import Attribute from './attribute';
 
-export function attribute(attributeName, selector, options = {}) {
-  return {
-    build: function(key, page) {
-      return function(...args) {
-        let qualifiedSelector = qualifySelector(options.scope || page.scope, selector),
-            element = findWithAssert(qualifiedSelector);
+function attribute() {
+  let element = findWithAssert(this.qualifiedSelector());
 
-        return element.attr(attributeName);
-      };
-    }
-  };
+  return element.attr(this.attributeName);
 }
 
-function query(fn, useFind = false) {
-  return function(selector, options = {}) {
-    return {
-      build: function(key, page) {
-        return function(...args) {
-          let qualifiedSelector = qualifySelector(options.scope || page.scope, selector),
-              element;
+function count() {
+  let element = find(this.qualifiedSelector());
 
-          element = (useFind) ? find(qualifiedSelector) : findWithAssert(qualifiedSelector);
-
-          return fn(element, ...args);
-        };
-      }
-    };
-  };
+  return element.length;
 }
 
-const count = query(elements => elements.length, true),
-      text = query(element => trim(element.text())),
-      value = query(element => element.val());
+function text() {
+  let element = findWithAssert(this.qualifiedSelector());
 
-export {
-  count,
-  text,
-  value
-};
+  return trim(element.text());
+}
+
+function value() {
+  let element = findWithAssert(this.qualifiedSelector());
+
+  return trim(element.val());
+}
+
+export function attributeAttribute(attributeName, selector, options = {}) {
+  return new Attribute(attribute, selector, options, { attributeName });
+}
+
+export function countAttribute(selector, options = {}) {
+  return new Attribute(count, selector, options);
+}
+
+export function textAttribute(selector, options = {}) {
+  return new Attribute(text, selector, options);
+}
+
+export function valueAttribute(selector, options = {}) {
+  return new Attribute(value, selector, options);
+}

--- a/test-support/page-object/queries.js
+++ b/test-support/page-object/queries.js
@@ -1,30 +1,20 @@
-/* global findWithAssert */
-
 import { trim } from './helpers';
 import Attribute from './attribute';
 
 function attribute() {
-  let element = findWithAssert(this.qualifiedSelector());
-
-  return element.attr(this.attributeName);
+  return this.elementOrRaise().attr(this.attributeName);
 }
 
 function count() {
-  let element = find(this.qualifiedSelector());
-
-  return element.length;
+  return this.element().length;
 }
 
 function text() {
-  let element = findWithAssert(this.qualifiedSelector());
-
-  return trim(element.text());
+  return trim(this.elementOrRaise().text())
 }
 
 function value() {
-  let element = findWithAssert(this.qualifiedSelector());
-
-  return trim(element.val());
+  return this.elementOrRaise().val();
 }
 
 export function attributeAttribute(attributeName, selector, options = {}) {

--- a/tests/unit/actions/clickable-test.js
+++ b/tests/unit/actions/clickable-test.js
@@ -1,0 +1,50 @@
+import {
+  buildAttribute,
+  buildAttributeWithOptions,
+  it,
+  itBehavesLikeAnAttribute,
+  moduleFor
+} from '../test-helper';
+import { clickable } from '../../page-object/actions';
+
+let OriginalClick = window.click;
+
+moduleFor('Actions', 'clickable', {
+  afterEach: function() {
+    window.click = OriginalClick;
+  }
+});
+
+itBehavesLikeAnAttribute(clickable);
+
+it('calls Ember\'s click helper', function(assert) {
+  assert.expect(1);
+
+  let expectedSelector = 'button';
+
+  window.click = function(actualSelector) {
+    assert.equal(actualSelector, expectedSelector);
+  };
+
+  buildAttribute(clickable, expectedSelector)();
+});
+
+it('uses scope', function(assert) {
+  assert.expect(1);
+
+  window.click = function(actualSelector) {
+    assert.equal(actualSelector, '.scope .element');
+  };
+
+  buildAttribute(clickable, '.element', { scope: '.scope' })();
+});
+
+it('uses page scope', function(assert) {
+  assert.expect(1);
+
+  window.click = function(actualSelector) {
+    assert.equal(actualSelector, '.scope .element');
+  };
+
+  buildAttributeWithOptions(clickable, { scope: '.scope' }, '.element')();
+});

--- a/tests/unit/actions/clickable-test.js
+++ b/tests/unit/actions/clickable-test.js
@@ -5,17 +5,17 @@ import {
   itBehavesLikeAnAttribute,
   moduleFor
 } from '../test-helper';
-import { clickable } from '../../page-object/actions';
+import { clickableAttribute } from '../../page-object/actions';
 
 let OriginalClick = window.click;
 
-moduleFor('Actions', 'clickable', {
+moduleFor('Actions', 'clickableAttribute', {
   afterEach: function() {
     window.click = OriginalClick;
   }
 });
 
-itBehavesLikeAnAttribute(clickable);
+itBehavesLikeAnAttribute(clickableAttribute);
 
 it('calls Ember\'s click helper', function(assert) {
   assert.expect(1);
@@ -26,7 +26,7 @@ it('calls Ember\'s click helper', function(assert) {
     assert.equal(actualSelector, expectedSelector);
   };
 
-  buildAttribute(clickable, expectedSelector)();
+  buildAttribute(clickableAttribute, expectedSelector)();
 });
 
 it('uses scope', function(assert) {
@@ -36,7 +36,7 @@ it('uses scope', function(assert) {
     assert.equal(actualSelector, '.scope .element');
   };
 
-  buildAttribute(clickable, '.element', { scope: '.scope' })();
+  buildAttribute(clickableAttribute, '.element', { scope: '.scope' })();
 });
 
 it('uses page scope', function(assert) {
@@ -46,5 +46,5 @@ it('uses page scope', function(assert) {
     assert.equal(actualSelector, '.scope .element');
   };
 
-  buildAttributeWithOptions(clickable, { scope: '.scope' }, '.element')();
+  buildAttributeWithOptions(clickableAttribute, { scope: '.scope' }, '.element')();
 });

--- a/tests/unit/actions/fillable-test.js
+++ b/tests/unit/actions/fillable-test.js
@@ -1,0 +1,52 @@
+import {
+  buildAttribute,
+  buildAttributeWithOptions,
+  it,
+  itBehavesLikeAnAttribute,
+  moduleFor
+} from '../test-helper';
+import { fillable } from '../../page-object/actions';
+
+let OriginalFillIn = window.fillIn;
+
+moduleFor('Actions', 'fillable', {
+  afterEach: function() {
+    window.fillIn = OriginalFillIn;
+  }
+});
+
+itBehavesLikeAnAttribute(fillable);
+
+it('calls Ember\'s fillIn helper', function(assert) {
+  assert.expect(2);
+
+  let selector = '.element',
+      text = 'dummy text';
+
+  window.fillIn = function(actualSelector, actualText) {
+    assert.equal(actualSelector, selector);
+    assert.equal(actualText, text);
+  };
+
+  buildAttribute(fillable, selector)(text);
+});
+
+it('uses scope', function(assert) {
+  assert.expect(1);
+
+  window.fillIn = function(actualSelector) {
+    assert.equal(actualSelector, '.scope .element');
+  };
+
+  buildAttribute(fillable, '.element', { scope: '.scope' })();
+});
+
+it('uses page scope', function(assert) {
+  assert.expect(1);
+
+  window.fillIn = function(actualSelector) {
+    assert.equal(actualSelector, '.scope .element');
+  };
+
+  buildAttributeWithOptions(fillable, { scope: '.scope' }, '.element')();
+});

--- a/tests/unit/actions/fillable-test.js
+++ b/tests/unit/actions/fillable-test.js
@@ -5,17 +5,17 @@ import {
   itBehavesLikeAnAttribute,
   moduleFor
 } from '../test-helper';
-import { fillable } from '../../page-object/actions';
+import { fillableAttribute } from '../../page-object/actions';
 
 let OriginalFillIn = window.fillIn;
 
-moduleFor('Actions', 'fillable', {
+moduleFor('Actions', 'fillableAttribute', {
   afterEach: function() {
     window.fillIn = OriginalFillIn;
   }
 });
 
-itBehavesLikeAnAttribute(fillable);
+itBehavesLikeAnAttribute(fillableAttribute);
 
 it('calls Ember\'s fillIn helper', function(assert) {
   assert.expect(2);
@@ -28,7 +28,7 @@ it('calls Ember\'s fillIn helper', function(assert) {
     assert.equal(actualText, text);
   };
 
-  buildAttribute(fillable, selector)(text);
+  buildAttribute(fillableAttribute, selector)(text);
 });
 
 it('uses scope', function(assert) {
@@ -38,7 +38,7 @@ it('uses scope', function(assert) {
     assert.equal(actualSelector, '.scope .element');
   };
 
-  buildAttribute(fillable, '.element', { scope: '.scope' })();
+  buildAttribute(fillableAttribute, '.element', { scope: '.scope' })();
 });
 
 it('uses page scope', function(assert) {
@@ -48,5 +48,5 @@ it('uses page scope', function(assert) {
     assert.equal(actualSelector, '.scope .element');
   };
 
-  buildAttributeWithOptions(fillable, { scope: '.scope' }, '.element')();
+  buildAttributeWithOptions(fillableAttribute, { scope: '.scope' }, '.element')();
 });

--- a/tests/unit/actions/visitable-test.js
+++ b/tests/unit/actions/visitable-test.js
@@ -1,0 +1,29 @@
+import {
+  buildAttribute,
+  it,
+  itBehavesLikeAnAttribute,
+  moduleFor
+} from '../test-helper';
+import { visitable } from '../../page-object/actions';
+
+let OriginalVisit = window.visit;
+
+moduleFor('Actions', 'visitable', {
+  afterEach: function() {
+    window.visit = OriginalVisit;
+  }
+});
+
+itBehavesLikeAnAttribute(visitable);
+
+it('calls Ember\'s visit helper', function(assert) {
+  assert.expect(1);
+
+  let expectedRoute = '/dummy-page';
+
+  window.visit = function(actualRoute) {
+    assert.equal(actualRoute, expectedRoute);
+  };
+
+  buildAttribute(visitable, expectedRoute)();
+});

--- a/tests/unit/actions/visitable-test.js
+++ b/tests/unit/actions/visitable-test.js
@@ -4,17 +4,17 @@ import {
   itBehavesLikeAnAttribute,
   moduleFor
 } from '../test-helper';
-import { visitable } from '../../page-object/actions';
+import { visitableAttribute } from '../../page-object/actions';
 
 let OriginalVisit = window.visit;
 
-moduleFor('Actions', 'visitable', {
+moduleFor('Actions', 'visitableAttribute', {
   afterEach: function() {
     window.visit = OriginalVisit;
   }
 });
 
-itBehavesLikeAnAttribute(visitable);
+itBehavesLikeAnAttribute(visitableAttribute);
 
 it('calls Ember\'s visit helper', function(assert) {
   assert.expect(1);
@@ -25,5 +25,5 @@ it('calls Ember\'s visit helper', function(assert) {
     assert.equal(actualRoute, expectedRoute);
   };
 
-  buildAttribute(visitable, expectedRoute)();
+  buildAttribute(visitableAttribute, expectedRoute)();
 });

--- a/tests/unit/predicates/has-class-test.js
+++ b/tests/unit/predicates/has-class-test.js
@@ -6,16 +6,16 @@ import {
   itBehavesLikeAnAttribute,
   moduleFor
 } from '../test-helper';
-import { hasClass } from '../../page-object/predicates';
+import { hasClassAttribute } from '../../page-object/predicates';
 
-moduleFor('Predicates', 'hasClass');
+moduleFor('Predicates', 'hasClassAttribute');
 
-itBehavesLikeAnAttribute(hasClass);
+itBehavesLikeAnAttribute(hasClassAttribute);
 
 it('returns true when the element has the class', function(assert) {
   fixture('<div class="element has-error" />');
 
-  var predicate = buildAttribute(hasClass, 'has-error', '.element');
+  var predicate = buildAttribute(hasClassAttribute, 'has-error', '.element');
 
   assert.ok(predicate());
 });
@@ -23,7 +23,7 @@ it('returns true when the element has the class', function(assert) {
 it('returns false when the element doesn\'t have the class', function(assert) {
   fixture('<div class="element" />');
 
-  var predicate = buildAttribute(hasClass, 'has-error', '.element');
+  var predicate = buildAttribute(hasClassAttribute, 'has-error', '.element');
 
   assert.ok(!predicate());
 });
@@ -31,7 +31,7 @@ it('returns false when the element doesn\'t have the class', function(assert) {
 it('raises an error when the element doesn\'t exist', function(assert) {
   assert.expect(1);
 
-  var predicate = buildAttribute(hasClass, 'has-error', '.element');
+  var predicate = buildAttribute(hasClassAttribute, 'has-error', '.element');
 
   try {
     predicate();
@@ -43,7 +43,7 @@ it('raises an error when the element doesn\'t exist', function(assert) {
 it('uses scope', function(assert) {
   fixture('<div class="element scope"><div class="element has-error" /></div>');
 
-  var predicate = buildAttribute(hasClass, 'has-error', '.element:first', { scope: '.scope' });
+  var predicate = buildAttribute(hasClassAttribute, 'has-error', '.element:first', { scope: '.scope' });
 
   assert.ok(predicate());
 });
@@ -51,7 +51,7 @@ it('uses scope', function(assert) {
 it('uses page scope', function(assert) {
   fixture('<div class="element scope"><div class="element has-error" /></div>');
 
-  var predicate = buildAttributeWithOptions(hasClass, { scope: '.scope' }, 'has-error', '.element:first');
+  var predicate = buildAttributeWithOptions(hasClassAttribute, { scope: '.scope' }, 'has-error', '.element:first');
 
   assert.ok(predicate());
 });

--- a/tests/unit/predicates/is-hidden-test.js
+++ b/tests/unit/predicates/is-hidden-test.js
@@ -6,22 +6,22 @@ import {
   itBehavesLikeAnAttribute,
   moduleFor
 } from '../test-helper';
-import { isHidden } from '../../page-object/predicates';
+import { isHiddenAttribute } from '../../page-object/predicates';
 
-moduleFor('Predicates', 'isHidden');
+moduleFor('Predicates', 'isHiddenAttribute');
 
-itBehavesLikeAnAttribute(isHidden);
+itBehavesLikeAnAttribute(isHiddenAttribute);
 
 it('returns true when the element is hidden', function(assert) {
   fixture('<div class="element" style="display:none" />');
 
-  var predicate = buildAttribute(isHidden, '.element');
+  var predicate = buildAttribute(isHiddenAttribute, '.element');
 
   assert.ok(predicate());
 });
 
 it('returns true when the element doesn\'t exist in the DOM', function(assert) {
-  var predicate = buildAttribute(isHidden, '.element');
+  var predicate = buildAttribute(isHiddenAttribute, '.element');
 
   assert.ok(predicate());
 });
@@ -29,7 +29,7 @@ it('returns true when the element doesn\'t exist in the DOM', function(assert) {
 it('returns false when the element is visible', function(assert) {
   fixture('<div class="element" />');
 
-  var predicate = buildAttribute(isHidden, '.element');
+  var predicate = buildAttribute(isHiddenAttribute, '.element');
 
   assert.ok(!predicate());
 });
@@ -37,7 +37,7 @@ it('returns false when the element is visible', function(assert) {
 it('uses scope', function(assert) {
   fixture('<div class="element" /><div class="scope"><div class="element" style="display:none" /></div>');
 
-  var predicate = buildAttribute(isHidden, '.element:first', { scope: '.scope' });
+  var predicate = buildAttribute(isHiddenAttribute, '.element:first', { scope: '.scope' });
 
   assert.ok(predicate());
 });
@@ -45,7 +45,7 @@ it('uses scope', function(assert) {
 it('uses page scope', function(assert) {
   fixture('<div class="element" /><div class="scope"><div class="element" style="display:none" /></div>');
 
-  var predicate = buildAttributeWithOptions(isHidden, { scope: '.scope' }, '.element:first');
+  var predicate = buildAttributeWithOptions(isHiddenAttribute, { scope: '.scope' }, '.element:first');
 
   assert.ok(predicate());
 });

--- a/tests/unit/predicates/is-visible-test.js
+++ b/tests/unit/predicates/is-visible-test.js
@@ -6,16 +6,16 @@ import {
   itBehavesLikeAnAttribute,
   moduleFor
 } from '../test-helper';
-import { isVisible } from '../../page-object/predicates';
+import { isVisibleAttribute } from '../../page-object/predicates';
 
-moduleFor('Predicates', 'isVisible');
+moduleFor('Predicates', 'isVisibleAttribute');
 
-itBehavesLikeAnAttribute(isVisible);
+itBehavesLikeAnAttribute(isVisibleAttribute);
 
 it('returns true when the element is visible', function(assert) {
   fixture('<div class="element" />');
 
-  var predicate = buildAttribute(isVisible, '.element');
+  var predicate = buildAttribute(isVisibleAttribute, '.element');
 
   assert.ok(predicate());
 });
@@ -23,7 +23,7 @@ it('returns true when the element is visible', function(assert) {
 it('returns false when the element is hidden', function(assert) {
   fixture('<div class="element" style="display:none" />');
 
-  var predicate = buildAttribute(isVisible, '.element');
+  var predicate = buildAttribute(isVisibleAttribute, '.element');
 
   assert.ok(!predicate());
 });
@@ -31,7 +31,7 @@ it('returns false when the element is hidden', function(assert) {
 it('throws an error when the element doesn\'t exist in the DOM', function(assert) {
   assert.expect(1);
 
-  var predicate = buildAttribute(isVisible, '.element');
+  var predicate = buildAttribute(isVisibleAttribute, '.element');
 
   try {
     predicate();
@@ -43,7 +43,7 @@ it('throws an error when the element doesn\'t exist in the DOM', function(assert
 it('uses scope', function(assert) {
   fixture('<div class="element" style="display:none" /><div class="scope"><div class="element" /></div>');
 
-  var predicate = buildAttribute(isVisible, '.element:first', { scope: '.scope' });
+  var predicate = buildAttribute(isVisibleAttribute, '.element:first', { scope: '.scope' });
 
   assert.ok(predicate());
 });
@@ -51,7 +51,7 @@ it('uses scope', function(assert) {
 it('uses page scope', function(assert) {
   fixture('<div class="element" style="display:none" /><div class="scope"><div class="element" /></div>');
 
-  var predicate = buildAttributeWithOptions(isVisible, { scope: '.scope' }, '.element:first');
+  var predicate = buildAttributeWithOptions(isVisibleAttribute, { scope: '.scope' }, '.element:first');
 
   assert.ok(predicate());
 });

--- a/tests/unit/predicates/not-has-class-test.js
+++ b/tests/unit/predicates/not-has-class-test.js
@@ -6,16 +6,16 @@ import {
   itBehavesLikeAnAttribute,
   moduleFor
 } from '../test-helper';
-import { notHasClass } from '../../page-object/predicates';
+import { notHasClassAttribute } from '../../page-object/predicates';
 
-moduleFor('Predicates', 'notHasClass');
+moduleFor('Predicates', 'notHasClassAttribute');
 
-itBehavesLikeAnAttribute(notHasClass);
+itBehavesLikeAnAttribute(notHasClassAttribute);
 
 it('returns false when the element has the class', function(assert) {
   fixture('<div class="element has-error" />');
 
-  var predicate = buildAttribute(notHasClass, 'has-error', '.element');
+  var predicate = buildAttribute(notHasClassAttribute, 'has-error', '.element');
 
   assert.ok(!predicate());
 });
@@ -23,7 +23,7 @@ it('returns false when the element has the class', function(assert) {
 it('returns true when the element doesn\'t have the class', function(assert) {
   fixture('<div class="element" />');
 
-  var predicate = buildAttribute(notHasClass, 'has-error', '.element');
+  var predicate = buildAttribute(notHasClassAttribute, 'has-error', '.element');
 
   assert.ok(predicate());
 });
@@ -31,7 +31,7 @@ it('returns true when the element doesn\'t have the class', function(assert) {
 it('raises an error when the element doesn\'t exist', function(assert) {
   assert.expect(1);
 
-  var predicate = buildAttribute(notHasClass, 'has-error', '.element');
+  var predicate = buildAttribute(notHasClassAttribute, 'has-error', '.element');
 
   try {
     predicate();
@@ -43,7 +43,7 @@ it('raises an error when the element doesn\'t exist', function(assert) {
 it('uses scope', function(assert) {
   fixture('<div class="element scope has-error"><div class="element" /></div>');
 
-  var predicate = buildAttribute(notHasClass, 'has-error', '.element:first', { scope: '.scope' });
+  var predicate = buildAttribute(notHasClassAttribute, 'has-error', '.element:first', { scope: '.scope' });
 
   assert.ok(predicate());
 });
@@ -51,7 +51,7 @@ it('uses scope', function(assert) {
 it('uses page scope', function(assert) {
   fixture('<div class="element scope has-error"><div class="element" /></div>');
 
-  var predicate = notHasClass('has-error', '.element:first').build('key', { scope: '.scope' });
+  var predicate = buildAttributeWithOptions(notHasClassAttribute, { scope: '.scope' }, 'has-error', '.element:first');
 
   assert.ok(predicate());
 });

--- a/tests/unit/queries/attribute-test.js
+++ b/tests/unit/queries/attribute-test.js
@@ -6,16 +6,16 @@ import {
   itBehavesLikeAnAttribute,
   moduleFor
 } from '../test-helper';
-import { attribute } from '../../page-object/queries';
+import { attributeAttribute } from '../../page-object/queries';
 
-moduleFor('Queries', 'attribute');
+moduleFor('Queries', 'attributeAttribute');
 
-itBehavesLikeAnAttribute(attribute);
+itBehavesLikeAnAttribute(attributeAttribute);
 
 it('returns element attribute\'s value', function(assert) {
   fixture('<img src="/path/to/image.png" />');
 
-  var attr = buildAttribute(attribute, 'src', 'img');
+  var attr = buildAttribute(attributeAttribute, 'src', 'img');
 
   assert.equal(attr(), '/path/to/image.png');
 });
@@ -23,7 +23,7 @@ it('returns element attribute\'s value', function(assert) {
 it('returns null when the attribute doesn\'t exist', function(assert) {
   fixture('<img />');
 
-  var attr = buildAttribute(attribute, 'alt', 'img');
+  var attr = buildAttribute(attributeAttribute, 'alt', 'img');
 
   assert.equal(attr(), null);
 });
@@ -32,7 +32,7 @@ it('raises an error when the element doesn\'t exist', function(assert) {
   assert.expect(1);
 
   try {
-    let attr = buildAttribute(attribute, 'alt', 'img');
+    let attr = buildAttribute(attributeAttribute, 'alt', 'img');
 
     attr();
   } catch(e) {
@@ -43,7 +43,7 @@ it('raises an error when the element doesn\'t exist', function(assert) {
 it('uses scope', function(assert) {
   fixture('<div class="scope logo"><img class="logo" alt="Logo small" /></div>');
 
-  var attr = buildAttribute(attribute, 'alt', '.logo', { scope: '.scope' });
+  var attr = buildAttribute(attributeAttribute, 'alt', '.logo', { scope: '.scope' });
 
   assert.equal(attr(), 'Logo small');
 });
@@ -51,7 +51,7 @@ it('uses scope', function(assert) {
 it('uses page scope', function(assert) {
   fixture('<div class="scope logo"><img class="logo" alt="Logo small" /></div>');
 
-  var attr = buildAttributeWithOptions(attribute, { scope: '.scope' }, 'alt', '.logo');
+  var attr = buildAttributeWithOptions(attributeAttribute, { scope: '.scope' }, 'alt', '.logo');
 
   assert.equal(attr(), 'Logo small');
 });

--- a/tests/unit/queries/count-test.js
+++ b/tests/unit/queries/count-test.js
@@ -6,22 +6,22 @@ import {
   itBehavesLikeAnAttribute,
   moduleFor
 } from '../test-helper';
-import { count } from '../../page-object/queries';
+import { countAttribute } from '../../page-object/queries';
 
-moduleFor('Queries', 'count');
+moduleFor('Queries', 'countAttribute');
 
-itBehavesLikeAnAttribute(count);
+itBehavesLikeAnAttribute(countAttribute);
 
 it('returns the number of elements that match the selector', function(assert) {
   fixture('<span /><span />');
 
-  var attr = buildAttribute(count, 'span');
+  var attr = buildAttribute(countAttribute, 'span');
 
   assert.equal(attr(), 2);
 });
 
 it('returns 0 when the selector doesn\'t match elements', function(assert) {
-  var attr = buildAttribute(count, '.nothing');
+  var attr = buildAttribute(countAttribute, '.nothing');
 
   assert.equal(attr(), 0);
 });
@@ -29,7 +29,7 @@ it('returns 0 when the selector doesn\'t match elements', function(assert) {
 it('uses scope', function(assert) {
   fixture('<div class="scope"><span /></div><span />');
 
-  var attr = buildAttribute(count, 'span', { scope: '.scope' });
+  var attr = buildAttribute(countAttribute, 'span', { scope: '.scope' });
 
   assert.equal(attr(), 1);
 });
@@ -37,7 +37,7 @@ it('uses scope', function(assert) {
 it('uses page scope', function(assert) {
   fixture('<div class="scope"><span /></div><span />');
 
-  var attr = buildAttributeWithOptions(count, { scope: '.scope' }, 'span');
+  var attr = buildAttributeWithOptions(countAttribute, { scope: '.scope' }, 'span');
 
   assert.equal(attr(), 1);
 });

--- a/tests/unit/queries/text-test.js
+++ b/tests/unit/queries/text-test.js
@@ -6,16 +6,16 @@ import {
   itBehavesLikeAnAttribute,
   moduleFor
 } from '../test-helper';
-import { text } from '../../page-object/queries';
+import { textAttribute } from '../../page-object/queries';
 
-moduleFor('Queries', 'text');
+moduleFor('Queries', 'textAttribute');
 
-itBehavesLikeAnAttribute(text);
+itBehavesLikeAnAttribute(textAttribute);
 
 it('returns the inner text of the element', function(assert) {
   fixture('Hello <span>world!</span>');
 
-  var attr = buildAttribute(text, 'span');
+  var attr = buildAttribute(textAttribute, 'span');
 
   assert.equal(attr(), 'world!');
 });
@@ -23,7 +23,7 @@ it('returns the inner text of the element', function(assert) {
 it('removes white spaces from the beginning and end of the text', function(assert) {
   fixture('<span>  awesome!  </span>');
 
-  var attr = buildAttribute(text, 'span');
+  var attr = buildAttribute(textAttribute, 'span');
 
   assert.equal(attr(), 'awesome!');
 });
@@ -31,7 +31,7 @@ it('removes white spaces from the beginning and end of the text', function(asser
 it('raises an error when the element doesn\'t exist', function(assert) {
   assert.expect(1);
 
-  var attr = buildAttribute(text, 'span');
+  var attr = buildAttribute(textAttribute, 'span');
 
   try {
     attr();
@@ -43,7 +43,7 @@ it('raises an error when the element doesn\'t exist', function(assert) {
 it('returns empty when the element doesn\'t have text', function(assert) {
   fixture('<span />');
 
-  var attr = buildAttribute(text, 'span');
+  var attr = buildAttribute(textAttribute, 'span');
 
   assert.equal(attr(), '');
 });
@@ -51,7 +51,7 @@ it('returns empty when the element doesn\'t have text', function(assert) {
 it('uses scope', function(assert) {
   fixture('<div class="scope"><span>Hello</span></div><span> world!</span>');
 
-  var attr = buildAttribute(text, 'span', { scope: '.scope' });
+  var attr = buildAttribute(textAttribute, 'span', { scope: '.scope' });
 
   assert.equal(attr(), 'Hello');
 });
@@ -59,7 +59,7 @@ it('uses scope', function(assert) {
 it('uses page scope', function(assert) {
   fixture('<div class="scope"><span>Hello</span></div><span> world!</span>');
 
-  var attr = buildAttributeWithOptions(text, { scope: '.scope' }, 'span');
+  var attr = buildAttributeWithOptions(textAttribute, { scope: '.scope' }, 'span');
 
   assert.equal(attr(), 'Hello');
 });

--- a/tests/unit/queries/value-test.js
+++ b/tests/unit/queries/value-test.js
@@ -6,16 +6,16 @@ import {
   itBehavesLikeAnAttribute,
   moduleFor
 } from '../test-helper';
-import { value } from '../../page-object/queries';
+import { valueAttribute } from '../../page-object/queries';
 
-moduleFor('Queries', 'value');
+moduleFor('Queries', 'valueAttribute');
 
-itBehavesLikeAnAttribute(value);
+itBehavesLikeAnAttribute(valueAttribute);
 
 it('returns the text of the input', function(assert) {
   fixture('<input value="Hello world" />');
 
-  var attr = buildAttribute(value, 'input');
+  var attr = buildAttribute(valueAttribute, 'input');
 
   assert.equal(attr(), 'Hello world');
 });
@@ -23,7 +23,7 @@ it('returns the text of the input', function(assert) {
 it('raises an error when the element doesn\'t exist', function(assert) {
   assert.expect(1);
 
-  var attr = buildAttribute(value, 'span');
+  var attr = buildAttribute(valueAttribute, 'span');
 
   try {
     attr();
@@ -35,7 +35,7 @@ it('raises an error when the element doesn\'t exist', function(assert) {
 it('returns empty when the element doesn\'t have value attribute', function(assert) {
   fixture('<span />');
 
-  var attr = buildAttribute(value, 'span');
+  var attr = buildAttribute(valueAttribute, 'span');
 
   assert.equal(attr(), '');
 });
@@ -43,7 +43,7 @@ it('returns empty when the element doesn\'t have value attribute', function(asse
 it('uses scope', function(assert) {
   fixture('<div class="scope"><input value="Hello" /></div><input value="world!" />');
 
-  var attr = buildAttribute(value, 'input', { scope: '.scope' });
+  var attr = buildAttribute(valueAttribute, 'input', { scope: '.scope' });
 
   assert.equal(attr(), 'Hello');
 });
@@ -51,7 +51,7 @@ it('uses scope', function(assert) {
 it('uses page scope', function(assert) {
   fixture('<div class="scope"><input value="Hello" /></div><input value="world!" />');
 
-  var attr = buildAttributeWithOptions(value, { scope: '.scope' }, 'input');
+  var attr = buildAttributeWithOptions(valueAttribute, { scope: '.scope' }, 'input');
 
   assert.equal(attr(), 'Hello');
 });

--- a/tests/unit/test-helper.js
+++ b/tests/unit/test-helper.js
@@ -1,10 +1,19 @@
 import { module, test } from 'qunit';
 
-export function moduleFor(category, helperName) {
+export function moduleFor(category, helperName, options = {}) {
   module(`${category} - .${helperName}`, {
+    beforeEach: function() {
+      if (options.beforeEach) {
+        options.beforeEach();
+      }
+    },
     afterEach: function() {
       // Cleanup DOM
       $('#ember-testing').html('');
+
+      if (options.afterEach) {
+        options.afterEach();
+      }
     }
   });
 }


### PR DESCRIPTION
The idea is that every attribute (i.e. `.hasClass`, `.isVisible`, `.clickable`, etc.) is an `Attribute` object.

Each attribute type executes a specific method within a context. That context has the `page`, `key`, `selector` and other attribute's options.

This makes it easy to create cross attribute functionality such as calculating the full qualified selector and it simplifies the creation of new functionalities (that will be shared on all attributes) such as index (see #3) and more to come.

This refactor is backwards compatible :smile_cat: 