### PR TITLE
Copy edit JSDoc inline documentation

### DIFF
--- a/docs.js
+++ b/docs.js
@@ -58,7 +58,9 @@ function massageMarkdown(markdown, options) {
   var headerRegex = /^#{1,6} /;
   var h2Regex = /^## (.*)$/;
   var lines = markdown.split('\n');
-  var tableOfContents = [];
+  var tableOfContents = [
+    '### Methods\n'
+  ];
   // The jekyll yml frontmatter
   var frontmatter = [
     '---',

--- a/test-support/page-object/actions/click-on-text.js
+++ b/test-support/page-object/actions/click-on-text.js
@@ -24,9 +24,10 @@ function findElement(tree, selector, textToClick, options) {
 }
 
 /**
- * Clicks on element that contains text within the element specified by selector
+ * Clicks on an element containing specified text.
  *
- * The element to be clicked can be the same as specified by selector
+ * The element can either match a specified selector,
+ * or be inside an element matching the specified selector.
  *
  * @example
  *
@@ -35,7 +36,7 @@ function findElement(tree, selector, textToClick, options) {
  * //  <button>Ipsum</button>
  * // </fieldset>
  *
- * var page = PageObject.create({
+ * const page = PageObject.create({
  *   clickOnFieldset: PageObject.clickOnText('fieldset'),
  *   clickOnButton: PageObject.clickOnText('button')
  * });
@@ -43,7 +44,7 @@ function findElement(tree, selector, textToClick, options) {
  * // queries the DOM with selector 'fieldset :contains("Lorem"):last'
  * page.clickOnFieldset('Lorem');
  *
- * // queries the DOM with selector 'button:contains("Lorem")'
+ * // queries the DOM with selector 'button:contains("Ipsum")'
  * page.clickOnButton('Ipsum');
  *
  * @example
@@ -55,7 +56,7 @@ function findElement(tree, selector, textToClick, options) {
  * //   </fieldset>
  * // </div>
  *
- * var page = PageObject.create({
+ * const page = PageObject.create({
  *   clickOnFieldset: PageObject.clickOnText('fieldset', { scope: '.scope' }),
  *   clickOnButton: PageObject.clickOnText('button', { scope: '.scope' })
  * });
@@ -63,7 +64,7 @@ function findElement(tree, selector, textToClick, options) {
  * // queries the DOM with selector '.scope fieldset :contains("Lorem"):last'
  * page.clickOnFieldset('Lorem');
  *
- * // queries the DOM with selector '.scope button:contains("Lorem")'
+ * // queries the DOM with selector '.scope button:contains("Ipsum")'
  * page.clickOnButton('Ipsum');
  *
  * @example
@@ -75,7 +76,7 @@ function findElement(tree, selector, textToClick, options) {
  * //   </fieldset>
  * // </div>
  *
- * var page = PageObject.create({
+ * const page = PageObject.create({
  *   scope: '.scope',
  *   clickOnFieldset: PageObject.clickOnText('fieldset'),
  *   clickOnButton: PageObject.clickOnText('button')
@@ -84,14 +85,14 @@ function findElement(tree, selector, textToClick, options) {
  * // queries the DOM with selector '.scope fieldset :contains("Lorem"):last'
  * page.clickOnFieldset('Lorem');
  *
- * // queries the DOM with selector '.scope button:contains("Lorem")'
+ * // queries the DOM with selector '.scope button:contains("Ipsum")'
  * page.clickOnButton('Ipsum');
  *
  * @public
  *
- * @param {string} selector - CSS selector of the element to look for text
+ * @param {string} selector - CSS selector of the element in which to look for text
  * @param {Object} options - Additional options
- * @param {string} options.scope - Nests provided scope with parent's scope
+ * @param {string} options.scope - Nests provided scope within parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.resetScope - Override parent's scope
  * @return {Descriptor}

--- a/test-support/page-object/actions/clickable.js
+++ b/test-support/page-object/actions/clickable.js
@@ -1,14 +1,14 @@
 import { buildSelector } from '../helpers';
 
 /**
- * Clicks element matched by selector
+ * Clicks elements matched by a selector.
  *
  * @example
  *
  * // <button class="continue">Continue<button>
  * // <button>Cancel</button>
  *
- * var page = PageObject.create({
+ * const page = PageObject.create({
  *   continue: clickable('button.continue')
  * });
  *
@@ -22,7 +22,7 @@ import { buildSelector } from '../helpers';
  * // </div>
  * // <button>Cancel</button>
  *
- * var page = PageObject.create({
+ * const page = PageObject.create({
  *   continue: clickable('button.continue', { scope: '.scope' })
  * });
  *
@@ -36,7 +36,7 @@ import { buildSelector } from '../helpers';
  * // </div>
  * // <button>Cancel</button>
  *
- * var page = PageObject.create({
+ * const page = PageObject.create({
  *   scope: '.scope',
  *   continue: clickable('button.continue')
  * });
@@ -48,12 +48,11 @@ import { buildSelector } from '../helpers';
  *
  * @param {string} selector - CSS selector of the element to click
  * @param {Object} options - Additional options
- * @param {string} options.scope - Nests provided scope with parent's scope
+ * @param {string} options.scope - Nests provided scope within parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.resetScope - Ignore parent scope
  * @return {Descriptor}
  */
-
 
 export function clickable(selector, options = {}) {
   return {

--- a/test-support/page-object/actions/fillable.js
+++ b/test-support/page-object/actions/fillable.js
@@ -1,13 +1,13 @@
 import { buildSelector } from '../helpers';
 
 /**
- * Fills an input matched by selector
+ * Fills in an input matched by a selector.
  *
  * @example
  *
  * // <input value="">
  *
- * var page = PageObject.create({
+ * const page = PageObject.create({
  *   fillIn: PageObject.fillable('input')
  * });
  *
@@ -23,7 +23,7 @@ import { buildSelector } from '../helpers';
  * //   <input value= "">
  * // </div>
  *
- * var page = PageObject.create({
+ * const page = PageObject.create({
  *   fillInName: PageObject.fillable('input', { scope: '.name' })
  * });
  *
@@ -43,7 +43,7 @@ import { buildSelector } from '../helpers';
  * //   <input value= "">
  * // </div>
  *
- * var page = PageObject.create({
+ * const page = PageObject.create({
  *   scope: 'name',
  *   fillInName: PageObject.fillable('input')
  * });
@@ -59,7 +59,7 @@ import { buildSelector } from '../helpers';
  *
  * @param {string} selector - CSS selector of the element to look for text
  * @param {Object} options - Additional options
- * @param {string} options.scope - Nests provided scope with parent's scope
+ * @param {string} options.scope - Nests provided scope within parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.resetScope - Override parent's scope
  * @return {Descriptor}

--- a/test-support/page-object/actions/visitable.js
+++ b/test-support/page-object/actions/visitable.js
@@ -33,11 +33,13 @@ function appendQueryParams(path, queryParams) {
 }
 
 /**
- * Loads a given route, result descriptor can be called with dynamic segments and parameters.
+ * Loads a given route.
+ *
+ * The resulting descriptor can be called with dynamic segments and parameters.
  *
  * @example
  *
- * var page = PageObject.create({
+ * const page = PageObject.create({
  *   visit: PageObject.visitable('/users')
  * });
  *
@@ -46,7 +48,7 @@ function appendQueryParams(path, queryParams) {
  *
  * @example
  *
- * var page = PageObject.create({
+ * const page = PageObject.create({
  *   visit: PageObject.visitable('/users/:user_id')
  * });
  *
@@ -55,7 +57,7 @@ function appendQueryParams(path, queryParams) {
  *
  * @example
  *
- * var page = PageObject.create({
+ * const page = PageObject.create({
  *   visit: PageObject.visitable('/users')
  * });
  *
@@ -64,12 +66,12 @@ function appendQueryParams(path, queryParams) {
  *
  * @example
  *
- * var page = PageObject.create({
+ * const page = PageObject.create({
  *   visit: PageObject.visitable('/users/:user_id')
  * });
  *
  * // visits '/users/1?name=john'
- * page.visit({ id: 1 }, { name: 'john' });
+ * page.visit({ user_id: 1, name: 'john' });
  *
  * @param {string} path - Full path of the route to visit
  * @return {Descriptor}

--- a/test-support/page-object/collection.js
+++ b/test-support/page-object/collection.js
@@ -31,9 +31,13 @@ function generateItem(index, definition) {
 }
 
 /**
- * Creates a component that represents a collection of items, the collection is zero-indexed
+ * Creates a component that represents a collection of items. The collection is zero-indexed.
  *
- * The collection component behaves as a regular PageObject when called without index (parens needed)
+ * Collections have a `count` property that returns the number of elements in the collection.
+ *
+ * The collection returned by the collection method behaves as a regular PageObject when called without an index.
+ *
+ * When called with an index, the method returns the matching item.
  *
  * @example
  *
@@ -50,12 +54,12 @@ function generateItem(index, definition) {
  * //   </tbody>
  * // </table>
  *
- * var page = PageObject.create({
+ * const page = PageObject.create({
  *   users: collection({
  *     itemScope: 'table tr',
  *
  *     item: {
- *       firstName: text('td', { at: 0 })
+ *       firstName: text('td', { at: 0 }),
  *       lastName: text('td', { at: 1 })
  *     }
  *   })
@@ -87,14 +91,14 @@ function generateItem(index, definition) {
  * //   </table>
  * // </div>
  *
- * var page = PageObject.create({
+ * const page = PageObject.create({
  *   users: collection({
  *     scope: '.admins',
  *
  *     itemScope: 'table tr',
  *
  *     item: {
- *       firstName: text('td', { at: 0 })
+ *       firstName: text('td', { at: 0 }),
  *       lastName: text('td', { at: 1 })
  *     }
  *   })
@@ -113,7 +117,7 @@ function generateItem(index, definition) {
  * //   </tbody>
  * // </table>
  *
- * var page = PageObject.create({
+ * const page = PageObject.create({
  *   users: PageObject.collection({
  *     scope: 'table',
  *     itemScope: 'tr',
@@ -126,10 +130,10 @@ function generateItem(index, definition) {
  *   })
  * });
  *
- * assert.equal(page.users().caption, "User Index");
+ * assert.equal(page.users().caption, 'User Index');
  *
  * @param {Object} definition - Collection definition
- * @param {string} definition.scope - Nests provided scope with parent's scope
+ * @param {string} definition.scope - Nests provided scope within parent's scope
  * @param {boolean} definition.resetScope - Override parent's scope
  * @param {String} definition.itemScope - CSS selector
  * @param {Object} definition.item - Item definition

--- a/test-support/page-object/create.js
+++ b/test-support/page-object/create.js
@@ -35,10 +35,8 @@ function plugDefaultProperties(definition) {
   }
 }
 
-/**
- * See https://github.com/san650/ceibo#examples for more info on how Ceibo
- * builders work.
- */
+// See https://github.com/san650/ceibo#examples for more info on how Ceibo
+// builders work.
 function buildObject(builder, target, key, definition) {
   var container = {};
 
@@ -52,17 +50,22 @@ function buildObject(builder, target, key, definition) {
 }
 
 /**
- * Creates a new PageObject
+ * Creates a new PageObject.
  *
- * By default, the result PageObject will respond to a default set of options: click, clickOn,
- * contains, isHidden, isVisible and text.
+ * By default, the resulting PageObject will respond to:
+ *
+ * - **Actions**: click, clickOn
+ * - **Predicates**: contains, isHidden, isVisible
+ * - **Queries**: text
  *
  * @example
  *
  * // <div class="title">My title</div>
  *
- * var page = PageObject.create({
- *   title: PageObject.text('.title')
+ * import PageObject, { text } from 'frontend/tests/page-object';
+ *
+ * const page = PageObject.create({
+ *   title: text('.title')
  * });
  *
  * assert.equal(page.title, 'My title');
@@ -70,21 +73,21 @@ function buildObject(builder, target, key, definition) {
  * @example
  *
  * // <div id="my-page">
- * //  My super text
- * //  <button> Press Me</button>
+ * //   My super text
+ * //   <button>Press Me</button>
  * // </div>
  *
- * var page = PageObject.create({
- *   scope: '#my-page',
+ * const page = PageObject.create({
+ *   scope: '#my-page'
  * });
  *
  * assert.equal(page.text, 'My super text');
- * assert.ok(page.isVisible);
- * assert.ok(!page.isHidden);
  * assert.ok(page.contains('super'));
+ * assert.ok(page.isVisible);
+ * assert.notOk(page.isHidden);
  *
  * // clicks div#my-page
- * page.click
+ * page.click();
  *
  * // clicks button
  * page.clickOn('Press Me');

--- a/test-support/page-object/helpers.js
+++ b/test-support/page-object/helpers.js
@@ -74,53 +74,53 @@ function guardMultiple(items, selector, supportMultiple) {
 }
 
 /**
- * Returns selector that includes all options specified as parameters
+ * Builds a CSS selector from a target selector and a PageObject or a node in a PageObject, along with optional parameters.
  *
  * @example
  *
- * let component = pageobject.create({ scope: '.component'} );
+ * const component = PageObject.create({ scope: '.component'});
  *
- * buildselector(component, '.my-element');
+ * buildSelector(component, '.my-element');
  * // returns '.component .my-element'
  *
  * @example
  *
- * let component = pageobject.create({});
+ * const page = PageObject.create({});
  *
- * buildselector(component, '.my-element', { at: 0 });
+ * buildSelector(page, '.my-element', { at: 0 });
  * // returns '.my-element:eq(0)'
  *
  * @example
  *
- * let component = pageobject.create({});
+ * const page = PageObject.create({});
  *
- * buildselector(component, '.my-element', { contains: "Example" });
+ * buildSelector(page, '.my-element', { contains: "Example" });
  * // returns ".my-element :contains('Example')"
  *
  * @example
  *
- * let component = pageobject.create({});
+ * const page = PageObject.create({});
  *
- * buildselector(component, '.my-element', { last: true });
- * // returns ".my-element:last"
+ * buildSelector(page, '.my-element', { last: true });
+ * // returns '.my-element:last'
  *
  * @public
  *
  * @param {Ceibo} node - Node of the tree
- * @param {string} targetSelector - Specific CSS selector
+ * @param {string} targetSelector - CSS selector
  * @param {Object} options - Additional options
  * @param {boolean} options.resetScope - Do not use inherited scope
  * @param {string} options.contains - Filter by using :contains('foo') pseudo-class
  * @param {number} options.at - Filter by index using :eq(x) pseudo-class
  * @param {boolean} options.last - Filter by using :last pseudo-class
- * @return {string} Full qualified selector
+ * @return {string} Fully qualified selector
  */
 export function buildSelector(node, targetSelector, options) {
   return (new Selector(node, options.scope, targetSelector, options)).toString();
 }
 
 /**
- * Return a jQuery element matched by selector built from parameters
+ * Returns a jQuery element matched by a selector built from parameters
  *
  * @public
  *
@@ -135,7 +135,7 @@ export function buildSelector(node, targetSelector, options) {
  * @return {Object} jQuery object
  *
  * @throws Will throw an error if no element matches selector
- * @throws Will throw an error if multiple elements are matched by selector and multiple options is not set
+ * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function findElementWithAssert(node, targetSelector, options = {}) {
   var selector = buildSelector(node, targetSelector, options);
@@ -147,7 +147,7 @@ export function findElementWithAssert(node, targetSelector, options = {}) {
 }
 
 /**
- * Return a jQuery element (can be an empty jQuery result)
+ * Returns a jQuery element (can be an empty jQuery result)
  *
  * @public
  *
@@ -161,7 +161,7 @@ export function findElementWithAssert(node, targetSelector, options = {}) {
  * @param {boolean} options.multiple - Specify if built selector can match multiple elements.
  * @return {Object} jQuery object
  *
- * @throws Will throw an error if multiple elements are matched by selector and multiple options is not set
+ * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function findElement(node, targetSelector, options = {}) {
   var selector = buildSelector(node, targetSelector, options);

--- a/test-support/page-object/predicates/contains.js
+++ b/test-support/page-object/predicates/contains.js
@@ -1,14 +1,14 @@
 import { findElementWithAssert, every } from '../helpers';
 
 /**
- * Validates if an element or a set of elements contain a subtext
+ * Returns a boolean representing whether an element or a set of elements contains the specified text.
  *
  * @example
  *
  * // Lorem <span>ipsum</span>
  *
- * let page = PageObject.create({
- *  spanContains: PageObject.contains('span')
+ * const page = PageObject.create({
+ *   spanContains: PageObject.contains('span')
  * });
  *
  * assert.ok(page.spanContains('ipsum'));
@@ -19,19 +19,19 @@ import { findElementWithAssert, every } from '../helpers';
  * // <span>ipsum</span>
  * // <span>dolor</span>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   spansContain: PageObject.contains('span', { multiple: true })
  * });
  *
  * // not all spans contain 'lorem'
- * assert.ok(!page.spansContain('lorem'));
+ * assert.notOk(page.spansContain('lorem'));
  *
  * @example
  *
  * // <span>super text</span>
  * // <span>regular text</span>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   spansContain: PageObject.contains('span', { multiple: true })
  * });
  *
@@ -44,12 +44,12 @@ import { findElementWithAssert, every } from '../helpers';
  * // <div class="scope"><span>ipsum</span></div>
  * // <div><span>dolor</span></div>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   spanContains: PageObject.contains('span', { scope: '.scope' })
  * });
  *
- * assert.ok(!page.spanContains('lorem'));
- * assert.ok(page.foo('ipsum'));
+ * assert.notOk(page.spanContains('lorem'));
+ * assert.ok(page.spanContains('ipsum'));
  *
  * @example
  *
@@ -57,27 +57,27 @@ import { findElementWithAssert, every } from '../helpers';
  * // <div class="scope"><span>ipsum</span></div>
  * // <div><span>dolor</span></div>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   scope: '.scope',
 
  *   spanContains: PageObject.contains('span')
  * });
  *
- * assert.ok(!page.spanContains('lorem'));
- * assert.ok(page.foo('ipsum'));
+ * assert.notOk(page.spanContains('lorem'));
+ * assert.ok(page.spanContains('ipsum'));
  *
  * @public
  *
  * @param {string} selector - CSS selector of the element to check
  * @param {Object} options - Additional options
- * @param {string} options.scope - Nests provided scope with parent's scope
+ * @param {string} options.scope - Nests provided scope within parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.resetScope - Override parent's scope
  * @param {boolean} options.multiple - Check if all elements matched by selector contain the subtext
  * @return {Descriptor}
  *
  * @throws Will throw an error if no element matches selector
- * @throws Will throw an error if multiple elements are matched by selector and multiple options is not set
+ * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function contains(selector, options = {}) {
   return {

--- a/test-support/page-object/predicates/has-class.js
+++ b/test-support/page-object/predicates/has-class.js
@@ -1,13 +1,13 @@
 import { findElementWithAssert, every } from '../helpers';
 
 /**
- * Validates if an element or a set of elements have a given CSS class
+ * Validates if an element or a set of elements have a given CSS class.
  *
  * @example
  *
  * // <em class="lorem"></em><span class="success">Message!</span>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   messageIsSuccess: PageObject.hasClass('success', 'span')
  * });
  *
@@ -18,18 +18,18 @@ import { findElementWithAssert, every } from '../helpers';
  * // <span class="success"></span>
  * // <span class="error"></span>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   messagesAreSuccessful: PageObject.hasClass('success', 'span', { multiple: true })
  * });
  *
- * assert.ok(!page.messagesAreSuccessful);
+ * assert.notOk(page.messagesAreSuccessful);
  *
  * @example
  *
  * // <span class="success"></span>
  * // <span class="success"></span>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   messagesAreSuccessful: PageObject.hasClass('success', 'span', { multiple: true })
  * });
  *
@@ -44,7 +44,7 @@ import { findElementWithAssert, every } from '../helpers';
  * //   <span class="ipsum"></span>
  * // </div>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   spanHasClass: PageObject.hasClass('ipsum', 'span', { scope: '.scope' })
  * });
  *
@@ -59,7 +59,7 @@ import { findElementWithAssert, every } from '../helpers';
  * //   <span class="ipsum"></span>
  * // </div>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   scope: '.scope',
  *   spanHasClass: PageObject.hasClass('ipsum', 'span')
  * });
@@ -71,14 +71,14 @@ import { findElementWithAssert, every } from '../helpers';
  * @param {string} cssClass - CSS class to be validated
  * @param {string} selector - CSS selector of the element to check
  * @param {Object} options - Additional options
- * @param {string} options.scope - Nests provided scope with parent's scope
+ * @param {string} options.scope - Nests provided scope within parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.resetScope - Override parent's scope
  * @param {boolean} options.multiple - Check if all elements matched by selector have the CSS class
  * @return {Descriptor}
  *
  * @throws Will throw an error if no element matches selector
- * @throws Will throw an error if multiple elements are matched by selector and multiple options is not set
+ * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function hasClass(cssClass, selector, options = {}) {
   return {

--- a/test-support/page-object/predicates/is-hidden.js
+++ b/test-support/page-object/predicates/is-hidden.js
@@ -1,13 +1,13 @@
 import { findElement, every } from '../helpers';
 
 /**
- * Validates if an element or set of elements are hidden
+ * Validates if an element or set of elements are hidden.
  *
  * @example
  *
  * // Lorem <span style="display:none">ipsum</span>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   spanIsHidden: PageObject.isHidden('span')
  * });
  *
@@ -18,19 +18,19 @@ import { findElement, every } from '../helpers';
  * // <span>ipsum</span>
  * // <span style="display:none">dolor</span>
  *
- * let page = create({
+ * const page = create({
  *   spansAreHidden: PageObject.isHidden('span', { multiple: true })
  * });
  *
  * // not all spans are hidden
- * assert.ok(!page.spansAreHidden);
+ * assert.notOk(page.spansAreHidden);
  *
  * @example
  *
  * // <span style="display:none">dolor</span>
  * // <span style="display:none">dolor</span>
  *
- * let page = create({
+ * const page = create({
  *   spansAreHidden: PageObject.isHidden('span', { multiple: true })
  * });
  *
@@ -39,9 +39,9 @@ import { findElement, every } from '../helpers';
  *
  * @example
  *
- * // Lorem <div>ipsum</div>
+ * // Lorem <strong>ipsum</strong>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   spanIsHidden: PageObject.isHidden('span')
  * });
  *
@@ -54,7 +54,7 @@ import { findElement, every } from '../helpers';
  * // <div class="scope"><span style="display:none">ipsum</span></div>
  * // <div><span>dolor</span></div>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   scopedSpanIsHidden: PageObject.isHidden('span', { scope: '.scope' })
  * });
  *
@@ -66,7 +66,7 @@ import { findElement, every } from '../helpers';
  * // <div class="scope"><span style="display:none">ipsum</span></div>
  * // <div><span>dolor</span></div>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   scope: '.scope',
  *   scopedSpanIsHidden: PageObject.isHidden('span')
  * });
@@ -77,13 +77,13 @@ import { findElement, every } from '../helpers';
  *
  * @param {string} selector - CSS selector of the element to check
  * @param {Object} options - Additional options
- * @param {string} options.scope - Nests provided scope with parent's scope
+ * @param {string} options.scope - Nests provided scope within parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.resetScope - Override parent's scope
  * @param {boolean} options.multiple - Check if all elements matched by selector are hidden
  * @return {Descriptor}
  *
- * @throws Will throw an error if multiple elements are matched by selector and multiple options is not set
+ * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function isHidden(selector, options = {}) {
   return {

--- a/test-support/page-object/predicates/is-visible.js
+++ b/test-support/page-object/predicates/is-visible.js
@@ -1,13 +1,13 @@
 import { findElement, every } from '../helpers';
 
 /**
- * Validates if an element or set of elements are visible
+ * Validates if an element or set of elements are visible.
  *
  * @example
  *
  * // Lorem <span>ipsum</span>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   spanIsVisible: PageObject.isVisible('span')
  * });
  *
@@ -18,19 +18,19 @@ import { findElement, every } from '../helpers';
  * // <span>ipsum</span>
  * // <span style="display:none">dolor</span>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   spansAreVisible: PageObject.isVisible('span', { multiple: true })
  * });
  *
  * // not all spans are visible
- * assert.ok(!page.spansAreVisible);
+ * assert.notOk(page.spansAreVisible);
  *
  * @example
  *
  * // <span>ipsum</span>
  * // <span>dolor</span>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   spansAreVisible: PageObject.isVisible('span', { multiple: true })
  * });
  *
@@ -39,22 +39,25 @@ import { findElement, every } from '../helpers';
  *
  * @example
  *
- * // Lorem <div>ipsum</div>
+ * // Lorem <strong>ipsum</strong>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   spanIsVisible: PageObject.isHidden('span')
  * });
  *
  * // returns false when element doesn't exist in DOM
- * assert.ok(!page.spanIsVisible);
+ * assert.notOk(page.spanIsVisible);
  *
  * @example
  *
- * // <div><span style="display:none">lorem</span></div>
+ * // <div>
+ * //   <span style="display:none">lorem</span>
+ * // </div>
+ * // <div class="scope">
+ * //   <span>ipsum</span>
+ * // </div>
  *
- * <div class="scope"><span>ipsum</span></div>
- *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   spanIsVisible: PageObject.isHidden('span', { scope: '.scope' })
  * });
  *
@@ -62,10 +65,14 @@ import { findElement, every } from '../helpers';
  *
  * @example
  *
- * // <div><span style="display:none">lorem</span></div>
- * // <div class="scope"><span>ipsum</span></div>
+ * // <div>
+ * //   <span style="display:none">lorem</span>
+ * // </div>
+ * // <div class="scope">
+ * //   <span>ipsum</span>
+ * // </div>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   scope: '.scope',
  *   spanIsVisible: PageObject.isHidden('span')
  * });
@@ -76,13 +83,13 @@ import { findElement, every } from '../helpers';
  *
  * @param {string} selector - CSS selector of the element to check
  * @param {Object} options - Additional options
- * @param {string} options.scope - Nests provided scope with parent's scope
+ * @param {string} options.scope - Nests provided scope within parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.resetScope - Override parent's scope
  * @param {boolean} options.multiple - Check if all elements matched by selector are visible
  * @return {Descriptor}
  *
- * @throws Will throw an error if multiple elements are matched by selector and multiple options is not set
+ * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function isVisible(selector, options = {}) {
   return {

--- a/test-support/page-object/predicates/not-has-class.js
+++ b/test-support/page-object/predicates/not-has-class.js
@@ -1,14 +1,14 @@
 import { findElementWithAssert, every } from '../helpers';
 
 /**
- * Validates if an element or a set of elements don't have a given CSS class
+ * Validates if an element or a set of elements don't have a given CSS class.
  *
  * @example
  *
  * // <em class="lorem"></em><span class="success">Message!</span>
  *
- * let page = PageObject.create({
- *   messageIsSuccess: PageObject.nothasClass('error', 'span')
+ * const page = PageObject.create({
+ *   messageIsSuccess: PageObject.notHasClass('error', 'span')
  * });
  *
  * assert.ok(page.messageIsSuccess);
@@ -18,19 +18,19 @@ import { findElementWithAssert, every } from '../helpers';
  * // <span class="success"></span>
  * // <span class="error"></span>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   messagesAreSuccessful: PageObject.notHasClass('error', 'span', { multiple: true })
  * });
  *
  * // one span has error class
- * assert.ok(!page.messagesAreSuccessful);
+ * assert.notOk(page.messagesAreSuccessful);
  *
  * @example
  *
  * // <span class="success"></span>
  * // <span class="success"></span>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   messagesAreSuccessful: PageObject.notHasClass('error', 'span', { multiple: true })
  * });
  *
@@ -46,11 +46,11 @@ import { findElementWithAssert, every } from '../helpers';
  * //   <span class="ipsum"></span>
  * // </div>
  *
- * let page = PageObject.create({
- *   spanHasNotClass: PageObject.notHasClass('lorem', 'span', { scope: '.scope' })
+ * const page = PageObject.create({
+ *   spanNotHasClass: PageObject.notHasClass('lorem', 'span', { scope: '.scope' })
  * });
  *
- * assert.ok(page.spanHasNotClass);
+ * assert.ok(page.spanNotHasClass);
  *
  * @example
  *
@@ -61,26 +61,26 @@ import { findElementWithAssert, every } from '../helpers';
  * //   <span class="ipsum"></span>
  * // </div>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   scope: '.scope',
- *   spanHasNotClass: PageObject.notHasClass('lorem', 'span')
+ *   spanNotHasClass: PageObject.notHasClass('lorem', 'span')
  * });
  *
- * assert.ok(page.spanHasNotClass);
+ * assert.ok(page.spanNotHasClass);
  *
  * @public
  *
  * @param {string} cssClass - CSS class to be validated
  * @param {string} selector - CSS selector of the element to check
  * @param {Object} options - Additional options
- * @param {string} options.scope - Nests provided scope with parent's scope
+ * @param {string} options.scope - Nests provided scope within parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.resetScope - Override parent's scope
  * @param {boolean} options.multiple - Check if all elements matched by selector don't have the CSS class
  * @return {Descriptor}
  *
  * @throws Will throw an error if no element matches selector
- * @throws Will throw an error if multiple elements are matched by selector and multiple options is not set
+ * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function notHasClass(cssClass, selector, options = {}) {
   return {

--- a/test-support/page-object/queries/attribute.js
+++ b/test-support/page-object/queries/attribute.js
@@ -1,28 +1,28 @@
 import { findElementWithAssert, map } from '../helpers';
 
 /**
- * Gets the value of an attribute from matched element or Array of value of
- * attributes of multiple matched elements
+ * Returns the value of an attribute from the matched element,
+ * or an array of values from multiple matched elements.
  *
  * @example
  * // <input placeholder="a value">
  *
- * var page = PageObject.create({
- *   inputPlaceHolder: PageObject.attribute('placeholder', 'input')
+ * const page = PageObject.create({
+ *   inputPlaceholder: PageObject.attribute('placeholder', 'input')
  * });
  *
- * assert.equal(page.inputPlaceHolder, 'a value');
+ * assert.equal(page.inputPlaceholder, 'a value');
  *
  * @example
  *
  * // <input placeholder="a value">
  * // <input placeholder="other value">
  *
- * let page = PageObject.create({
- *   inputPlaceHolder: PageObject.attribute('placeholder', ':input', { multiple: true })
+ * const page = PageObject.create({
+ *   inputPlaceholders: PageObject.attribute('placeholder', ':input', { multiple: true })
  * });
  *
- * assert.equal(page.inputPlaceHolder, ['a value', 'other value']);
+ * assert.deepEqual(page.inputPlaceholders, ['a value', 'other value']);
  *
  * @example
  *
@@ -30,11 +30,11 @@ import { findElementWithAssert, map } from '../helpers';
  * // <div class="scope"><input placeholder="a value"></div>
  * // <div><input></div>
  *
- * let page = PageObject.create({
- *   inputPlaceHolder: PageObject.attribute('placeholder', ':input', { scope: '.scope' })
+ * const page = PageObject.create({
+ *   inputPlaceholder: PageObject.attribute('placeholder', ':input', { scope: '.scope' })
  * });
  *
- * assert.equal(page.inputPlaceHolder, 'a value');
+ * assert.equal(page.inputPlaceholder, 'a value');
  *
  * @example
  *
@@ -42,19 +42,19 @@ import { findElementWithAssert, map } from '../helpers';
  * // <div class="scope"><input placeholder="a value"></div>
  * // <div><input></div>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   scope: 'scope',
- *   inputPlaceHolder: PageObject.attribute('placeholder', ':input')
+ *   inputPlaceholder: PageObject.attribute('placeholder', ':input')
  * });
  *
- * assert.equal(page.inputPlaceHolder, 'a value');
+ * assert.equal(page.inputPlaceholder, 'a value');
  *
  * @public
  *
  * @param {string} attributeName - Name of the attribute to get
  * @param {string} selector - CSS selector of the element to check
  * @param {Object} options - Additional options
- * @param {string} options.scope - Nests provided scope with parent's scope
+ * @param {string} options.scope - Nests provided scope within parent's scope
  * @param {boolean} options.resetScope - Override parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.multiple - If set, the function will return an array of values

--- a/test-support/page-object/queries/count.js
+++ b/test-support/page-object/queries/count.js
@@ -4,14 +4,14 @@ import { findElement } from '../helpers';
 var $ = Ember.$;
 
 /**
- * Gets the count of elements matched by selector
+ * Returns the number of elements matched by a selector.
  *
  * @example
  *
  * // <span>1</span>
  * // <span>2</span>
  *
- * var page = PageObject.create({
+ * const page = PageObject.create({
  *   spanCount: PageObject.count('span')
  * });
  *
@@ -21,7 +21,7 @@ var $ = Ember.$;
  *
  * // <div>Text</div>
  *
- * var page = PageObject.create({
+ * const page = PageObject.create({
  *   spanCount: PageObject.count('span')
  * });
  *
@@ -32,7 +32,7 @@ var $ = Ember.$;
  * // <div><span></span></div>
  * // <div class="scope"><span></span><span></span></div>
  *
- * var page = PageObject.create({
+ * const page = PageObject.create({
  *   spanCount: PageObject.count('span', { scope: '.scope' })
  * });
  *
@@ -43,7 +43,7 @@ var $ = Ember.$;
  * // <div><span></span></div>
  * // <div class="scope"><span></span><span></span></div>
  *
- * var page = PageObject.create({
+ * const page = PageObject.create({
  *   scope: '.scope',
  *   spanCount: PageObject.count('span')
  * });
@@ -55,7 +55,7 @@ var $ = Ember.$;
  * // <div><span></span></div>
  * // <div class="scope"><span></span><span></span></div>
  *
- * var page = PageObject.create({
+ * const page = PageObject.create({
  *   scope: '.scope',
  *   spanCount: PageObject.count('span', { resetScope: true })
  * });

--- a/test-support/page-object/queries/text.js
+++ b/test-support/page-object/queries/text.js
@@ -1,13 +1,13 @@
 import { findElementWithAssert, map, normalizeText } from '../helpers';
 
 /**
- * Gets text of the element or Array of texts of all matched elements by selector
+ * Returns text of the element or Array of texts of all matched elements by selector.
  *
  * @example
  *
  * // Hello <span>world!</span>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   text: PageObject.text('span')
  * });
  *
@@ -19,11 +19,11 @@ import { findElementWithAssert, map, normalizeText } from '../helpers';
  * // <span> ipsum </span>
  * // <span>dolor</span>
  *
- * var page = PageObject.create({
+ * const page = PageObject.create({
  *   texts: PageObject.text('span', { multiple: true })
  * });
  *
- * assert.equal(page.texts, ['lorem', 'ipsum', 'dolor']);
+ * assert.deepEqual(page.texts, ['lorem', 'ipsum', 'dolor']);
  *
  * @example
  *
@@ -31,7 +31,7 @@ import { findElementWithAssert, map, normalizeText } from '../helpers';
  * // <div class="scope"><span>ipsum</span></div>
  * // <div><span>dolor</span></div>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   text: PageObject.text('span', { scope: '.scope' })
  * });
  *
@@ -43,7 +43,7 @@ import { findElementWithAssert, map, normalizeText } from '../helpers';
  * // <div class="scope"><span>ipsum</span></div>
  * // <div><span>dolor</span></div>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   scope: '.scope',
  *   text: PageObject.text('span')
  * });
@@ -55,14 +55,14 @@ import { findElementWithAssert, map, normalizeText } from '../helpers';
  *
  * @param {string} selector - CSS selector of the element to check
  * @param {Object} options - Additional options
- * @param {string} options.scope - Nests provided scope with parent's scope
+ * @param {string} options.scope - Nests provided scope within parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.resetScope - Override parent's scope
  * @param {boolean} options.multiple - Return an array of values
  * @return {Descriptor}
  *
  * @throws Will throw an error if no element matches selector
- * @throws Will throw an error if multiple elements are matched by selector and multiple options is not set
+ * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function text(selector, options = {}) {
   return {

--- a/test-support/page-object/queries/value.js
+++ b/test-support/page-object/queries/value.js
@@ -1,13 +1,14 @@
 import { findElementWithAssert, map } from '../helpers';
 
 /**
- * Gets the value of matched element or get Array of values of all matched elements
+ * Returns the value of a matched element,
+ * or an array of values of all matched elements.
  *
  * @example
  *
  * // <input value="Lorem ipsum">
  *
- * var page = PageObject.create({
+ * const page = PageObject.create({
  *   value: PageObject.value('input')
  * });
  *
@@ -18,18 +19,18 @@ import { findElementWithAssert, map } from '../helpers';
  * // <input value="lorem">
  * // <input value="ipsum">
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   value: PageObject.value('input', { multiple: true })
  * });
  *
- * assert.equal(page.value, ['lorem', 'ipsum']);
+ * assert.deepEqual(page.value, ['lorem', 'ipsum']);
  *
  * @example
  *
  * // <div><input value="lorem"></div>
  * // <div class="scope"><input value="ipsum"></div>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   value: PageObject.value('input', { scope: '.scope' })
  * });
  *
@@ -40,7 +41,7 @@ import { findElementWithAssert, map } from '../helpers';
  * // <div><input value="lorem"></div>
  * // <div class="scope"><input value="ipsum"></div>
  *
- * let page = PageObject.create({
+ * const page = PageObject.create({
  *   scope: '.scope',
  *   value: PageObject.value('input')
  * });
@@ -51,7 +52,7 @@ import { findElementWithAssert, map } from '../helpers';
  *
  * @param {string} selector - CSS selector of the element to check
  * @param {Object} options - Additional options
- * @param {string} options.scope - Nests provided scope with parent's scope
+ * @param {string} options.scope - Nests provided scope within parent's scope
  * @param {boolean} options.resetScope - Override parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.multiple - If set, the function will return an array of values


### PR DESCRIPTION
Includes replacing `var` and `let` with `const` (just in the docs), per the convention in the Ember Guides.