### PR TITLE
Missing `ember-cli-string-utils` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "testing"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5"
+    "ember-cli-babel": "^5.1.5",
+    "ember-cli-string-utils": "^1.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Generators use `ember-cli-string-utils` to generate the app name but we forgot to declare the dependency in the package.json file.