### PR TITLE
Support Normalizing &nbsp; characters in Text trim

### DIFF
--- a/test-support/page-object/helpers.js
+++ b/test-support/page-object/helpers.js
@@ -13,7 +13,7 @@ export function qualifySelector(...selectors) {
  * @see http://api.jquery.com/text/
  */
 export function trim(text) {
-  return Ember.$.trim(text).replace(/\n/g, ' ').replace(/\s\s+/g, ' ');
+  return Ember.$.trim(text).replace(/\n/g, ' ').replace(/\s\s*/g, ' ');
 }
 
 export function isNullOrUndefined(object) {

--- a/tests/unit/queries/text-test.js
+++ b/tests/unit/queries/text-test.js
@@ -47,6 +47,12 @@ it('normalizes inner text of the element containing newlines', function(assert) 
   assert.equal(attr(), 'Hello multi-line world!');
 });
 
+it('converts &nbsp; characters into standard whitespace characters', function(assert) {
+  fixture('<span>This&nbsp;is&nbsp;awesome.</span>');
+  var attr = buildAttribute(textAttribute, 'span');
+  assert.equal(attr(), 'This is awesome.');
+});
+
 it('raises an error when the element doesn\'t exist', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
This modifies the regular expressions a bit to make sure that `&nbsp;` whitespace characters are converted to standard whitespace characters. 