### PR TITLE
Change `.visitable` signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# master
+
+- [Change] Change `.visitable` signature
+
 # v1.0.0-alpha.1
 
 - [Feature] Can import properties directly `import { create } from 'path/to/page-object';`

--- a/tests/unit/actions/visitable-test.js
+++ b/tests/unit/actions/visitable-test.js
@@ -52,7 +52,7 @@ test("raises an exception if params aren't given for all dynamic segments", func
   }
 });
 
-test('appends queryParams to the path', function(assert) {
+test('appends query params to the path', function(assert) {
   assert.expect(1);
 
   let page;
@@ -65,5 +65,21 @@ test('appends queryParams to the path', function(assert) {
     foo: visitable('/dummy-page')
   });
 
-  page.foo({}, { hello: "world", lorem: "ipsum" });
+  page.foo({ hello: "world", lorem: "ipsum" });
+});
+
+test('accepts both dynamic segments and query params', function(assert) {
+  assert.expect(1);
+
+  let page;
+
+  window.visit = function(actualRoute) {
+    assert.equal(actualRoute, '/users/1/0?hello=world&lorem=ipsum');
+  };
+
+  page = create({
+    foo: visitable('/users/:user_id/:another_id')
+  });
+
+  page.foo({ user_id: 1, another_id: 0, hello: "world", lorem: "ipsum" });
 });


### PR DESCRIPTION
Instead of receiving two distinct object parameters (dynamic segments
and query params) now it receives only one.

The idea is to fill the dynamic segments first using the values from
the param that match the keys and then use the rest of the keys and
values as query params.

e.g.

```
var page = create({
  visit: visitable('/users/:user_id')
})

page.visit({ user_id: 1, expanded: true });

// is equivalent to

visit("/users/1?expanded=true")
```

Fixes #113 