### PR TITLE
Autogenerate API docs path from version number

### DIFF
--- a/docs.js
+++ b/docs.js
@@ -225,6 +225,7 @@ function copyDocs(srcDir, destDir) {
       if (err) {
         reject(err);
       } else {
+        console.log('Copied docs to ' + destDir);
         resolve();
       }
     });
@@ -262,7 +263,7 @@ function removeDir(dir) {
       if (err) {
         reject(err);
       } else {
-        console.log('Finished writing documentation files.');
+        console.log('Removed directory ' + dir);
         resolve();
       }
     });
@@ -303,6 +304,9 @@ function removeDir(dir) {
   .then(function() {
     // Delete the temporary directory
     return removeDir(tmpDir);
+  })
+  .then(function() {
+    console.log('Finished writing documentation files.');
   })
   .catch(function(reason) {
     console.log(reason.stack);

--- a/docs.js
+++ b/docs.js
@@ -14,6 +14,7 @@ var ncp = require('ncp');
 var mkdirp = require('mkdirp');
 var rimraf = require('rimraf');
 var RSVP = require('rsvp');
+var packageJSON = require('./package.json');
 
 /* Runs an arbitrary shell command.
  *
@@ -63,7 +64,6 @@ function massageMarkdown(markdown, options) {
     '---',
     'layout: page',
     'title: ' + options.title,
-    'permalink: ' + '/api/methods/' + options.slug + '/',
     '---'
   ];
   var processedMarkdown;
@@ -105,7 +105,7 @@ function massageMarkdown(markdown, options) {
  * @param {string} srcPath - The full path of the source file or directory.
  * @param {string} destDir - The directory in which to write the Markdown file.
  * @param {Object} options
- * @param {string} options.slug - The slug of the documentation. Used to construct the filename and permalink.
+ * @param {string} options.slug - The slug of the documentation. Used to construct the filename.
  * @param {string} options.title - The page title of the documentation.
  * @returns {Promise}
  */
@@ -270,9 +270,13 @@ function removeDir(dir) {
 }
 
 (function() {
-  var srcDir = path.join(__dirname, 'test-support', 'page-object');
-  var tmpDir    = path.join(__dirname, 'tmp_docs');
-  var destDir   = path.join(__dirname, 'api', 'methods');
+  var versionArray = packageJSON.version.split('.');
+  // ex., '1.0.3' -> 'v1.0.x'
+  var version = 'v' + versionArray[0] + '.' + versionArray[1] + '.x';
+
+  var srcDir  = path.join(__dirname, 'test-support', 'page-object');
+  var tmpDir  = path.join(__dirname, 'tmp_docs');
+  var destDir = path.join(__dirname, 'docs', version, 'api');
 
   // Create the temporary directory for the docs
   createDir(tmpDir)


### PR DESCRIPTION
Changes docs destination path in docs.js from `api/methods` to one automatically generated based on the version number in package.json.

Removes permalink from markdown frontmatter.

Improves `console.log` messages in docs.js.