### PR TITLE
Add support for dynamic segments in visitable urls

### DIFF
--- a/test-support/page-object/actions.js
+++ b/test-support/page-object/actions.js
@@ -2,8 +2,32 @@
 
 import Attribute from './attribute';
 
-function visitable() {
-  this.page.lastPromise = visit(this.path);
+function fillInDynamicSegments(path, params) {
+  return path.split('/').map(function(segment) {
+    let match;
+
+    if (match = segment.match(/^:(.+)$/)) {
+      let key = match[1];
+
+      if (!params[key]) {
+        throw new Error(`Missing parameter for '${key}'`);
+      }
+
+      return params[key];
+    }
+
+    return segment;
+  }).join('/');
+}
+
+function visitable(params = {}) {
+  let path = this.path;
+
+  if (path.indexOf(':') !== -1) {
+    path = fillInDynamicSegments(path, params);
+  }
+
+  this.page.lastPromise = visit(path);
 
   return this.page;
 }

--- a/tests/unit/actions/visitable-test.js
+++ b/tests/unit/actions/visitable-test.js
@@ -27,3 +27,26 @@ it('calls Ember\'s visit helper', function(assert) {
 
   buildAttribute(visitableAttribute, expectedRoute)();
 });
+
+it('fills in dynamic segments', function(assert) {
+  assert.expect(1);
+
+  window.visit = function(actualRoute) {
+    assert.equal(actualRoute, '/users/5/comments/1');
+  };
+
+  buildAttribute(visitableAttribute, '/users/:user_id/comments/:comment_id')({
+    user_id: 5,
+    comment_id: 1
+  });
+});
+
+it("raises an exception if params aren't given for all dynamic segments", function(assert) {
+  assert.expect(1);
+
+  try {
+    buildAttribute(visitableAttribute, '/users/:user_id')();
+  } catch(e) {
+    assert.equal(e.message, "Missing parameter for 'user_id'");
+  }
+});


### PR DESCRIPTION
This allows you to do the following:
```javascript
let userPage = PO.build({
  visit: PO.visitable('/users/:id')
});

userPage.visit({id: 5});
```