### PR TITLE
Nested collection items do not use the correct parent index

### DIFF
--- a/tests/unit/components/collection-test.js
+++ b/tests/unit/components/collection-test.js
@@ -260,6 +260,7 @@ test('assigns the correct scope to sub collection items', function(assert) {
   ).toFunction();
 
   assert.equal(attribute(1).spans(2).text(), 'Ipsum');
+  assert.equal(attribute(2).spans(1).text(), 'Dolor');
 });
 
 import { create } from '../../page-object/create';


### PR DESCRIPTION
Hey, the recent changes helped with my use of `count()` on a nested collection, but when using an index to get an item in a nested collection, it’s always scoped to the first item of the parent collection.

Thanks so much for your work on this, I really like how it’s improving my tests.