### PR TITLE
Adds better error messages when elements not found

### DIFF
--- a/test-support/page-object/helpers.js
+++ b/test-support/page-object/helpers.js
@@ -1,17 +1,76 @@
 import Ember from 'ember';
 
+export function BetterError(propType, key, target, selector, options) {
+  this.propType = propType;
+  this.key = key;
+  this.target = target;
+  this.selector = selector;
+  this.options = options;
+}
+
+BetterError.prototype = {
+  elementNotFoundMessage(fullQualifiedSelector) {
+    return `
+    ###########################
+    Element not found
+    ${this.inspect()}
+      => find("${fullQualifiedSelector}")`;
+  },
+
+  inspect() {
+    let message = [],
+        sanitizeOptions;
+
+    sanitizeOptions = Object
+      .keys(this.options)
+      .map(key => ({ key, value: this.options[key] }))
+      .filter(opt => typeof(opt.value) !== 'undefined')
+      .map(opt => `${opt.key}: "${opt.value}"`)
+      .join(', ');
+
+    message.push(`${this.key}: ${this.propType}("${this.selector}"`);
+
+    if (sanitizeOptions.length) {
+      message.push(`, { ${sanitizeOptions} })`);
+    } else {
+      message.push(')');
+    }
+
+    return message.join('');
+  }
+};
+
 export function qualifySelector(...selectors) {
   return selectors.filter(item => !!item).join(' ');
 }
 
-export function findElementWithAssert(options, target) {
+/**
+ * Looks for an element in the DOM. Raises an error if not found.
+ *
+ * @param {Object} options - Options
+ * @param {string} options.selector - CSS selector of the element to check
+ * @param {string} options.scope - Overrides parent scope
+ * @param {number} options.index - Reduce the set of matched elements to the one at the specified index
+ * @param {Object} target - Component that owns the property
+ * @return {string} value of the attribute
+ */
+export function findElementWithAssert(options, target, error) {
   let selector = qualifySelector(
     options.scope || target.scope,
     indexedSelector(options.selector, options.index)
   );
 
-  /* global findWithAssert */
-  return findWithAssert(selector);
+  let element = findElement(options, target)
+
+  if (element.length === 0) {
+    if (error) {
+      throw error.elementNotFoundMessage(selector);
+    } else {
+      throw `Element not found. find('${selector}')`;
+    }
+  }
+
+  return element;
 }
 
 export function findElement(options, target) {

--- a/test-support/page-object/properties/text.js
+++ b/test-support/page-object/properties/text.js
@@ -1,5 +1,5 @@
 import Descriptor from '../descriptor';
-import { findElementWithAssert, trim } from '../helpers';
+import { findElementWithAssert, trim, BetterError } from '../helpers';
 
 /**
  * Gets the text of the matched element
@@ -13,7 +13,8 @@ import { findElementWithAssert, trim } from '../helpers';
  * @return {string} value of the attribute
  */
 function getText(target, key, options) {
-  let element = findElementWithAssert(options, target);
+  let error = new BetterError('text', key, target, options.selector, { scope: options.scope, index: options.index }),
+      element = findElementWithAssert(options, target, error);
 
   return trim(element.text());
 }

--- a/tests/unit/find-element-with-assert-test.js
+++ b/tests/unit/find-element-with-assert-test.js
@@ -1,0 +1,92 @@
+import { test } from 'qunit';
+import { moduleFor, fixture } from './test-helper';
+import { findElementWithAssert } from '../page-object/helpers';
+import { create } from '../page-object/create';
+import text from '../page-object/properties/text';
+
+moduleFor('Base', 'findElementWithAssert');
+
+function assertMessage(assert, error, message, prop, finder) {
+  var msg = error.toString();
+
+  assert.ok(msg.indexOf(message) > -1, 'Includes error message');
+  assert.ok(msg.indexOf(prop) > -1, 'Includes property definition');
+  assert.ok(msg.indexOf(finder) > -1, 'Includes finder');
+}
+
+test('finds element', function(assert) {
+  let expected = fixture('<div class="scope"></div>').get(0);
+
+  let actual = findElementWithAssert({ selector: '.scope'}, {}).get(0);
+
+  assert.equal(actual, expected, 'returns the element');
+});
+
+test('raise an error', function(assert) {
+  assert.throws(() =>
+    findElementWithAssert({ selector: '.scope'}, {}),
+    'Throws an error'
+  );
+});
+
+test('shows simple error validation', function(assert) {
+  assert.expect(3);
+
+  let page = create({
+    key: text('.a-selector')
+  });
+
+  try {
+    page.key();
+  } catch(error) {
+    assertMessage(
+      assert,
+      error,
+      'Element not found',
+      'key: text(".a-selector")',
+      '=> find(".a-selector")'
+    );
+  }
+});
+
+test('includes scope', function(assert) {
+  assert.expect(3);
+
+  let page = create({
+    scope: '.a-scope',
+    key: text('.a-selector', { scope: '.b-scope' })
+  });
+
+  try {
+    page.key();
+  } catch(error) {
+    assertMessage(
+      assert,
+      error,
+      'Element not found',
+      'key: text(".a-selector", { scope: ".b-scope" })',
+      '=> find(".b-scope .a-selector")'
+    );
+  }
+});
+
+test('includes component scope', function(assert) {
+  assert.expect(3);
+
+  let page = create({
+    scope: '.a-scope',
+    key: text('.a-selector')
+  });
+
+  try {
+    page.key();
+  } catch(error) {
+    assertMessage(
+      assert,
+      error,
+      'Element not found',
+      'key: text(".a-selector")',
+      '=> find(".a-scope .a-selector")'
+    );
+  }
+});

--- a/tests/unit/test-helper.js
+++ b/tests/unit/test-helper.js
@@ -20,6 +20,8 @@ export function moduleFor(category, helperName) {
 
 export function fixture(str) {
   $('#ember-testing').html(str);
+
+  return $('#ember-testing').children(':first');
 }
 
 export function buildProperty(descriptor, parent = {}) {


### PR DESCRIPTION
Tackles #75

## To do

- [ ] Define a good error message
- [ ] Use assertions for QUnit instead of exceptions
- [ ] Add better errors for `attribute`
- [ ] Add better errors for `click-on-text`
- [ ] Add better errors for `clickable`
- [ ] Add better errors for `component`
- [ ] Add better errors for `contains`
- [ ] Add better errors for `count`
- [ ] Add better errors for `fillable`
- [ ] Add better errors for `has-class`
- [ ] Add better errors for `is-hidden`
- [ ] Add better errors for `is-visible`
- [ ] Add better errors for `not-has-class`
- [ ] Add better errors for `text`
- [ ] Add better errors for `value`
- [ ] Add better errors for `visitable`