### PR TITLE
Normalize whitespaces in the way browser does it

### DIFF
--- a/test-support/page-object/helpers.js
+++ b/test-support/page-object/helpers.js
@@ -4,8 +4,16 @@ export function qualifySelector(...selectors) {
   return selectors.filter(item => !!item).join(' ');
 }
 
+/**
+ * Trim whitespaces at both ends and normalize whitespaces inside `text`
+ *
+ * Due to variations in the HTML parsers in different browsers, the text
+ * returned may vary in newlines and other white space.
+ *
+ * @see http://api.jquery.com/text/
+ */
 export function trim(text) {
-  return Ember.$.trim(text);
+  return Ember.$.trim(text).replace(/\n/g, ' ').replace(/\s\s+/g, ' ');
 }
 
 export function isNullOrUndefined(object) {

--- a/tests/unit/queries/text-test.js
+++ b/tests/unit/queries/text-test.js
@@ -28,6 +28,14 @@ it('removes white spaces from the beginning and end of the text', function(asser
   assert.equal(attr(), 'awesome!');
 });
 
+it('normalizes inner text of the element containing newlines', function(assert) {
+  fixture(['<span>', 'Hello', 'multi-line', 'world!', '</span>'].join("\n"));
+
+  var attr = buildAttribute(textAttribute, 'span');
+
+  assert.equal(attr(), 'Hello multi-line world!');
+});
+
 it('raises an error when the element doesn\'t exist', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
This change will allow to write page objects without knowledge of how text is broken down on multiple lines, making tests less fragile.