### PR TITLE
Removes PageObject.component from the page-object-component blueprint.

### DIFF
--- a/blueprints/page-object-component/files/tests/pages/components/__name__.js
+++ b/blueprints/page-object-component/files/tests/pages/components/__name__.js
@@ -4,6 +4,6 @@ let {
   text
 } = PageObject;
 
-export default PageObject.component({
+export default {
   title: text('h1')
-});
+};


### PR DESCRIPTION
Fixes generated deprecation error discussed in https://github.com/san650/ember-cli-page-object/issues/77

This doesn't update the documentation, though.