### PR TITLE
Make components and collections inherit scope by default

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -979,14 +979,15 @@ var page = PageObject.create({
 | `page.todos().create()` | `click('.todo button')` |
 | `page.todos(1).value()` | `find('.todo input:eq(0)').val()` |
 
-You can reset parent scope by setting the `scope` attribute on the collection declaration.
+You can reset parent scope by setting the `scope` attribute on the collection declaration
+and adding the `resetScope` flag.
 
 ```js
 var page = PageObject.create({
   scope: '.todo',
 
   todos: collection({
-    scope: '',
+    resetScope: true,
     itemScope: 'input',
 
     item: {
@@ -1052,8 +1053,10 @@ var page = PageObject.create({
     scope: '.search',
 
     input: {
-      fillIn: fillable('input'),
-      value: value('input')
+      scope: 'input',
+
+      fillIn: fillable(),
+      value: value()
     }
   }
 });
@@ -1063,7 +1066,8 @@ var page = PageObject.create({
 | ------- | -------- |
 | `page.search().input().value()` | `find('.search input').val()` |
 
-You can reset parent scope by setting the `scope` attribute on the component declaration.
+You can reset parent scope by setting the `scope` attribute on the component declaration
+and adding the `resetScope` flag.
 
 ```js
 var page = PageObject.create({
@@ -1072,6 +1076,7 @@ var page = PageObject.create({
 
     input: {
       scope: 'input',
+      resetScope: true,
 
       fillIn: fillable(),
       value: value()

--- a/test-support/page-object/collection.js
+++ b/test-support/page-object/collection.js
@@ -33,8 +33,8 @@ function preProcess(target, key, options) {
   options.itemDefinition = extract(definition, 'item');
   options.itemScope = extract(definition, 'itemScope');
 
-  if (isNullOrUndefined(definition.scope)) {
-    definition.scope = target.scope;
+  if (definition.resetScope) {
+    target.scope = "";
   }
 
   options.scope = definition.scope;
@@ -54,18 +54,13 @@ function getCollection(target, key, options, index) {
   }
 
   if (index) {
-    if (target.__forceScopeToChildren) {
-      options.scope = target.scope;
-    }
+    options.scope = target.scope;
 
     component = copy(options.itemDefinition);
     component.scope = qualifySelector(options.scope, scopeWithIndex(options.itemScope, index));
-    component.__forceScopeToChildren = true;
     component = create(component);
   } else {
-    if (target.__forceScopeToChildren) {
-      options.collectionComponent.scope = target.scope;
-    }
+    options.collectionComponent.scope = target.scope;
 
     component = create(options.collectionComponent);
   }

--- a/test-support/page-object/create.js
+++ b/test-support/page-object/create.js
@@ -7,6 +7,8 @@ import clickable from './properties/clickable';
 import contains from './properties/contains';
 import text from './properties/text';
 
+let trim = Ember.$.trim;
+
 function Node() {
   this.isHidden = isHidden().propertyFor(this, 'isHidden');
   this.isVisible = isVisible().propertyFor(this, 'isVisible');
@@ -65,11 +67,12 @@ function setScopes(definition) {
     let attr = definition[key];
 
     if ($.isPlainObject(attr)) {
-
-      if (definition.__forceScopeToChildren) {
-        attr.scope = [definition.scope, attr.scope].join(' ');
-      } else if (typeof(attr.scope) === 'undefined' && typeof(definition.scope) !== 'undefined') {
-        attr.scope = definition.scope;
+      if (typeof(attr.resetScope) !== "undefined" && attr) {
+        if (typeof(attr.scope) === 'undefined' && typeof(definition.scope) !== 'undefined') {
+          attr.scope = definition.scope;
+        }
+      } else {
+        attr.scope = trim([definition.scope, attr.scope].join(' '));
       }
 
       setScopes(attr);

--- a/tests/unit/components/collection-test.js
+++ b/tests/unit/components/collection-test.js
@@ -124,13 +124,23 @@ test('inherits parent scope for generated count attribute', function(assert) {
   assert.equal(attribute().count(), 2);
 });
 
-test('resets parent scope for generated count attribute', function(assert) {
-  fixture('<span>Wrong</span><span class="scope"><span>First</span><span>Second</span></span>');
+test('resets parent scope for generated count attribute if reset', function(assert) {
+  fixture(`
+    <span>Wrong</span>
+    <span class="scope">
+      <span>First</span>
+      <span>Second</span>
+    </span>
+  `);
 
   let attribute = buildProperty(
     collection({
-      scope: '',
-      itemScope: 'span'
+      resetScope: true,
+      itemScope: 'span',
+
+      item: {
+        text: text()
+      }
     }),
     { scope: ".scope" }
   ).toFunction();
@@ -143,7 +153,7 @@ test('resets parent scope', function(assert) {
 
   let attribute = buildProperty(
     collection({
-      scope: '',
+      resetScope: true,
       itemScope: 'span',
 
       item: {
@@ -243,7 +253,15 @@ test('assigns the correct scope to sub collection component', function(assert) {
 });
 
 test('assigns the correct scope to sub collection items', function(assert) {
-  fixture('<div><span>Lorem</span><span>Ipsum</span></div><div><span>Dolor</span></div>');
+  fixture(`
+    <div>
+      <span>Lorem</span>
+      <span>Ipsum</span>
+    </div>
+    <div>
+      <span>Dolor</span>
+    </div>`
+  );
 
   let attribute = buildProperty(
     collection({
@@ -295,4 +313,26 @@ test('doesn\'t mutate collection definition', function(assert) {
   });
 
   assert.equal(pageObject.one().two().four(1).text(), 'Dolor');
+});
+
+test('sets scope to deeper components under item object', function(assert) {
+  fixture('<ul><li><main><header>Wrong Title</header></main></li><li><main><header>Right Title</header></main></li></ul>');
+
+  let attribute = buildProperty(
+    collection({
+      itemScope: 'li',
+      item: {
+        main: {
+          scope: 'main',
+
+          header: {
+            scope: 'header',
+            text: text()
+          }
+        }
+      }
+    })
+  ).toFunction();
+
+  assert.equal(attribute(2).main().header().text(), 'Right Title');
 });

--- a/tests/unit/create-test.js
+++ b/tests/unit/create-test.js
@@ -3,6 +3,37 @@ import { create } from '../page-object/create';
 
 module('Base | create');
 
+test('nests scope by default', function(assert) {
+  let definition = {
+    scope: '.page',
+
+    component: {
+      scope: '.component'
+    }
+  };
+
+  let pageObject = create(definition);
+
+  assert.equal(pageObject.scope, '.page');
+  assert.equal(pageObject.component().scope, '.page .component');
+});
+
+test('resets scope if resetScope flag is used', function(assert) {
+  let definition = {
+    scope: '.page',
+
+    component: {
+      scope: '.component',
+      resetScope: true
+    }
+  };
+
+  let pageObject = create(definition);
+
+  assert.equal(pageObject.scope, '.page');
+  assert.equal(pageObject.component().scope, '.component');
+});
+
 test('returns an object', function(assert) {
   let pageObject = create({});
 


### PR DESCRIPTION
Based on discussions started by #80, here is a first draft of the behavior described.

@san650 if we agree on this, we can start thinking on releasing v1.0 with this since it's a big behavior change.