### PR TITLE
Make collections easier to enumerate

### DIFF
--- a/tests/helpers/with-iterator-symbol-defined.js
+++ b/tests/helpers/with-iterator-symbol-defined.js
@@ -1,0 +1,14 @@
+// Executes the given callback ensuring Symbol.iterator has a value,
+// faking it in pre-ES6 environments.
+export default function withIteratorSymbolDefined(callback) {
+  if ('Symbol' in window) {
+    return callback();
+  }
+
+  window.Symbol = { iterator: '@@iterator' };
+  try {
+    return callback();
+  } finally {
+    delete window.Symbol;
+  }
+}


### PR DESCRIPTION
This PR implements the changes discussed in https://github.com/san650/ember-cli-page-object/issues/54. @san650 it also includes the delegation of array methods we talked about, since it was easy to add them while I was in there. If you'd prefer to have that addressed in a separate PR, I'm happy to pull them out.

With this change, the following properties are now added to collection objects on creation if they haven't already been defined:
- a `toArray()` method that returns an array containing the elements of the collection
- a `[Symbol.iterator]()` method which yields each item in the collection sequentially (only if `Symbol.iterator` is present in the current environment)
- `map`, `mapBy`, `filter`, and `filterBy` methods, all of which just delegate to the methods of the same name on the result of `toArray()`.
