### PR TITLE
Allow nested pages with full path to "page-object" module

### DIFF
--- a/blueprints/page-object/files/tests/pages/__name__.js
+++ b/blueprints/page-object/files/tests/pages/__name__.js
@@ -1,4 +1,4 @@
-import PageObject from '../page-object';
+import PageObject from '<%= testFolderRoot %>/page-object';
 
 let {
   visitable

--- a/blueprints/page-object/index.js
+++ b/blueprints/page-object/index.js
@@ -1,3 +1,12 @@
+var stringUtils = require('ember-cli-string-utils');
+
 module.exports = {
-  description: 'Generates a page object for acceptance tests.'
+  description: 'Generates a page object for acceptance tests.',
+  locals: function(options) {
+    var testFolderRoot = stringUtils.dasherize(options.project.name());
+
+    return {
+      testFolderRoot: testFolderRoot,
+    };
+  }
 };


### PR DESCRIPTION
Currently making a page nested in a namespace leads to failing module look up because the blueprint uses `../page-object`.

So the command `ember g page-object parent/child` will fail silently if you try use this new page object generated.

This instead uses the same pattern as the Acceptance test generator from Ember CLI to use the fully qualified module name for the `page-object` module.