### PR TITLE
Change `.clickOnText` to match current element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# master
+
+- [Change] `.clickOnText` now matches current element as well
+
 # v1.0.0-alpha.1
 
 - [Feature] Can import properties directly `import { create } from 'path/to/page-object';`

--- a/test-support/page-object/properties/click-on-text.js
+++ b/test-support/page-object/properties/click-on-text.js
@@ -1,7 +1,27 @@
 import Ember from 'ember';
 import { buildSelector } from '../helpers';
 
+/* global wait, find, click */
+
 var { merge } = Ember;
+
+function findChildElement(tree, selector, textToClick, options) {
+  // Suppose that we have something like `<form><button>Submit</button></form>`
+  // In this case <form> and <button> elements contains "Submit" text, so, we'll
+  // want to __always__ click on the __last__ element that contains the text.
+  var selctorWithSpace = (selector || '') + ' ';
+  var fullSelector = buildSelector(tree, selctorWithSpace, merge({ contains: textToClick, last: true }, options));
+
+  if (find(fullSelector).length) {
+    return fullSelector;
+  }
+}
+
+function findElement(tree, selector, textToClick, options) {
+  var fullSelector = buildSelector(tree, selector, merge({ contains: textToClick }, options));
+
+  return fullSelector;
+}
 
 /**
  * Creates an action to click an element
@@ -25,17 +45,11 @@ export function clickOnText(selector, options = {}) {
     isDescriptor: true,
 
     value(textToClick) {
-      // Suppose that we have something like `<form><button>Submit</button></form>`
-      // In this case <form> and <button> elements contains "Submit" text, so, we'll
-      // want to __always__ click on the __last__ element that contains the text.
-      var selctorWithSpace = (selector || '') + ' ';
-      var fullSelector = buildSelector(
-        this,
-        selctorWithSpace,
-        merge({ contains: textToClick, last: true }, options));
+      wait().then(() => {
+        var actualSelector = findChildElement(this, selector, textToClick, options) || findElement(this, selector, textToClick, options);
 
-      /* global click */
-      click(fullSelector);
+        click(actualSelector);
+      });
 
       return this;
     }

--- a/tests/unit/actions/click-on-text-test.js
+++ b/tests/unit/actions/click-on-text-test.js
@@ -1,74 +1,141 @@
 import { test } from 'qunit';
-import { moduleFor } from '../test-helper';
+import { moduleFor, fixture } from '../test-helper';
 import { create, clickOnText } from '../../page-object';
 
 moduleFor('Unit | Property | .clickOnText');
 
 test('calls Ember\'s click helper', function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
-  let expectedSelector = 'span :contains("dummy text"):last',
-      page;
+  fixture(`
+    <fieldset>
+      <button>Lorem</button>
+      <button>Ipsum</button>
+    </fieldset>
+  `);
+
+  let expectedSelector, page;
 
   window.click = function(actualSelector) {
     assert.equal(actualSelector, expectedSelector);
   };
 
   page = create({
-    foo: clickOnText('span')
+    foo: clickOnText('fieldset'),
+    bar: clickOnText('button')
   });
 
-  page.foo('dummy text');
+  andThen(() => {
+    expectedSelector = 'fieldset :contains("Lorem"):last';
+    page.foo('Lorem');
+  });
+
+  andThen(() => {
+    expectedSelector = 'button:contains("Lorem")';
+    page.bar('Lorem');
+  });
 });
 
 test('looks for elements inside the scope', function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
-  let page;
+  fixture(`
+    <div class="scope">
+      <fieldset>
+        <button>Lorem</button>
+        <button>Ipsum</button>
+      </fieldset>
+    </div>
+  `);
+
+  let expectedSelector, page;
 
   window.click = function(actualSelector) {
-    assert.equal(actualSelector, '.scope span :contains("dummy text"):last');
+    assert.equal(actualSelector, expectedSelector);
   };
 
   page = create({
-    foo: clickOnText('span', { scope: '.scope' })
+    foo: clickOnText('fieldset', { scope: '.scope' }),
+    bar: clickOnText('button', { scope: '.scope' })
   });
 
-  page.foo('dummy text');
+  andThen(() => {
+    expectedSelector = '.scope fieldset :contains("Lorem"):last';
+    page.foo('Lorem');
+  });
+
+  andThen(() => {
+    expectedSelector = '.scope button:contains("Lorem")';
+    page.bar('Lorem');
+  });
 });
 
 test('looks for elements inside page\'s scope', function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
-  let page;
+  fixture(`
+    <div class="scope">
+      <fieldset>
+        <button>Lorem</button>
+        <button>Ipsum</button>
+      </fieldset>
+    </div>
+  `);
+
+  let page, expectedSelector;
 
   window.click = function(actualSelector) {
-    assert.equal(actualSelector, '.scope span :contains("dummy text"):last');
+    assert.equal(actualSelector, expectedSelector);
   };
 
   page = create({
     scope: '.scope',
-    foo: clickOnText('span')
+    foo: clickOnText('fieldset'),
+    bar: clickOnText('button')
   });
 
-  page.foo('dummy text');
+  andThen(() => {
+    expectedSelector = '.scope fieldset :contains("Lorem"):last';
+    page.foo('Lorem');
+  });
+
+  andThen(() => {
+    expectedSelector = '.scope button:contains("Lorem")';
+    page.bar('Lorem');
+  });
 });
 
 test('resets scope', function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
-  let page;
+  fixture(`
+    <fieldset>
+      <button>Lorem</button>
+      <button>Ipsum</button>
+    </fieldset>
+  `);
+
+  let page, expectedSelector;
 
   window.click = function(actualSelector) {
-    assert.equal(actualSelector, 'span :contains("dummy text"):last');
+    assert.equal(actualSelector, expectedSelector);
   };
 
   page = create({
     scope: '.scope',
-    foo: clickOnText('span', { resetScope: true })
+    foo: clickOnText('fieldset', { resetScope: true }),
+    bar: clickOnText('button', { resetScope: true })
   });
 
-  page.foo('dummy text');
+  andThen(() => {
+    expectedSelector = 'fieldset :contains("Lorem"):last';
+    page.foo('Lorem');
+  });
+
+  andThen(() => {
+    expectedSelector = 'button:contains("Lorem")';
+    page.bar('Lorem');
+  });
 });
 
 test('returns target object', function(assert) {
@@ -89,18 +156,35 @@ test('returns target object', function(assert) {
 });
 
 test('finds element by index', function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
-  let expectedSelector = 'span :contains("dummy text"):eq(3)',
-      page;
+  fixture(`
+    <fieldset>
+      <button>Lorem</button>
+      <button>Lorem</button>
+      <button>Lorem</button>
+      <button>Ipsum</button>
+    </fieldset>
+  `);
+
+  let expectedSelector, page;
 
   window.click = function(actualSelector) {
     assert.equal(actualSelector, expectedSelector);
   };
 
   page = create({
-    foo: clickOnText('span', { at: 3 })
+    foo: clickOnText('fieldset', { at: 2 }),
+    bar: clickOnText('button', { at: 2 })
   });
 
-  page.foo('dummy text');
+  andThen(() => {
+    expectedSelector = 'fieldset :contains("Lorem"):eq(2)';
+    page.foo('Lorem');
+  });
+
+  andThen(() => {
+    expectedSelector = 'button:contains("Lorem"):eq(2)';
+    page.bar('Lorem');
+  });
 });


### PR DESCRIPTION
Now the property can match both, current element or child elements

Fixes #114 