### PR TITLE
Assert predicates and queries only match one element

### DIFF
--- a/test-support/page-object/helpers.js
+++ b/test-support/page-object/helpers.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
 import Ceibo from 'ceibo';
 
-var { trim } = Ember.$;
+var { trim } = Ember.$,
+  assert = Ember.assert;
 
 class Selector {
   constructor(node, scope, selector, filters) {
@@ -94,10 +95,19 @@ export function buildSelector(node, targetSelector, options) {
  * @param {boolean} options.last - Filter by using :last pseudo-class
  * @return {string} Full qualified selector
  */
-export function findElementWithAssert(node, targetSelector, options) {
-  var selector = buildSelector(node, targetSelector, options);
+export function findElementWithAssert(node, targetSelector, options = {}) {
+  var selector = buildSelector(node, targetSelector, options),
+    allowMultiple = options['multiple'],
+    result;
 
-  return findWithAssert(selector);
+  result = findWithAssert(selector);
+
+  assert(
+    `${selector} matched more than one element. If this is not an error use { multiple: true }`,
+    allowMultiple || result.length <= 1
+  )
+
+  return result;
 }
 
 /**
@@ -112,10 +122,19 @@ export function findElementWithAssert(node, targetSelector, options) {
  * @param {boolean} options.last - Filter by using :last pseudo-class
  * @return {string} Full qualified selector
  */
-export function findElement(node, targetSelector, options) {
-  var selector = buildSelector(node, targetSelector, options);
+export function findElement(node, targetSelector, options = {}) {
+  var selector = buildSelector(node, targetSelector, options),
+    allowMultiple = options['multiple'],
+    result;
 
-  return find(selector);
+  result = find(selector);
+
+  assert(
+    `${selector} matched more than one element. If this is not an error use { multiple: true }`,
+    allowMultiple || result.length <= 1
+  )
+
+  return result;
 }
 
 /**

--- a/test-support/page-object/properties/attribute.js
+++ b/test-support/page-object/properties/attribute.js
@@ -1,5 +1,7 @@
 import { findElementWithAssert } from '../helpers';
 
+var $ = Ember.$;
+
 /**
  * Gets the value of an attribute from an element
  *
@@ -16,6 +18,7 @@ import { findElementWithAssert } from '../helpers';
  * @param {Object} options - Additional options
  * @param {string} options.scope - Overrides parent scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
+ * @param {boolean} options.multiple - Return an array of values
  * @return {Descriptor}
  */
 export function attribute(attributeName, selector, options = {}) {
@@ -24,6 +27,10 @@ export function attribute(attributeName, selector, options = {}) {
 
     get() {
       var element = findElementWithAssert(this, selector, options);
+
+      if (options.multiple) {
+        return $.map(element, e => $(e).attr(attributeName));
+      }
 
       return element.attr(attributeName);
     }

--- a/test-support/page-object/properties/contains.js
+++ b/test-support/page-object/properties/contains.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { findElementWithAssert } from '../helpers';
 
 /**
@@ -25,7 +26,9 @@ export function contains(selector, options = {}) {
     value(textToSearch) {
       let element = findElementWithAssert(this, selector, options);
 
-      return element.text().indexOf(textToSearch) >= 0;
+      return !(Ember.A(element).any(function(e) {
+        return $(e).text().indexOf(textToSearch) < 0;
+      }));
     }
   };
 }

--- a/test-support/page-object/properties/count.js
+++ b/test-support/page-object/properties/count.js
@@ -22,6 +22,7 @@ export function count(selector, options = {}) {
     isDescriptor: true,
 
     get() {
+      options.multiple = true;
       return findElement(this, selector, options).length;
     }
   };

--- a/test-support/page-object/properties/count.js
+++ b/test-support/page-object/properties/count.js
@@ -1,4 +1,7 @@
+import Ember from 'ember';
 import { findElement } from '../helpers';
+
+var $ = Ember.$;
 
 /**
  * Gets the count of matched elements
@@ -22,8 +25,11 @@ export function count(selector, options = {}) {
     isDescriptor: true,
 
     get() {
-      options.multiple = true;
-      return findElement(this, selector, options).length;
+      let countOptions = {};
+
+      $.extend(true, countOptions, options, { multiple: true });
+
+      return findElement(this, selector, countOptions).length;
     }
   };
 }

--- a/test-support/page-object/properties/has-class.js
+++ b/test-support/page-object/properties/has-class.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { findElementWithAssert } from '../helpers';
 
 /**
@@ -25,8 +26,9 @@ export function hasClass(cssClass, selector, options = {}) {
     get() {
       let element = findElementWithAssert(this, selector, options);
 
-
-      return element.hasClass(cssClass);
+      return !(Ember.A(element).any(function(e) {
+        return !$(e).hasClass(cssClass);
+      }));
     }
   };
 }

--- a/test-support/page-object/properties/is-hidden.js
+++ b/test-support/page-object/properties/is-hidden.js
@@ -1,4 +1,7 @@
+import Ember from 'ember';
 import { findElement } from '../helpers';
+
+var $ = Ember.$;
 
 /**
  * Creates a predicate to validate if an element is hidden
@@ -22,9 +25,22 @@ export function isHidden(selector, options = {}) {
     isDescriptor: true,
 
     get() {
-      let element = findElement(this, selector, options);
+      let element = findElement(this, selector, options),
+        result;
 
-      return (element.length > 0) ? element.is(':hidden') : true;
+      if (element.length > 0) {
+        if (options.multiple) {
+          result = !(Ember.A(element).any(function(e) {
+            return $(e).is(':visible')
+          }));
+        } else {
+          result = element.is(':hidden')
+        }
+      } else {
+        result = true
+      }
+
+      return result;
     }
   };
 }

--- a/test-support/page-object/properties/is-hidden.js
+++ b/test-support/page-object/properties/is-hidden.js
@@ -28,17 +28,9 @@ export function isHidden(selector, options = {}) {
       let element = findElement(this, selector, options),
         result;
 
-      if (element.length > 0) {
-        if (options.multiple) {
-          result = !(Ember.A(element).any(function(e) {
-            return $(e).is(':visible')
-          }));
-        } else {
-          result = element.is(':hidden')
-        }
-      } else {
-        result = true
-      }
+      result = !(Ember.A(element).any(function(e) {
+        return $(e).is(':visible')
+      }));
 
       return result;
     }

--- a/test-support/page-object/properties/is-visible.js
+++ b/test-support/page-object/properties/is-visible.js
@@ -27,13 +27,9 @@ export function isVisible(selector, options = {}) {
         result;
 
       if (element.length > 0) {
-        if (options.multiple) {
-          result = !(Ember.A(element).any(function(e) {
-            return $(e).is(':hidden')
-          }));
-        } else {
-          result = element.is(':visible')
-        }
+        result = !(Ember.A(element).any(function(e) {
+          return $(e).is(':hidden')
+        }));
       } else {
         result = false
       }

--- a/test-support/page-object/properties/is-visible.js
+++ b/test-support/page-object/properties/is-visible.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { findElement } from '../helpers';
 
 /**
@@ -22,9 +23,22 @@ export function isVisible(selector, options = {}) {
     isDescriptor: true,
 
     get() {
-      let element = findElement(this, selector, options);
+      let element = findElement(this, selector, options),
+        result;
 
-      return element.is(':visible');
+      if (element.length > 0) {
+        if (options.multiple) {
+          result = !(Ember.A(element).any(function(e) {
+            return $(e).is(':hidden')
+          }));
+        } else {
+          result = element.is(':visible')
+        }
+      } else {
+        result = false
+      }
+
+      return result;
     }
   };
 }

--- a/test-support/page-object/properties/not-has-class.js
+++ b/test-support/page-object/properties/not-has-class.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { findElementWithAssert } from '../helpers';
 
 /**
@@ -25,7 +26,9 @@ export function notHasClass(cssClass, selector, options = {}) {
     get() {
       let element = findElementWithAssert(this, selector, options);
 
-      return !element.hasClass(cssClass);
+      return !(Ember.A(element).any(function(e) {
+        return $(e).hasClass(cssClass);
+      }));
     }
   };
 }

--- a/test-support/page-object/properties/value.js
+++ b/test-support/page-object/properties/value.js
@@ -1,5 +1,7 @@
 import { findElementWithAssert, trim } from '../helpers';
 
+var $ = Ember.$;
+
 /**
  * Gets the value of the matched element
  *
@@ -25,7 +27,13 @@ export function value(selector, options = {}) {
     get() {
       var element = findElementWithAssert(this, selector, options);
 
-      return element.val();
+      if (options.multiple) {
+        result = $.map(element, e => $(e).val());
+      } else {
+        result = element.val();
+      }
+
+      return result;
     }
   };
 }

--- a/tests/unit/actions/click-on-text-test.js
+++ b/tests/unit/actions/click-on-text-test.js
@@ -2,7 +2,7 @@ import { test } from 'qunit';
 import { moduleFor } from '../test-helper';
 import { create, clickOnText } from '../../page-object';
 
-moduleFor('.clickOnText');
+moduleFor('Unit | Property | .clickOnText');
 
 test('calls Ember\'s click helper', function(assert) {
   assert.expect(1);

--- a/tests/unit/actions/clickable-test.js
+++ b/tests/unit/actions/clickable-test.js
@@ -2,7 +2,7 @@ import { test } from 'qunit';
 import { moduleFor } from '../test-helper';
 import { create, clickable } from '../../page-object';
 
-moduleFor('.clickable');
+moduleFor('Unit | Property | .clickable');
 
 test('calls Ember\'s click helper', function(assert) {
   assert.expect(1);

--- a/tests/unit/actions/fillable-test.js
+++ b/tests/unit/actions/fillable-test.js
@@ -2,7 +2,7 @@ import { test } from 'qunit';
 import { moduleFor } from '../test-helper';
 import { create, fillable, selectable } from '../../page-object';
 
-moduleFor('.fillable');
+moduleFor('Unit | Property | .fillable');
 
 test('calls Ember\'s fillIn helper', function(assert) {
   assert.expect(2);

--- a/tests/unit/actions/visitable-test.js
+++ b/tests/unit/actions/visitable-test.js
@@ -2,7 +2,7 @@ import { test } from 'qunit';
 import { moduleFor } from '../test-helper';
 import { create, visitable } from '../../page-object';
 
-moduleFor('.visitable');
+moduleFor('Unit | Property | .visitable');
 
 test('calls Ember\'s visit helper', function(assert) {
   assert.expect(1);

--- a/tests/unit/components/collection-test.js
+++ b/tests/unit/components/collection-test.js
@@ -2,7 +2,7 @@ import { test } from 'qunit';
 import { fixture, moduleFor } from '../test-helper';
 import { create, collection, text } from '../../page-object';
 
-moduleFor('.collection');
+moduleFor('Unit | Property | .collection');
 
 test('generates a count property', function(assert) {
   fixture(`

--- a/tests/unit/create-test.js
+++ b/tests/unit/create-test.js
@@ -2,7 +2,7 @@ import { test } from 'qunit';
 import { fixture, moduleFor } from './test-helper';
 import { create, text } from '../page-object';
 
-moduleFor('.create');
+moduleFor('Unit | Property | .create');
 
 test('creates new page object', function(assert) {
   var page = create({

--- a/tests/unit/predicates/contains-test.js
+++ b/tests/unit/predicates/contains-test.js
@@ -1,8 +1,11 @@
 import { test } from 'qunit';
 import { fixture, moduleFor } from '../test-helper';
 import { create, contains } from '../../page-object';
+import {
+  test_throws_if_not_multiple
+} from '../shared';
 
-moduleFor('.contains');
+moduleFor('Unit | Property | .contains');
 
 test('returns true when the element contains the text', function(assert) {
   fixture('Lorem <span>ipsum</span>');
@@ -71,7 +74,7 @@ test('resets scope', function(assert) {
   assert.ok(page.foo('lorem'));
 });
 
-test('throws error if selector matches more than one element', function(assert) {
+test_throws_if_not_multiple(function() {
   fixture(`
     <span>lorem</span>
     <span> ipsum </span>
@@ -82,10 +85,7 @@ test('throws error if selector matches more than one element', function(assert) 
     foo: contains('span')
   });
 
-  assert.throws(
-    () => page.foo('lorem'),
-    /span matched more than one element. If this is not an error use { multiple: true }/
-  );
+  page.foo('lorem');
 });
 
 test('matches multiple elements with multiple: true option, returns false if not all elements contain text', function(assert) {

--- a/tests/unit/predicates/contains-test.js
+++ b/tests/unit/predicates/contains-test.js
@@ -88,11 +88,24 @@ test('throws error if selector matches more than one element', function(assert) 
   );
 });
 
-test('matches multiple elements with multiple: true option', function(assert) {
+test('matches multiple elements with multiple: true option, returns false if not all elements contain text', function(assert) {
   fixture(`
     <span>lorem</span>
     <span>ipsum</span>
     <span>dolor</span>
+  `);
+
+  let page = create({
+    foo: contains('span', { multiple: true })
+  });
+
+  assert.ok(!page.foo('lorem'));
+});
+
+test('matches multiple elements with multiple: true option, returns true if all elements contain text', function(assert) {
+  fixture(`
+    <span>lorem</span>
+    <span>lorem</span>
   `);
 
   let page = create({

--- a/tests/unit/predicates/contains-test.js
+++ b/tests/unit/predicates/contains-test.js
@@ -65,11 +65,41 @@ test('resets scope', function(assert) {
   let page = create({
     scope: '.scope',
 
-    foo: contains('span', { resetScope: true })
+    foo: contains('span', { at: 0, resetScope: true })
   });
 
   assert.ok(page.foo('lorem'));
-  assert.ok(page.foo('ipsum'));
+});
+
+test('throws error if selector matches more than one element', function(assert) {
+  fixture(`
+    <span>lorem</span>
+    <span> ipsum </span>
+    <span>dolor</span>
+  `);
+
+  let page = create({
+    foo: contains('span')
+  });
+
+  assert.throws(
+    () => page.foo('lorem'),
+    /span matched more than one element. If this is not an error use { multiple: true }/
+  );
+});
+
+test('matches multiple elements with multiple: true option', function(assert) {
+  fixture(`
+    <span>lorem</span>
+    <span>ipsum</span>
+    <span>dolor</span>
+  `);
+
+  let page = create({
+    foo: contains('span', { multiple: true })
+  });
+
+  assert.ok(page.foo('lorem'));
 });
 
 test('finds element by index', function(assert) {

--- a/tests/unit/predicates/has-class-test.js
+++ b/tests/unit/predicates/has-class-test.js
@@ -1,8 +1,11 @@
 import { test } from 'qunit';
 import { fixture, moduleFor } from '../test-helper';
 import { create, hasClass } from '../../page-object';
+import {
+  test_throws_if_not_multiple
+} from '../shared';
 
-moduleFor('.hasClass');
+moduleFor('Unit | Property | .hasClass');
 
 test('returns true when the element has the class', function(assert) {
   fixture('<em class="lorem"></em><span class="ipsum"></span>');
@@ -87,8 +90,7 @@ test('resets scope', function(assert) {
   assert.ok(page.foo);
 });
 
-
-test('throws error if selector matches more than one element', function(assert) {
+test_throws_if_not_multiple(function() {
   fixture(`
     <span class="lorem"></span>
     <span class="ipsum"></span>
@@ -98,10 +100,7 @@ test('throws error if selector matches more than one element', function(assert) 
     foo: hasClass('lorem', 'span')
   });
 
-  assert.throws(
-    () => page.foo,
-    /span matched more than one element. If this is not an error use { multiple: true }/
-  );
+  return page.foo;
 });
 
 test('matches multiple elements with multiple: true option returns false if not all elements have class', function(assert) {

--- a/tests/unit/predicates/has-class-test.js
+++ b/tests/unit/predicates/has-class-test.js
@@ -87,6 +87,36 @@ test('resets scope', function(assert) {
   assert.ok(page.foo);
 });
 
+
+test('throws error if selector matches more than one element', function(assert) {
+  fixture(`
+    <span class="lorem"></span>
+    <span class="ipsum"></span>
+  `);
+
+  let page = create({
+    foo: hasClass('lorem', 'span')
+  });
+
+  assert.throws(
+    () => page.foo,
+    /span matched more than one element. If this is not an error use { multiple: true }/
+  );
+});
+
+test('matches multiple elements with multiple: true option', function(assert) {
+  fixture(`
+    <span class="lorem"></span>
+    <span class="ipsum"></span>
+  `);
+
+  let page = create({
+    foo: hasClass('lorem', 'span', { multiple: true })
+  });
+
+  assert.ok(page.foo);
+});
+
 test('finds element by index', function(assert) {
   fixture(`
     <span class="lorem"></span>

--- a/tests/unit/predicates/has-class-test.js
+++ b/tests/unit/predicates/has-class-test.js
@@ -104,10 +104,23 @@ test('throws error if selector matches more than one element', function(assert) 
   );
 });
 
-test('matches multiple elements with multiple: true option', function(assert) {
+test('matches multiple elements with multiple: true option returns false if not all elements have class', function(assert) {
   fixture(`
     <span class="lorem"></span>
     <span class="ipsum"></span>
+  `);
+
+  let page = create({
+    foo: hasClass('lorem', 'span', { multiple: true })
+  });
+
+  assert.ok(!page.foo);
+});
+
+test('matches multiple elements with multiple: true option returns true if all elements have class', function(assert) {
+  fixture(`
+    <span class="lorem"></span>
+    <span class="lorem"></span>
   `);
 
   let page = create({

--- a/tests/unit/predicates/is-hidden-test.js
+++ b/tests/unit/predicates/is-hidden-test.js
@@ -78,6 +78,22 @@ test('resets scope', function(assert) {
   assert.ok(page.foo);
 });
 
+test('throws error if selector matches more than one element', function(assert) {
+  fixture(`
+    <em style="display:none">ipsum</em>
+    <em style="display:none">dolor</em>
+  `);
+
+  let page = create({
+    foo: isHidden('em')
+  });
+
+  assert.throws(
+    () => page.foo,
+    /em matched more than one element. If this is not an error use { multiple: true }/
+  );
+});
+
 test('matches multiple elements with multiple: true option, returns true if all elements are hidden', function(assert) {
   fixture(`
     <em style="display:none">ipsum</em>

--- a/tests/unit/predicates/is-hidden-test.js
+++ b/tests/unit/predicates/is-hidden-test.js
@@ -78,6 +78,32 @@ test('resets scope', function(assert) {
   assert.ok(page.foo);
 });
 
+test('matches multiple elements with multiple: true option, returns true if all elements are hidden', function(assert) {
+  fixture(`
+    <em style="display:none">ipsum</em>
+    <em style="display:none">dolor</em>
+  `);
+
+  let page = create({
+    foo: isHidden('em', { multiple: true })
+  });
+
+  assert.ok(page.foo);
+});
+
+test('matches multiple elements with multiple: true option, returns false if some elements are visible', function(assert) {
+  fixture(`
+    <em>ipsum</em>
+    <em style="display:none">dolor</em>
+  `);
+
+  let page = create({
+    foo: isHidden('em', { multiple: true })
+  });
+
+  assert.ok(!page.foo);
+});
+
 test('finds element by index', function(assert) {
   fixture(`
     <em>lorem</em>

--- a/tests/unit/predicates/is-hidden-test.js
+++ b/tests/unit/predicates/is-hidden-test.js
@@ -1,8 +1,11 @@
 import { test } from 'qunit';
 import { fixture, moduleFor } from '../test-helper';
 import { create, isHidden } from '../../page-object';
+import {
+  test_throws_if_not_multiple
+} from '../shared';
 
-moduleFor('.isHidden');
+moduleFor('Unit | Property | .isHidden');
 
 test('returns true when the element is hidden', function(assert) {
   fixture('Lorem <span style="display:none">ipsum</span>');
@@ -78,7 +81,7 @@ test('resets scope', function(assert) {
   assert.ok(page.foo);
 });
 
-test('throws error if selector matches more than one element', function(assert) {
+test_throws_if_not_multiple(function() {
   fixture(`
     <em style="display:none">ipsum</em>
     <em style="display:none">dolor</em>
@@ -88,10 +91,7 @@ test('throws error if selector matches more than one element', function(assert) 
     foo: isHidden('em')
   });
 
-  assert.throws(
-    () => page.foo,
-    /em matched more than one element. If this is not an error use { multiple: true }/
-  );
+  return page.foo;
 });
 
 test('matches multiple elements with multiple: true option, returns true if all elements are hidden', function(assert) {

--- a/tests/unit/predicates/is-visible-test.js
+++ b/tests/unit/predicates/is-visible-test.js
@@ -75,6 +75,37 @@ test('resets scope', function(assert) {
   assert.ok(page.foo);
 });
 
+test('throws error if selector matches more than one element', function(assert) {
+  fixture(`
+    <span>lorem</span>
+    <span> ipsum </span>
+    <span>dolor</span>
+  `);
+
+  let page = create({
+    foo: isVisible('span')
+  });
+
+  assert.throws(
+    () => page.foo,
+    /span matched more than one element. If this is not an error use { multiple: true }/
+  );
+});
+
+test('matches multiple elements with multiple: true option', function(assert) {
+  fixture(`
+    <span>lorem</span>
+    <span style="display:none"> ipsum </span>
+    <span>dolor</span>
+  `);
+
+  let page = create({
+    foo: isVisible('span', { multiple: true })
+  });
+
+  assert.ok(page.foo);
+});
+
 test('finds element by index', function(assert) {
   fixture(`
     <em style="display:none">lorem</em>

--- a/tests/unit/predicates/is-visible-test.js
+++ b/tests/unit/predicates/is-visible-test.js
@@ -92,10 +92,23 @@ test('throws error if selector matches more than one element', function(assert) 
   );
 });
 
-test('matches multiple elements with multiple: true option', function(assert) {
+test('matches multiple elements with multiple: true option, return false if not all elements are visible', function(assert) {
   fixture(`
     <span>lorem</span>
     <span style="display:none"> ipsum </span>
+    <span>dolor</span>
+  `);
+
+  let page = create({
+    foo: isVisible('span', { multiple: true })
+  });
+
+  assert.ok(!page.foo);
+});
+
+test('matches multiple elements with multiple: true option, return true if all elements are visible', function(assert) {
+  fixture(`
+    <span>lorem</span>
     <span>dolor</span>
   `);
 

--- a/tests/unit/predicates/is-visible-test.js
+++ b/tests/unit/predicates/is-visible-test.js
@@ -1,8 +1,11 @@
 import { test } from 'qunit';
 import { fixture, moduleFor } from '../test-helper';
 import { create, isVisible } from '../../page-object';
+import {
+  test_throws_if_not_multiple
+} from '../shared';
 
-moduleFor('.isVisible');
+moduleFor('Unit | Property | .isVisible');
 
 test('returns true when the element is visible', function(assert) {
   fixture('Lorem <span>ipsum</span>');
@@ -75,7 +78,7 @@ test('resets scope', function(assert) {
   assert.ok(page.foo);
 });
 
-test('throws error if selector matches more than one element', function(assert) {
+test_throws_if_not_multiple(function() {
   fixture(`
     <span>lorem</span>
     <span> ipsum </span>
@@ -86,10 +89,7 @@ test('throws error if selector matches more than one element', function(assert) 
     foo: isVisible('span')
   });
 
-  assert.throws(
-    () => page.foo,
-    /span matched more than one element. If this is not an error use { multiple: true }/
-  );
+  return page.foo;
 });
 
 test('matches multiple elements with multiple: true option, return false if not all elements are visible', function(assert) {

--- a/tests/unit/predicates/not-has-class-test.js
+++ b/tests/unit/predicates/not-has-class-test.js
@@ -103,7 +103,7 @@ test('throws error if selector matches more than one element', function(assert) 
   );
 });
 
-test('matches multiple elements with multiple: true option', function(assert) {
+test('matches multiple elements with multiple: true option, returns true if no elements have class', function(assert) {
   fixture(`
     <span class="lorem"></span>
     <span class="ipsum"></span>
@@ -114,6 +114,19 @@ test('matches multiple elements with multiple: true option', function(assert) {
   });
 
   assert.ok(page.foo);
+});
+
+test('matches multiple elements with multiple: true option, returns false if some elements have class', function(assert) {
+  fixture(`
+    <span class="lorem"></span>
+    <span class="ipsum"></span>
+  `);
+
+  let page = create({
+    foo: notHasClass('lorem', 'span', { multiple: true })
+  });
+
+  assert.ok(!page.foo);
 });
 
 test('finds element by index', function(assert) {

--- a/tests/unit/predicates/not-has-class-test.js
+++ b/tests/unit/predicates/not-has-class-test.js
@@ -87,6 +87,35 @@ test('resets scope', function(assert) {
   assert.ok(page.foo);
 });
 
+test('throws error if selector matches more than one element', function(assert) {
+  fixture(`
+    <span class="lorem"></span>
+    <span class="ipsum"></span>
+  `);
+
+  let page = create({
+    foo: notHasClass('lorem', 'span')
+  });
+
+  assert.throws(
+    () => page.foo,
+    /span matched more than one element. If this is not an error use { multiple: true }/
+  );
+});
+
+test('matches multiple elements with multiple: true option', function(assert) {
+  fixture(`
+    <span class="lorem"></span>
+    <span class="ipsum"></span>
+  `);
+
+  let page = create({
+    foo: notHasClass('other-class', 'span', { multiple: true })
+  });
+
+  assert.ok(page.foo);
+});
+
 test('finds element by index', function(assert) {
   fixture(`
     <span class="lorem"></span>

--- a/tests/unit/predicates/not-has-class-test.js
+++ b/tests/unit/predicates/not-has-class-test.js
@@ -1,8 +1,11 @@
 import { test } from 'qunit';
 import { fixture, moduleFor } from '../test-helper';
 import { create, notHasClass } from '../../page-object';
+import {
+  test_throws_if_not_multiple
+} from '../shared';
 
-moduleFor('.notHasClass');
+moduleFor('Unit | Property | .notHasClass');
 
 test('returns false when the element has the class', function(assert) {
   fixture('<span class="lorem ipsum"></span>');
@@ -87,7 +90,7 @@ test('resets scope', function(assert) {
   assert.ok(page.foo);
 });
 
-test('throws error if selector matches more than one element', function(assert) {
+test_throws_if_not_multiple(function() {
   fixture(`
     <span class="lorem"></span>
     <span class="ipsum"></span>
@@ -97,10 +100,7 @@ test('throws error if selector matches more than one element', function(assert) 
     foo: notHasClass('lorem', 'span')
   });
 
-  assert.throws(
-    () => page.foo,
-    /span matched more than one element. If this is not an error use { multiple: true }/
-  );
+  return page.foo;
 });
 
 test('matches multiple elements with multiple: true option, returns true if no elements have class', function(assert) {

--- a/tests/unit/queries/attribute-test.js
+++ b/tests/unit/queries/attribute-test.js
@@ -5,7 +5,7 @@ import {
   test_throws_if_not_multiple
 } from '../shared';
 
-moduleFor('.attribute');
+moduleFor('Unit | Property | .attribute');
 
 test('returns attribute value', function(assert) {
   fixture('<input placeholder="a value">');

--- a/tests/unit/queries/attribute-test.js
+++ b/tests/unit/queries/attribute-test.js
@@ -1,6 +1,9 @@
 import { test } from 'qunit';
 import { fixture, moduleFor } from '../test-helper';
 import { create, attribute } from '../../page-object';
+import {
+  test_throws_if_not_multiple
+} from '../shared';
 
 moduleFor('.attribute');
 
@@ -77,7 +80,7 @@ test('resets scope', function(assert) {
   assert.equal(page.foo, 'a value');
 });
 
-test('throws error if selector matches more than one element', function(assert) {
+test_throws_if_not_multiple(function() {
   fixture(`
     <input placeholder="a value">
     <input placeholder="other value">
@@ -87,13 +90,10 @@ test('throws error if selector matches more than one element', function(assert) 
     foo: attribute('placeholder', ':input')
   });
 
-  assert.throws(
-    () => page.foo,
-    /input matched more than one element. If this is not an error use { multiple: true }/
-  );
+  return page.foo;
 });
 
-test('matches multiple elements with multiple: true option', function(assert) {
+test('matches multiple elements', function(assert) {
   fixture(`
     <input placeholder="a value">
     <input placeholder="other value">
@@ -103,7 +103,7 @@ test('matches multiple elements with multiple: true option', function(assert) {
     foo: attribute('placeholder', ':input', { multiple: true })
   });
 
-  assert.equal(page.foo, "a value");
+  assert.deepEqual(page.foo, ['a value', 'other value']);
 });
 
 test('finds element by index', function(assert) {

--- a/tests/unit/queries/attribute-test.js
+++ b/tests/unit/queries/attribute-test.js
@@ -77,6 +77,35 @@ test('resets scope', function(assert) {
   assert.equal(page.foo, 'a value');
 });
 
+test('throws error if selector matches more than one element', function(assert) {
+  fixture(`
+    <input placeholder="a value">
+    <input placeholder="other value">
+  `);
+
+  let page = create({
+    foo: attribute('placeholder', ':input')
+  });
+
+  assert.throws(
+    () => page.foo,
+    /input matched more than one element. If this is not an error use { multiple: true }/
+  );
+});
+
+test('matches multiple elements with multiple: true option', function(assert) {
+  fixture(`
+    <input placeholder="a value">
+    <input placeholder="other value">
+  `);
+
+  let page = create({
+    foo: attribute('placeholder', ':input', { multiple: true })
+  });
+
+  assert.equal(page.foo, "a value");
+});
+
 test('finds element by index', function(assert) {
   fixture(`
     <input>

--- a/tests/unit/queries/count-test.js
+++ b/tests/unit/queries/count-test.js
@@ -2,7 +2,7 @@ import { test } from 'qunit';
 import { fixture, moduleFor } from '../test-helper';
 import { create, count } from '../../page-object';
 
-moduleFor('.count');
+moduleFor('Unit | Property | .count');
 
 test('returns the number of elements that match the selector', function(assert) {
   fixture(`

--- a/tests/unit/queries/count-test.js
+++ b/tests/unit/queries/count-test.js
@@ -67,3 +67,18 @@ test('resets scope', function(assert) {
 
   assert.equal(page.foo, 1);
 });
+
+test('resets multiple value', function(assert) {
+  fixture(`
+    <div><span></span></div>
+    <div class="scope"><span></span><span></span></div>
+  `);
+
+  let page = create({
+    scope: '.scope',
+
+    foo: count('span', { multiple: false })
+  });
+
+  assert.equal(page.foo, 2);
+});

--- a/tests/unit/queries/text-test.js
+++ b/tests/unit/queries/text-test.js
@@ -102,10 +102,10 @@ test('resets scope', function(assert) {
   let page = create({
     scope: '.scope',
 
-    foo: text('span', { resetScope: true })
+    foo: text('span', { at: 0, resetScope: true })
   });
 
-  assert.equal(page.foo, 'lorem ipsum dolor');
+  assert.equal(page.foo, 'lorem');
 });
 
 test('finds element by index', function(assert) {
@@ -139,6 +139,25 @@ test('finds element without using a selector', function(assert) {
 
   assert.equal(page.foo, 'Hello world!');
   assert.equal(page.bar.baz, 'world!');
+});
+
+test('throws error if selector matches more than one element', function(assert) {
+  fixture(`
+    <span>lorem</span>
+    <span> ipsum </span>
+    <span>dolor</span>
+  `);
+
+  let page = create({
+    scope: '.scope',
+
+    foo: text('span', { resetScope: true })
+  });
+
+  assert.throws(
+    () => page.foo,
+    /span matched more than one element. If this is not an error use { multiple: true }/
+  );
 });
 
 test('returns multiple values', function(assert) {

--- a/tests/unit/queries/text-test.js
+++ b/tests/unit/queries/text-test.js
@@ -1,8 +1,11 @@
 import { test } from 'qunit';
 import { fixture, moduleFor } from '../test-helper';
 import { create, text } from '../../page-object';
+import {
+  test_throws_if_not_multiple
+} from '../shared';
 
-moduleFor('.text');
+moduleFor('Unit | Property | .text');
 
 test('returns the inner text of the element', function(assert) {
   fixture('Hello <span>world!</span>');
@@ -141,7 +144,7 @@ test('finds element without using a selector', function(assert) {
   assert.equal(page.bar.baz, 'world!');
 });
 
-test('throws error if selector matches more than one element', function(assert) {
+test_throws_if_not_multiple(function() {
   fixture(`
     <span>lorem</span>
     <span> ipsum </span>
@@ -154,10 +157,7 @@ test('throws error if selector matches more than one element', function(assert) 
     foo: text('span', { resetScope: true })
   });
 
-  assert.throws(
-    () => page.foo,
-    /span matched more than one element. If this is not an error use { multiple: true }/
-  );
+  return page.foo;
 });
 
 test('returns multiple values', function(assert) {

--- a/tests/unit/queries/value-test.js
+++ b/tests/unit/queries/value-test.js
@@ -69,10 +69,39 @@ test('resets scope', function(assert) {
   let page = create({
     scope: '.scope',
 
-    foo: value('input', { resetScope: true })
+    foo: value('input', { at: 0, resetScope: true })
   });
 
   assert.equal(page.foo, 'lorem');
+});
+
+test('throws error if selector matches more than one element', function(assert) {
+  fixture(`
+    <input value="lorem">
+    <input value="ipsum">
+  `);
+
+  let page = create({
+    foo: value('input')
+  });
+
+  assert.throws(
+    () => page.foo,
+    /input matched more than one element. If this is not an error use { multiple: true }/
+  );
+});
+
+test('matches multiple elements with multiple: true option', function(assert) {
+  fixture(`
+    <input value="lorem">
+    <input value="ipsum">
+  `);
+
+  let page = create({
+    foo: value('input', { multiple: true })
+  });
+
+  assert.equal(page.foo, "lorem");
 });
 
 test('finds element by index', function(assert) {

--- a/tests/unit/queries/value-test.js
+++ b/tests/unit/queries/value-test.js
@@ -101,7 +101,7 @@ test('matches multiple elements with multiple: true option', function(assert) {
     foo: value('input', { multiple: true })
   });
 
-  assert.equal(page.foo, "lorem");
+  assert.deepEqual(page.foo, ["lorem", "ipsum"]);
 });
 
 test('finds element by index', function(assert) {

--- a/tests/unit/queries/value-test.js
+++ b/tests/unit/queries/value-test.js
@@ -1,8 +1,11 @@
 import { test } from 'qunit';
 import { fixture, moduleFor } from '../test-helper';
 import { create, value } from '../../page-object';
+import {
+  test_throws_if_not_multiple
+} from '../shared';
 
-moduleFor('.value');
+moduleFor('Unit | Property | .value');
 
 test('returns the text of the input', function(assert) {
   fixture('<input value="Lorem ipsum">');
@@ -75,7 +78,7 @@ test('resets scope', function(assert) {
   assert.equal(page.foo, 'lorem');
 });
 
-test('throws error if selector matches more than one element', function(assert) {
+test_throws_if_not_multiple(function() {
   fixture(`
     <input value="lorem">
     <input value="ipsum">
@@ -85,10 +88,7 @@ test('throws error if selector matches more than one element', function(assert) 
     foo: value('input')
   });
 
-  assert.throws(
-    () => page.foo,
-    /input matched more than one element. If this is not an error use { multiple: true }/
-  );
+  return page.foo;
 });
 
 test('matches multiple elements with multiple: true option', function(assert) {

--- a/tests/unit/shared.js
+++ b/tests/unit/shared.js
@@ -1,0 +1,7 @@
+import { test } from 'qunit';
+
+export function test_throws_if_not_multiple(fn) {
+  test('throws error if selector matches more than one element', function(assert) {
+    assert.throws(fn, /matched more than one element. If this is not an error use { multiple: true }/);
+  });
+}


### PR DESCRIPTION
* [x] Predicates and queries throw error when DOM lookups return more than one element.
* [x] `multiple: true` option overrides this behavior.