### PR TITLE
Nested collections are not properly scoped

### DIFF
--- a/tests/unit/components/collection-test.js
+++ b/tests/unit/components/collection-test.js
@@ -225,6 +225,23 @@ test('assigns the correct scope to item sub components when component doesn\'t d
   assert.equal(attribute(1).anotherComponent().text(), 'Lorem');
 });
 
+test('assigns the correct scope to sub collection items', function(assert) {
+  fixture('<div><span></span><span></span></div><div><span></span></div>');
+
+  let attribute = buildProperty(
+    collection({
+      itemScope: 'div',
+      item: {
+        spans: collection({
+          itemScope: 'span'
+        })
+      }
+    })
+  ).toFunction();
+
+  assert.equal(attribute(1).spans().count(), 2);
+});
+
 import { build } from '../../page-object/build';
 
 test('doesn\'t mutate collection definition', function(assert) {


### PR DESCRIPTION
Hey, here is a test showing that nested collections aren’t inheriting the scope of their containing collection. I see that you [recently fixed something related to collection scope](https://github.com/san650/ember-cli-page-object/releases/tag/v0.8.1) and the changes look pretty in-depth, so I suspect you’d be much quicker at fixing this than me.

Or maybe I’m just mistaken and this is expected behaviour?