### PR TITLE
Re-add JSDoc documentation that vanished during merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
   },
   "keywords": [
     "acceptance",
+    "integration",
+    "components",
     "ember",
     "ember-addon",
     "ember-cli",

--- a/test-support/page-object/actions/clickable.js
+++ b/test-support/page-object/actions/clickable.js
@@ -1,19 +1,54 @@
 import { findElementWithAssert, buildSelector, getContext } from '../helpers';
 
 /**
- * Creates an action to click an element
+ * Clicks elements matched by a selector.
  *
  * @example
  *
- *   var page = PageObject.create({
- *     submit: clickable('button[type=submit]')
- *   });
+ * // <button class="continue">Continue<button>
+ * // <button>Cancel</button>
  *
- *   page.submit();
+ * const page = PageObject.create({
+ *   continue: clickable('button.continue')
+ * });
+ *
+ * // clicks on element with selector 'button.continue'
+ * page.continue();
+ *
+ * @example
+ *
+ * // <div class="scope">
+ * //   <button>Continue<button>
+ * // </div>
+ * // <button>Cancel</button>
+ *
+ * const page = PageObject.create({
+ *   continue: clickable('button.continue', { scope: '.scope' })
+ * });
+ *
+ * // clicks on element with selector '.scope button.continue'
+ * page.continue();
+ *
+ * @example
+ *
+ * // <div class="scope">
+ * //   <button>Continue<button>
+ * // </div>
+ * // <button>Cancel</button>
+ *
+ * const page = PageObject.create({
+ *   scope: '.scope',
+ *   continue: clickable('button.continue')
+ * });
+ *
+ * // clicks on element with selector '.scope button.continue'
+ * page.continue();
+ *
+ * @public
  *
  * @param {string} selector - CSS selector of the element to click
  * @param {Object} options - Additional options
- * @param {string} options.scope - Overrides parent scope
+ * @param {string} options.scope - Nests provided scope within parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.resetScope - Ignore parent scope
  * @return {Descriptor}

--- a/test-support/page-object/actions/fillable.js
+++ b/test-support/page-object/actions/fillable.js
@@ -2,21 +2,67 @@ import Ember from 'ember';
 import { findElementWithAssert, buildSelector, getContext } from '../helpers';
 
 /**
- * Creates an action to fill in an input
+ * Fills in an input matched by a selector.
  *
  * @example
  *
- *   var page = PageObject.create({
- *     name: fillable('#name')
- *   });
+ * // <input value="">
  *
- *   page.name('John Doe');
+ * const page = PageObject.create({
+ *   fillIn: PageObject.fillable('input')
+ * });
  *
- * @param {string} selector - CSS selector of the element to fill
+ * // result: <input value="John Doe">
+ * page.fillIn('John Doe');
+ *
+ * @example
+ *
+ * // <div class="name">
+ * //   <input value="">
+ * // </div>
+ * // <div class="last-name">
+ * //   <input value= "">
+ * // </div>
+ *
+ * const page = PageObject.create({
+ *   fillInName: PageObject.fillable('input', { scope: '.name' })
+ * });
+ *
+ * page.fillInName('John Doe');
+ *
+ * // result
+ * // <div class="name">
+ * //   <input value="John Doe">
+ * // </div>
+ *
+ * @example
+ *
+ * // <div class="name">
+ * //   <input value="">
+ * // </div>
+ * // <div class="last-name">
+ * //   <input value= "">
+ * // </div>
+ *
+ * const page = PageObject.create({
+ *   scope: 'name',
+ *   fillInName: PageObject.fillable('input')
+ * });
+ *
+ * page.fillInName('John Doe');
+ *
+ * // result
+ * // <div class="name">
+ * //   <input value="John Doe">
+ * // </div>
+ *
+ * @public
+ *
+ * @param {string} selector - CSS selector of the element to look for text
  * @param {Object} options - Additional options
- * @param {string} options.scope - Overrides parent scope
+ * @param {string} options.scope - Nests provided scope within parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
- * @param {boolean} options.resetScope - Ignore parent scope
+ * @param {boolean} options.resetScope - Override parent's scope
  * @return {Descriptor}
  */
 export function fillable(selector, options = {}) {

--- a/test-support/page-object/predicates/contains.js
+++ b/test-support/page-object/predicates/contains.js
@@ -1,22 +1,83 @@
 import { findElementWithAssert, every } from '../helpers';
 
 /**
- * Creates a predicate to validate if an element contains a subtext
+ * Returns a boolean representing whether an element or a set of elements contains the specified text.
  *
  * @example
- *   <h1> Page Title </h1>
  *
- *   var page = PageObject.create({
- *     titleIncludes: contains('h1')
- *   });
+ * // Lorem <span>ipsum</span>
  *
- *   assert.ok(page.titleIncludes('Page'));
+ * const page = PageObject.create({
+ *   spanContains: PageObject.contains('span')
+ * });
+ *
+ * assert.ok(page.spanContains('ipsum'));
+ *
+ * @example
+ *
+ * // <span>lorem</span>
+ * // <span>ipsum</span>
+ * // <span>dolor</span>
+ *
+ * const page = PageObject.create({
+ *   spansContain: PageObject.contains('span', { multiple: true })
+ * });
+ *
+ * // not all spans contain 'lorem'
+ * assert.notOk(page.spansContain('lorem'));
+ *
+ * @example
+ *
+ * // <span>super text</span>
+ * // <span>regular text</span>
+ *
+ * const page = PageObject.create({
+ *   spansContain: PageObject.contains('span', { multiple: true })
+ * });
+ *
+ * // all spans contain 'text'
+ * assert.ok(page.spanContains('text'));
+ *
+ * @example
+ *
+ * // <div><span>lorem</span></div>
+ * // <div class="scope"><span>ipsum</span></div>
+ * // <div><span>dolor</span></div>
+ *
+ * const page = PageObject.create({
+ *   spanContains: PageObject.contains('span', { scope: '.scope' })
+ * });
+ *
+ * assert.notOk(page.spanContains('lorem'));
+ * assert.ok(page.spanContains('ipsum'));
+ *
+ * @example
+ *
+ * // <div><span>lorem</span></div>
+ * // <div class="scope"><span>ipsum</span></div>
+ * // <div><span>dolor</span></div>
+ *
+ * const page = PageObject.create({
+ *   scope: '.scope',
+
+ *   spanContains: PageObject.contains('span')
+ * });
+ *
+ * assert.notOk(page.spanContains('lorem'));
+ * assert.ok(page.spanContains('ipsum'));
+ *
+ * @public
  *
  * @param {string} selector - CSS selector of the element to check
  * @param {Object} options - Additional options
- * @param {string} options.scope - Overrides parent scope
- * @param {number} options.index - Reduce the set of matched elements to the one at the specified index
+ * @param {string} options.scope - Nests provided scope within parent's scope
+ * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
+ * @param {boolean} options.resetScope - Override parent's scope
+ * @param {boolean} options.multiple - Check if all elements matched by selector contain the subtext
  * @return {Descriptor}
+ *
+ * @throws Will throw an error if no element matches selector
+ * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function contains(selector, options = {}) {
   return {

--- a/test-support/page-object/predicates/has-class.js
+++ b/test-support/page-object/predicates/has-class.js
@@ -1,22 +1,84 @@
 import { findElementWithAssert, every } from '../helpers';
 
 /**
- * Creates a predicate to validate if an element has a given CSS class
+ * Validates if an element or a set of elements have a given CSS class.
  *
  * @example
  *
- *   var page = PageObject.create({
- *     isImageActive: hasClass('is-active', '.img')
- *   });
+ * // <em class="lorem"></em><span class="success">Message!</span>
  *
- *   assert.ok(page.isImageActive(), 'Image is active');
+ * const page = PageObject.create({
+ *   messageIsSuccess: PageObject.hasClass('success', 'span')
+ * });
  *
- * @param {string} cssClass - Name of the CSS class to look for
+ * assert.ok(page.messageIsSuccess);
+ *
+ * @example
+ *
+ * // <span class="success"></span>
+ * // <span class="error"></span>
+ *
+ * const page = PageObject.create({
+ *   messagesAreSuccessful: PageObject.hasClass('success', 'span', { multiple: true })
+ * });
+ *
+ * assert.notOk(page.messagesAreSuccessful);
+ *
+ * @example
+ *
+ * // <span class="success"></span>
+ * // <span class="success"></span>
+ *
+ * const page = PageObject.create({
+ *   messagesAreSuccessful: PageObject.hasClass('success', 'span', { multiple: true })
+ * });
+ *
+ * assert.ok(page.messagesAreSuccessful);
+ *
+ * @example
+ *
+ * // <div>
+ * //   <span class="lorem"></span>
+ * // </div>
+ * // <div class="scope">
+ * //   <span class="ipsum"></span>
+ * // </div>
+ *
+ * const page = PageObject.create({
+ *   spanHasClass: PageObject.hasClass('ipsum', 'span', { scope: '.scope' })
+ * });
+ *
+ * assert.ok(page.spanHasClass);
+ *
+ * @example
+ *
+ * // <div>
+ * //   <span class="lorem"></span>
+ * // </div>
+ * // <div class="scope">
+ * //   <span class="ipsum"></span>
+ * // </div>
+ *
+ * const page = PageObject.create({
+ *   scope: '.scope',
+ *   spanHasClass: PageObject.hasClass('ipsum', 'span')
+ * });
+ *
+ * assert.ok(page.spanHasClass);
+ *
+ * @public
+ *
+ * @param {string} cssClass - CSS class to be validated
  * @param {string} selector - CSS selector of the element to check
  * @param {Object} options - Additional options
- * @param {string} options.scope - Overrides parent scope
- * @param {number} options.index - Reduce the set of matched elements to the one at the specified index
+ * @param {string} options.scope - Nests provided scope within parent's scope
+ * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
+ * @param {boolean} options.resetScope - Override parent's scope
+ * @param {boolean} options.multiple - Check if all elements matched by selector have the CSS class
  * @return {Descriptor}
+ *
+ * @throws Will throw an error if no element matches selector
+ * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function hasClass(cssClass, selector, options = {}) {
   return {

--- a/test-support/page-object/predicates/is-hidden.js
+++ b/test-support/page-object/predicates/is-hidden.js
@@ -1,21 +1,89 @@
 import { findElement, every } from '../helpers';
 
 /**
- * Creates a predicate to validate if an element is hidden
+ * Validates if an element or set of elements are hidden.
  *
  * @example
  *
- *   var page = PageObject.create({
- *     isImageVisible: isVisible('.img')
- *   });
+ * // Lorem <span style="display:none">ipsum</span>
  *
- *   assert.ok(page.isImageVisible(), 'Image is visible');
+ * const page = PageObject.create({
+ *   spanIsHidden: PageObject.isHidden('span')
+ * });
+ *
+ * assert.ok(page.spanIsHidden);
+ *
+ * @example
+ *
+ * // <span>ipsum</span>
+ * // <span style="display:none">dolor</span>
+ *
+ * const page = create({
+ *   spansAreHidden: PageObject.isHidden('span', { multiple: true })
+ * });
+ *
+ * // not all spans are hidden
+ * assert.notOk(page.spansAreHidden);
+ *
+ * @example
+ *
+ * // <span style="display:none">dolor</span>
+ * // <span style="display:none">dolor</span>
+ *
+ * const page = create({
+ *   spansAreHidden: PageObject.isHidden('span', { multiple: true })
+ * });
+ *
+ * // all spans are hidden
+ * assert.ok(page.spansAreHidden);
+ *
+ * @example
+ *
+ * // Lorem <strong>ipsum</strong>
+ *
+ * const page = PageObject.create({
+ *   spanIsHidden: PageObject.isHidden('span')
+ * });
+ *
+ * // returns true when element doesn't exist in DOM
+ * assert.ok(page.spanIsHidden);
+ *
+ * @example
+ *
+ * // <div><span>lorem</span></div>
+ * // <div class="scope"><span style="display:none">ipsum</span></div>
+ * // <div><span>dolor</span></div>
+ *
+ * const page = PageObject.create({
+ *   scopedSpanIsHidden: PageObject.isHidden('span', { scope: '.scope' })
+ * });
+ *
+ * assert.ok(page.scopedSpanIsHidden);
+ *
+ * @example
+ *
+ * // <div><span>lorem</span></div>
+ * // <div class="scope"><span style="display:none">ipsum</span></div>
+ * // <div><span>dolor</span></div>
+ *
+ * const page = PageObject.create({
+ *   scope: '.scope',
+ *   scopedSpanIsHidden: PageObject.isHidden('span')
+ * });
+ *
+ * assert.ok(page.scopedSpanIsHidden);
+ *
+ * @public
  *
  * @param {string} selector - CSS selector of the element to check
  * @param {Object} options - Additional options
- * @param {string} options.scope - Overrides parent scope
+ * @param {string} options.scope - Nests provided scope within parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
+ * @param {boolean} options.resetScope - Override parent's scope
+ * @param {boolean} options.multiple - Check if all elements matched by selector are hidden
  * @return {Descriptor}
+ *
+ * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function isHidden(selector, options = {}) {
   return {

--- a/test-support/page-object/predicates/is-visible.js
+++ b/test-support/page-object/predicates/is-visible.js
@@ -1,21 +1,95 @@
 import { findElement, every } from '../helpers';
 
 /**
- * Creates a predicate to validate if an element is visible
+ * Validates if an element or set of elements are visible.
  *
  * @example
  *
- *   var page = PageObject.create({
- *     isImageVisible: isVisible('.img')
- *   });
+ * // Lorem <span>ipsum</span>
  *
- *   assert.ok(page.isImageVisible(), 'Image is visible');
+ * const page = PageObject.create({
+ *   spanIsVisible: PageObject.isVisible('span')
+ * });
+ *
+ * assert.ok(page.spanIsVisible);
+ *
+ * @example
+ *
+ * // <span>ipsum</span>
+ * // <span style="display:none">dolor</span>
+ *
+ * const page = PageObject.create({
+ *   spansAreVisible: PageObject.isVisible('span', { multiple: true })
+ * });
+ *
+ * // not all spans are visible
+ * assert.notOk(page.spansAreVisible);
+ *
+ * @example
+ *
+ * // <span>ipsum</span>
+ * // <span>dolor</span>
+ *
+ * const page = PageObject.create({
+ *   spansAreVisible: PageObject.isVisible('span', { multiple: true })
+ * });
+ *
+ * // all spans are visible
+ * assert.ok(page.spansAreVisible);
+ *
+ * @example
+ *
+ * // Lorem <strong>ipsum</strong>
+ *
+ * const page = PageObject.create({
+ *   spanIsVisible: PageObject.isHidden('span')
+ * });
+ *
+ * // returns false when element doesn't exist in DOM
+ * assert.notOk(page.spanIsVisible);
+ *
+ * @example
+ *
+ * // <div>
+ * //   <span style="display:none">lorem</span>
+ * // </div>
+ * // <div class="scope">
+ * //   <span>ipsum</span>
+ * // </div>
+ *
+ * const page = PageObject.create({
+ *   spanIsVisible: PageObject.isHidden('span', { scope: '.scope' })
+ * });
+ *
+ * assert.ok(page.spanIsVisible);
+ *
+ * @example
+ *
+ * // <div>
+ * //   <span style="display:none">lorem</span>
+ * // </div>
+ * // <div class="scope">
+ * //   <span>ipsum</span>
+ * // </div>
+ *
+ * const page = PageObject.create({
+ *   scope: '.scope',
+ *   spanIsVisible: PageObject.isHidden('span')
+ * });
+ *
+ * assert.ok(page.spanIsVisible);
+ *
+ * @public
  *
  * @param {string} selector - CSS selector of the element to check
  * @param {Object} options - Additional options
- * @param {string} options.scope - Overrides parent scope
+ * @param {string} options.scope - Nests provided scope within parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
+ * @param {boolean} options.resetScope - Override parent's scope
+ * @param {boolean} options.multiple - Check if all elements matched by selector are visible
  * @return {Descriptor}
+ *
+ * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function isVisible(selector, options = {}) {
   return {

--- a/test-support/page-object/predicates/not-has-class.js
+++ b/test-support/page-object/predicates/not-has-class.js
@@ -1,22 +1,86 @@
 import { findElementWithAssert, every } from '../helpers';
 
 /**
- * Creates a predicate to validate if an element doesn't have a given CSS class
+ * Validates if an element or a set of elements don't have a given CSS class.
  *
  * @example
  *
- *   var page = PageObject.create({
- *     isImageDeactivated: notHasClass('is-active', '.img')
- *   });
+ * // <em class="lorem"></em><span class="success">Message!</span>
  *
- *   assert.ok(page.isImageDeactivated(), 'Image is not active');
+ * const page = PageObject.create({
+ *   messageIsSuccess: PageObject.notHasClass('error', 'span')
+ * });
  *
- * @param {string} cssClass - Name of the CSS class to look for
+ * assert.ok(page.messageIsSuccess);
+ *
+ * @example
+ *
+ * // <span class="success"></span>
+ * // <span class="error"></span>
+ *
+ * const page = PageObject.create({
+ *   messagesAreSuccessful: PageObject.notHasClass('error', 'span', { multiple: true })
+ * });
+ *
+ * // one span has error class
+ * assert.notOk(page.messagesAreSuccessful);
+ *
+ * @example
+ *
+ * // <span class="success"></span>
+ * // <span class="success"></span>
+ *
+ * const page = PageObject.create({
+ *   messagesAreSuccessful: PageObject.notHasClass('error', 'span', { multiple: true })
+ * });
+ *
+ * // no spans have error class
+ * assert.ok(page.messagesAreSuccessful);
+ *
+ * @example
+ *
+ * // <div>
+ * //   <span class="lorem"></span>
+ * // </div>
+ * // <div class="scope">
+ * //   <span class="ipsum"></span>
+ * // </div>
+ *
+ * const page = PageObject.create({
+ *   spanNotHasClass: PageObject.notHasClass('lorem', 'span', { scope: '.scope' })
+ * });
+ *
+ * assert.ok(page.spanNotHasClass);
+ *
+ * @example
+ *
+ * // <div>
+ * //   <span class="lorem"></span>
+ * // </div>
+ * // <div class="scope">
+ * //   <span class="ipsum"></span>
+ * // </div>
+ *
+ * const page = PageObject.create({
+ *   scope: '.scope',
+ *   spanNotHasClass: PageObject.notHasClass('lorem', 'span')
+ * });
+ *
+ * assert.ok(page.spanNotHasClass);
+ *
+ * @public
+ *
+ * @param {string} cssClass - CSS class to be validated
  * @param {string} selector - CSS selector of the element to check
  * @param {Object} options - Additional options
- * @param {string} options.scope - Overrides parent scope
- * @param {number} options.index - Reduce the set of matched elements to the one at the specified index
+ * @param {string} options.scope - Nests provided scope within parent's scope
+ * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
+ * @param {boolean} options.resetScope - Override parent's scope
+ * @param {boolean} options.multiple - Check if all elements matched by selector don't have the CSS class
  * @return {Descriptor}
+ *
+ * @throws Will throw an error if no element matches selector
+ * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function notHasClass(cssClass, selector, options = {}) {
   return {

--- a/test-support/page-object/queries/attribute.js
+++ b/test-support/page-object/queries/attribute.js
@@ -1,23 +1,67 @@
 import { findElementWithAssert, map } from '../helpers';
 
 /**
- * Gets the value of an attribute from an element
+ * Returns the value of an attribute from the matched element,
+ * or an array of values from multiple matched elements.
+ *
+ * @example
+ * // <input placeholder="a value">
+ *
+ * const page = PageObject.create({
+ *   inputPlaceholder: PageObject.attribute('placeholder', 'input')
+ * });
+ *
+ * assert.equal(page.inputPlaceholder, 'a value');
  *
  * @example
  *
- *   var page = PageObject.create({
- *     imageAlternateText: attribute('alt', '.img')
- *   });
+ * // <input placeholder="a value">
+ * // <input placeholder="other value">
  *
- *   assert.equal(page.imageAlternateText, 'Logo');
+ * const page = PageObject.create({
+ *   inputPlaceholders: PageObject.attribute('placeholder', ':input', { multiple: true })
+ * });
+ *
+ * assert.deepEqual(page.inputPlaceholders, ['a value', 'other value']);
+ *
+ * @example
+ *
+ * // <div><input></div>
+ * // <div class="scope"><input placeholder="a value"></div>
+ * // <div><input></div>
+ *
+ * const page = PageObject.create({
+ *   inputPlaceholder: PageObject.attribute('placeholder', ':input', { scope: '.scope' })
+ * });
+ *
+ * assert.equal(page.inputPlaceholder, 'a value');
+ *
+ * @example
+ *
+ * // <div><input></div>
+ * // <div class="scope"><input placeholder="a value"></div>
+ * // <div><input></div>
+ *
+ * const page = PageObject.create({
+ *   scope: 'scope',
+ *   inputPlaceholder: PageObject.attribute('placeholder', ':input')
+ * });
+ *
+ * assert.equal(page.inputPlaceholder, 'a value');
+ *
+ * @public
  *
  * @param {string} attributeName - Name of the attribute to get
  * @param {string} selector - CSS selector of the element to check
  * @param {Object} options - Additional options
- * @param {string} options.scope - Overrides parent scope
+ * @param {string} options.scope - Nests provided scope within parent's scope
+ * @param {boolean} options.resetScope - Override parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
- * @param {boolean} options.multiple - Return an array of values
+ * @param {boolean} options.multiple - If set, the function will return an array of values
  * @return {Descriptor}
+ *
+ * @throws Will throw an error if no element matches selector
+ * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function attribute(attributeName, selector, options = {}) {
   return {

--- a/test-support/page-object/queries/count.js
+++ b/test-support/page-object/queries/count.js
@@ -4,17 +4,67 @@ import { findElement } from '../helpers';
 var $ = Ember.$;
 
 /**
- * Gets the count of matched elements
+ * Returns the number of elements matched by a selector.
  *
  * @example
  *
- *   var page = PageObject.create({
- *     imageCount: count('.img')
- *   });
+ * // <span>1</span>
+ * // <span>2</span>
  *
- *   assert.equal(page.imageCount(), 2);
+ * const page = PageObject.create({
+ *   spanCount: PageObject.count('span')
+ * });
  *
- * @param {string} selector - CSS selector of the element to check
+ * assert.equal(page.spanCount, 2);
+ *
+ * @example
+ *
+ * // <div>Text</div>
+ *
+ * const page = PageObject.create({
+ *   spanCount: PageObject.count('span')
+ * });
+ *
+ * assert.equal(page.spanCount, 0);
+ *
+ * @example
+ *
+ * // <div><span></span></div>
+ * // <div class="scope"><span></span><span></span></div>
+ *
+ * const page = PageObject.create({
+ *   spanCount: PageObject.count('span', { scope: '.scope' })
+ * });
+ *
+ * assert.equal(page.spanCount, 2)
+ *
+ * @example
+ *
+ * // <div><span></span></div>
+ * // <div class="scope"><span></span><span></span></div>
+ *
+ * const page = PageObject.create({
+ *   scope: '.scope',
+ *   spanCount: PageObject.count('span')
+ * });
+ *
+ * assert.equal(page.spanCount, 2)
+ *
+ * @example
+ *
+ * // <div><span></span></div>
+ * // <div class="scope"><span></span><span></span></div>
+ *
+ * const page = PageObject.create({
+ *   scope: '.scope',
+ *   spanCount: PageObject.count('span', { resetScope: true })
+ * });
+ *
+ * assert.equal(page.spanCount, 1);
+ *
+ * @public
+ *
+ * @param {string} selector - CSS selector of the element or elements to check
  * @param {Object} options - Additional options
  * @param {string} options.scope - Add scope
  * @param {boolean} options.resetScope - Ignore parent scope

--- a/test-support/page-object/queries/text.js
+++ b/test-support/page-object/queries/text.js
@@ -1,29 +1,68 @@
 import { findElementWithAssert, map, normalizeText } from '../helpers';
 
 /**
- * Gets the text of the matched element
+ * Returns text of the element or Array of texts of all matched elements by selector.
  *
  * @example
  *
- *   var page = PageObject.create({
- *     title: text('h1')
- *   });
+ * // Hello <span>world!</span>
  *
- *   assert.equal(page.title, 'Page title');
+ * const page = PageObject.create({
+ *   text: PageObject.text('span')
+ * });
  *
- *   var page = PageObject.create({
- *     options: text('li', { multiple: true })
- *   });
+ * assert.equal(page.text, 'world!');
  *
- *   assert.deepEqual(page.options, ['lorem', 'ipsum'])
+ * @example
+ *
+ * // <span>lorem</span>
+ * // <span> ipsum </span>
+ * // <span>dolor</span>
+ *
+ * const page = PageObject.create({
+ *   texts: PageObject.text('span', { multiple: true })
+ * });
+ *
+ * assert.deepEqual(page.texts, ['lorem', 'ipsum', 'dolor']);
+ *
+ * @example
+ *
+ * // <div><span>lorem</span></div>
+ * // <div class="scope"><span>ipsum</span></div>
+ * // <div><span>dolor</span></div>
+ *
+ * const page = PageObject.create({
+ *   text: PageObject.text('span', { scope: '.scope' })
+ * });
+ *
+ * assert.equal(page.text, 'ipsum');
+ *
+ * @example
+ *
+ * // <div><span>lorem</span></div>
+ * // <div class="scope"><span>ipsum</span></div>
+ * // <div><span>dolor</span></div>
+ *
+ * const page = PageObject.create({
+ *   scope: '.scope',
+ *   text: PageObject.text('span')
+ * });
+ *
+ * // returns 'ipsum'
+ * assert.equal(page.text, 'ipsum');
+ *
+ * @public
  *
  * @param {string} selector - CSS selector of the element to check
  * @param {Object} options - Additional options
- * @param {string} options.scope - Overrides parent scope
+ * @param {string} options.scope - Nests provided scope within parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
- * @param {boolean} options.resetScope - Ignore parent scope
+ * @param {boolean} options.resetScope - Override parent's scope
  * @param {boolean} options.multiple - Return an array of values
  * @return {Descriptor}
+ *
+ * @throws Will throw an error if no element matches selector
+ * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function text(selector, options = {}) {
   return {

--- a/test-support/page-object/queries/value.js
+++ b/test-support/page-object/queries/value.js
@@ -1,22 +1,64 @@
 import { findElementWithAssert, map } from '../helpers';
 
 /**
- * Gets the value of the matched element
+ * Returns the value of a matched element, or an array of values of all matched elements.
  *
  * @example
  *
- *   var page = PageObject.create({
- *     search: value('input')
- *   });
+ * // <input value="Lorem ipsum">
  *
- *   assert.equal(page.search, 'search term');
+ * const page = PageObject.create({
+ *   value: PageObject.value('input')
+ * });
+ *
+ * assert.equal(page.value, 'Lorem ipsum');
+ *
+ * @example
+ *
+ * // <input value="lorem">
+ * // <input value="ipsum">
+ *
+ * const page = PageObject.create({
+ *   value: PageObject.value('input', { multiple: true })
+ * });
+ *
+ * assert.deepEqual(page.value, ['lorem', 'ipsum']);
+ *
+ * @example
+ *
+ * // <div><input value="lorem"></div>
+ * // <div class="scope"><input value="ipsum"></div>
+ *
+ * const page = PageObject.create({
+ *   value: PageObject.value('input', { scope: '.scope' })
+ * });
+ *
+ * assert.equal(page.value, 'ipsum');
+ *
+ * @example
+ *
+ * // <div><input value="lorem"></div>
+ * // <div class="scope"><input value="ipsum"></div>
+ *
+ * const page = PageObject.create({
+ *   scope: '.scope',
+ *   value: PageObject.value('input')
+ * });
+ *
+ * assert.equal(page.value, 'ipsum');
+ *
+ * @public
  *
  * @param {string} selector - CSS selector of the element to check
  * @param {Object} options - Additional options
- * @param {string} options.scope - Overrides parent scope
+ * @param {string} options.scope - Nests provided scope within parent's scope
+ * @param {boolean} options.resetScope - Override parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
- * @param {boolean} options.resetScope - Ignore parent scope
+ * @param {boolean} options.multiple - If set, the function will return an array of values
  * @return {Descriptor}
+ *
+ * @throws Will throw an error if no element matches selector
+ * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function value(selector, options = {}) {
   return {


### PR DESCRIPTION
While merging #99, most of the new inline JSDoc disappeared. This PR re-adds it.