### PR TITLE
Assign correct scope to sub-collection items

### DIFF
--- a/test-support/page-object/collection.js
+++ b/test-support/page-object/collection.js
@@ -54,6 +54,10 @@ function getCollection(target, key, options, index) {
   }
 
   if (index) {
+    if (target.__forceScopeToChildren) {
+      options.scope = target.scope;
+    }
+
     component = copy(options.itemDefinition);
     component.scope = qualifySelector(options.scope, scopeWithIndex(options.itemScope, index));
     component.__forceScopeToChildren = true;

--- a/tests/unit/components/collection-test.js
+++ b/tests/unit/components/collection-test.js
@@ -259,7 +259,7 @@ test('assigns the correct scope to sub collection items', function(assert) {
     })
   ).toFunction();
 
-  assert.equal(attribute(1).spans(2).text(), 'Ipsum');
+  assert.equal(attribute(2).spans(1).text(), 'Dolor');
 });
 
 import { create } from '../../page-object/create';


### PR DESCRIPTION
Same issue as described in https://github.com/san650/ember-cli-page-object/issues/63

I believe that the test that was added was only passing because "Ipsum" was the value for `attribute(1).spans(2)` and also happened to be the same as `spans(2)` without the `attribute(1)` scope.

This correctly assigns the scope of `target` when an `index` is provided to `getCollection`.