### PR TITLE
Add .is property

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -11,9 +11,10 @@ import { isVisible }   from './predicates/is-visible';    export { isVisible };
 import { notHasClass } from './predicates/not-has-class'; export { notHasClass };
 import { attribute }   from './queries/attribute';        export { attribute };
 import { count }       from './queries/count';            export { count };
+import { is }          from './queries/is';               export { is };
+import { property }    from './queries/property';         export { property };
 import { text }        from './queries/text';             export { text };
 import { value }       from './queries/value';            export { value };
-import { proeprty }    from './queries/property';         export { property };
 
 export { buildSelector, findElementWithAssert, findElement } from './helpers';
 
@@ -27,6 +28,7 @@ export default {
   create,
   fillable,
   hasClass,
+  is,
   isHidden,
   isVisible,
   notHasClass,

--- a/addon/queries/is.js
+++ b/addon/queries/is.js
@@ -1,0 +1,56 @@
+import { findElementWithAssert, every } from '../helpers';
+
+/**
+ * Validates if an element (or elements) matches a given selector.
+ *
+ * Useful for checking if an element (or elements) matches a selector like
+ * `:disabled` or `:checked`, which can be the result of either an attribute
+ * (`disabled="disabled"`, `disabled=true`) or a property (`disabled`).
+ *
+ * @example
+ * // <input type="checkbox" checked="checked">
+ * // <input type="checkbox" checked>
+ *
+ * const page = PageObject.create({
+ *   areInputsChecked: is(':checked', 'input', { multiple: true })
+ * });
+ *
+ * assert.equal(page.areInputsChecked, true, 'Inputs are checked');
+ *
+ * @example
+ * // <button class="toggle-button active" disabled>Toggle something</button>
+ *
+ * const page = PageObject.create({
+ *   isToggleButtonActive: is('.active:disabled', '.toggle-button')
+ * });
+ *
+ * assert.equal(page.isToggleButtonActive, true, 'Button is active');
+ *
+ * @param {string} testSelector - CSS selector to test
+ * @param {string} targetSelector - CSS selector of the element to check
+ * @param {Object} options - Additional options
+ * @param {string} options.scope - Nests provided scope within parent's scope
+ * @param {boolean} options.resetScope - Override parent's scope
+ * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
+ * @param {boolean} options.multiple - If set, the function will return an array of values
+ * @param {String} options.testContainer - Context where to search elements in the DOM
+ * @return {Descriptor}
+ *
+ * @throws Will throw an error if no element matches selector
+ * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
+ */
+export function is(testSelector, targetSelector, options = {}) {
+  return {
+    isDescriptor: true,
+
+    get(key) {
+      const elements = findElementWithAssert(this, targetSelector, { ...options, pageObjectKey: key });
+
+      const result = every(elements, function(element) {
+        return element.is(testSelector);
+      });
+
+      return result;
+    }
+  };
+}

--- a/test-support/page-object.js
+++ b/test-support/page-object.js
@@ -15,6 +15,7 @@ import { notHasClass } from 'ember-cli-page-object/predicates/not-has-class';
 
 import { attribute } from 'ember-cli-page-object/queries/attribute';
 import { count } from 'ember-cli-page-object/queries/count';
+import { is } from 'ember-cli-page-object/queries/is';
 import { text } from 'ember-cli-page-object/queries/text';
 import { value } from 'ember-cli-page-object/queries/value';
 
@@ -35,6 +36,7 @@ export { notHasClass } from 'ember-cli-page-object/predicates/not-has-class';
 
 export { attribute } from 'ember-cli-page-object/queries/attribute';
 export { count } from 'ember-cli-page-object/queries/count';
+export { is } from 'ember-cli-page-object/queries/is';
 export { text } from 'ember-cli-page-object/queries/text';
 export { value } from 'ember-cli-page-object/queries/value';
 export { property } from 'ember-cli-page-object/queries/property';
@@ -51,6 +53,7 @@ export default {
   create,
   fillable,
   hasClass,
+  is,
   isHidden,
   isVisible,
   notHasClass,

--- a/tests/unit/queries/is-test.js
+++ b/tests/unit/queries/is-test.js
@@ -1,0 +1,126 @@
+import { test } from 'qunit';
+import { fixture, moduleFor } from '../test-helper';
+import { create, is } from '../../page-object';
+import { test_throws_if_not_multiple } from '../shared';
+
+moduleFor('Unit | Property | .is');
+
+test('returns is value', function(assert) {
+  fixture('<input type="checkbox" checked>');
+
+  let page = create({
+    foo: is(':checked', ':input')
+  });
+
+  assert.equal(page.foo, true);
+});
+
+test("raises an error when the element doesn't exist", function(assert) {
+  let page = create({
+    foo: {
+      checked: is(':checked', ':input')
+    }
+  });
+
+  assert.throws(() => page.foo.checked, /page\.foo\.checked/);
+});
+
+test('looks for elements inside the scope', function(assert) {
+  fixture(`
+    <div><input></div>
+    <div class="scope"><input type="checkbox" checked></div>
+    <div><input></div>
+  `);
+
+  let page = create({
+    foo: is(':checked', ':input', { scope: '.scope' })
+  });
+
+  assert.equal(page.foo, true);
+});
+
+test("looks for elements inside page's scope", function(assert) {
+  fixture(`
+    <div><input></div>
+    <div class="scope"><input type="checkbox" checked></div>
+    <div><input></div>
+  `);
+
+  let page = create({
+    scope: '.scope',
+
+    foo: is(':checked', ':input')
+  });
+
+  assert.equal(page.foo, true);
+});
+
+test('resets scope', function(assert) {
+  fixture(`
+    <div class="scope"></div>
+    <div><input type="checkbox" checked></div>
+  `);
+
+  let page = create({
+    scope: '.scope',
+
+    foo: is(':checked', ':input', { resetScope: true })
+  });
+
+  assert.ok(page.foo);
+});
+
+test_throws_if_not_multiple(function() {
+  fixture(`
+    <input type="checkbox" checked>
+    <input type="checkbox" checked>
+  `);
+
+  let page = create({
+    foo: is(':checked', ':input')
+  });
+
+  return page.foo;
+});
+
+test('matches multiple elements', function(assert) {
+  fixture(`
+    <input class="foo" type="checkbox" checked>
+    <input class="foo" type="checkbox" checked="checked">
+    <input class="foo" type="checkbox" checked=true>
+    <input class="bar" type="checkbox" checked>
+    <input class="bar" type="checkbox">
+  `);
+
+  let page = create({
+    foo: is(':checked', 'input.foo', { multiple: true }),
+    bar: is(':checked', 'input.bar', { multiple: true })
+  });
+
+  assert.equal(page.foo, true);
+  assert.equal(page.bar, false);
+});
+
+test('finds element by index', function(assert) {
+  fixture(`
+    <input>
+    <input type="checkbox" checked>
+  `);
+
+  let page = create({
+    foo: is(':checked', ':input', { at: 1 })
+  });
+
+  assert.ok(page.foo);
+});
+
+
+test('looks for elements outside the testing container', function(assert) {
+  fixture('<h1 class="foo">lorem ipsum</h1>', { useAlternateContainer: true  });
+
+  var page = create({
+    foo: is('.foo', 'h1', { testContainer: '#alternate-ember-testing'  })
+  });
+
+  assert.equal(page.foo, true);
+});


### PR DESCRIPTION
Closes #147.

Adds the query `PageObject.is()`, which validates if an element (or elements) matches a given selector.

Useful for checking if an element (or elements) matches a selector like `:disabled` or `:checked`, which can be the result of either an attribute (`disabled="disabled"`, `disabled=true`) or a property (`disabled`).

(Uses jQuery's [`.is()`](http://api.jquery.com/is/).)

Examples:

```js
// <input type="checkbox" checked="checked">
// <input type="checkbox" checked>

const page = PageObject.create({
  areInputsChecked: is(':checked', 'input', { multiple: true })
});

assert.equal(page.areInputsChecked, true, 'Inputs are checked');
``` 
```js
// <button class="toggle-button active" disabled>Toggle something</button>

const page = PageObject.create({
  isToggleButtonActive: is('.active:disabled', '.toggle-button')
});

assert.equal(page.isToggleButtonActive, true, 'Button is active');
```