### PR TITLE
Allow Components to act like a promise so async/await works

### DIFF
--- a/test-support/page-object/actions.js
+++ b/test-support/page-object/actions.js
@@ -27,19 +27,19 @@ function visitable(params = {}) {
     path = fillInDynamicSegments(path, params);
   }
 
-  this.page.lastPromise = visit(path);
+  visit(path);
 
   return this.page;
 }
 
 function clickable() {
-  this.page.lastPromise = click(this.qualifiedSelector());
+  click(this.qualifiedSelector());
 
   return this.page;
 }
 
 function fillable(text) {
-  this.page.lastPromise = fillIn(this.qualifiedSelector(), text);
+  fillIn(this.qualifiedSelector(), text);
 
   return this.page;
 }
@@ -50,7 +50,7 @@ function clickOnText(text) {
   // want to __always__ click on the __last__ element that contains the text.
   let selector = this.qualifiedSelector(`:contains("${text}"):last`);
 
-  this.page.lastPromise = click(selector);
+  click(selector);
 
   return this.page;
 }

--- a/test-support/page-object/build.js
+++ b/test-support/page-object/build.js
@@ -1,7 +1,13 @@
+/* global wait */
+
 import { isNullOrUndefined } from './helpers';
 
 function Component() {
 }
+
+Component.prototype.then = function() {
+  return wait().then(...arguments);
+};
 
 function isAttribute(candidate) {
   return $.isFunction(candidate.buildPageObjectAttribute);

--- a/tests/acceptance/login-test.js
+++ b/tests/acceptance/login-test.js
@@ -62,3 +62,16 @@ test('Retries login', function(assert) {
     assert.equal(page.message(), 'Valid user!');
   });
 });
+
+test('Action chains act like a promise', function(assert) {
+  assert.expect(1);
+
+  page
+    .visit()
+    .form()
+    .userName('invalid')
+    .password('invalid')
+    .click().then(function() {
+      assert.ok(page.hasError(), 'Page has error');
+    });
+});


### PR DESCRIPTION
The way actions are chainable is awesome, but one downside is that you can't use ES7's `async`/`await` with page objects, since actions return `this` instead of a promise.

This change makes it so that `Component` can act like a promise by implementing a `then` method. This allows you to do the following:

```javascript
test('login', async function(assert) {
  assert.expect(2);

  await page
    .visit()
    .form()
    .userName('user@example.com')
    .password('secret')
    .click();

  assert.ok(page.notHasError(), 'Page doesn\'t have error');
  assert.equal(page.message(), 'Valid user!');
});
```

I wasn't sure of the best way to test this. I could write an acceptance test using async/await, but I am not sure what side-effects turning on Babel's `es7.asyncFunctions` feature would have for apps using this add-on.

Do you think this feature is worthwhile? And if so, how would you like to see this tested?