### PR TITLE
Update link to selenium page objects information

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ An excerpt from the Selenium Wiki
 The pattern was first introduced by the Selenium
 
 You can find more information about this design pattern here:
-* [Page Objects - Selenium wiki](https://code.google.com/p/selenium/wiki/PageObjects)
+* [Page Objects - Selenium wiki](https://seleniumhq.github.io/docs/best.html#page_object_models)
 * [PageObject - Martin Fowler](http://martinfowler.com/bliki/PageObject.html)
 
 ## Community


### PR DESCRIPTION
This is just an update to the link to Selenium Page Object information. The current link is outdated and redirects to https://github.com/seleniumhq/selenium-google-code-issue-archive