### PR TITLE
Move travis-ci build badge to top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ember Page Objects
+# Ember Page Objects [![Build Status](https://travis-ci.org/san650/ember-cli-page-object.svg?branch=master)](https://travis-ci.org/san650/ember-cli-page-object)
 
 Represent the screens of your web app as a series of objects. This ember-cli
 addon ease the construction of these objects on your acceptance tests.


### PR DESCRIPTION
emberobserver.com likes build badges to be on top of the readme file