### PR TITLE
Add mechanism to extend page objects

### DIFF
--- a/test-support/page-object/create.js
+++ b/test-support/page-object/create.js
@@ -7,7 +7,7 @@ import { clickOnText } from './properties/click-on-text';
 import { clickable } from './properties/clickable';
 import { contains } from './properties/contains';
 
-var { merge } = Ember;
+var { merge, $ } = Ember;
 
 function plugDefaultProperties(definition) {
   if (typeof(definition.isVisible) === 'undefined') {
@@ -52,6 +52,31 @@ function buildObject(builder, target, key, definition) {
 }
 
 /**
+ * Creates a new page object by extending an existing one
+ *
+ * @example
+ *
+ *   var page = create({
+ *     foo: 'bar'
+ *   });
+ *
+ *   var extended = page.extend({
+ *     baz: 'qux'
+ *   });
+ *
+ *   assert.equal(extended.foo, 'bar');
+ *   assert.equal(extended.baz, 'qux');
+ *
+ * @param {Object} definition - new properties
+ * @return {PageObject}
+ */
+function extend(definition) {
+  var def = $.extend(true, {}, this['__meta'].definition, definition);
+
+  return create(def);
+}
+
+/**
  * Creates a new PageObject
  *
  * @example
@@ -71,5 +96,13 @@ export function create(definition, options = {}) {
     object: buildObject
   };
 
-  return Ceibo.create(definition, merge({ builder }, options ));
+  var tree = Ceibo.create(definition, merge({ builder }, options ));
+
+  tree['__meta'] = {
+    definition: $.extend(true, {}, definition)
+  };
+
+  tree.extend = extend;
+
+  return tree;
 }

--- a/tests/unit/create-test.js
+++ b/tests/unit/create-test.js
@@ -130,3 +130,50 @@ test('generates .text property', function(assert) {
   assert.equal(page.text, 'Ipsum Dolor');
   assert.equal(page.foo.text, 'Dolor');
 });
+
+test('.extend deep merges attributes', function(assert) {
+  var page = create({
+    foo: 'foo value',
+    bar: {
+      baz: 'baz value'
+    }
+  });
+
+  var extended = page.extend({
+    qux: 'qux value',
+    bar: {
+      norf: 'norf value'
+    }
+  });
+
+  assert.equal(extended.foo, 'foo value');
+  assert.equal(extended.bar.baz, 'baz value');
+  assert.equal(extended.qux, 'qux value');
+  assert.equal(extended.bar.norf, 'norf value');
+});
+
+test('.extend accepts descriptors', function(assert) {
+  fixture('Lorem <span>ipsum</span>');
+
+  var page = create({});
+  var extended = page.extend({
+    foo: text('span')
+  });
+
+  assert.equal(extended.foo, 'ipsum');
+});
+
+test('.extend doesn\'t modify the original page', function(assert) {
+  var page = create({
+    foo: 'bar'
+  });
+
+  var extended = page.extend({
+    foo: 'baz',
+    qux: 'norf'
+  });
+
+  assert.equal(page.foo, 'bar');
+  assert.ok(!page.qux);
+  assert.equal(extended.foo, 'baz');
+});


### PR DESCRIPTION
This PR adds an easy way to extend existing page objects

```js
var page = create({
  foo: 'bar'
});

var extended = page.extend({
  baz: 'qux'
});

assert.equal(extended.foo, 'bar');
assert.equal(extended.baz, 'qux');
```