### PR TITLE
Add focus property

### DIFF
--- a/addon/actions/focusable.js
+++ b/addon/actions/focusable.js
@@ -1,0 +1,94 @@
+import Ember from 'ember';
+import { simpleFindElementWithAssert, buildSelector, getContext } from '../helpers';
+
+function focusableInternal(tree, selector, options, context) {
+  var fullSelector = buildSelector(tree, selector, options);
+
+  // Run this to validate if the element exists
+  simpleFindElementWithAssert(tree, fullSelector, options)
+
+  if (context) {
+    if (options.testContainer) {
+      Ember.$(fullSelector, options.testContainer).focus();
+    } else {
+      context.$(fullSelector).focus();
+    }
+  } else {
+    /* global triggerEvent */
+    triggerEvent(fullSelector, options.testContainer, "focus");
+  }
+}
+
+/**
+ *
+ * Focus on element matched by selector.
+ *
+ * @example
+ *
+ * // <input class="name">
+ * // <input class="email">
+ *
+ * const page = PageObject.create({
+ *   focusOnName: focusable('.name')
+ * });
+ *
+ * // focuses on element with selector '.name'
+ * page.focusOnName();
+ *
+ * @example
+ *
+ * // <div class="scope">
+ * //   <input class="name">
+ * // </div>
+ * // <input class="email">
+ *
+ * const page = PageObject.create({
+ *   focusOnName: focusable('.name', { scope: '.scope' })
+ * });
+ *
+ * // focuses on element with selector '.scope .name'
+ * page.focusOnName();
+ *
+ * @example
+ *
+ * // <div class="scope">
+ * //   <input class="name">
+ * // </div>
+ * // <input class="email">
+ *
+ * const page = PageObject.create({
+ *   scope: '.scope',
+ *   continue: focusable('.name')
+ * });
+ *
+ * // clicks on element with selector '.scope button.continue'
+ * page.focusOnName();
+ *
+ * @public
+ *
+ * @param {string} selector - CSS selector of the element to focus on
+ * @param {Object} options - Additional options
+ * @param {string} options.scope - Nests provided scope within parent's scope
+ * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
+ * @param {boolean} options.resetScope - Ignore parent scope
+ * @return {Descriptor}
+*/
+export function focusable(selector, options = {}) {
+  return {
+    isDescriptor: true,
+
+    get(key) {
+      return function() {
+        const context = getContext(this);
+
+        if (context) {
+          run(() => focusableInternal(this, selector, { ...options, pageObjectKey: `${key}()` }, context));
+        } else {
+          wait().then(() => focusableInternal(this, selector, { ...options, pageObjectKey: `${key}()` }));
+        }
+
+        return this;
+      };
+    }
+  };
+}

--- a/addon/create.js
+++ b/addon/create.js
@@ -6,6 +6,7 @@ import { isHidden } from './predicates/is-hidden';
 import { contains } from './predicates/contains';
 import { clickOnText } from './actions/click-on-text';
 import { clickable } from './actions/clickable';
+import { focusable } from './actions/focusable';
 import { render, setContext, removeContext } from './context';
 
 const merge = Ember.assign || Ember.merge;
@@ -24,6 +25,7 @@ var defaultProperties = {
   clickOn: clickOnText,
   click: clickable,
   contains: contains,
+  focus: focusable,
   text: text,
   then: thenDescriptor
 };

--- a/test-support/page-object.js
+++ b/test-support/page-object.js
@@ -5,6 +5,7 @@ import { collection } from 'ember-cli-page-object/collection';
 import { clickable } from 'ember-cli-page-object/actions/clickable';
 import { clickOnText } from 'ember-cli-page-object/actions/click-on-text';
 import { fillable, fillable as selectable } from 'ember-cli-page-object/actions/fillable';
+import { focusable } from 'ember-cli-page-object/actions/focusable';
 import { visitable } from 'ember-cli-page-object/actions/visitable';
 
 import { contains } from 'ember-cli-page-object/predicates/contains';
@@ -25,6 +26,7 @@ export { collection } from 'ember-cli-page-object/collection';
 export { clickable } from 'ember-cli-page-object/actions/clickable';
 export { clickOnText } from 'ember-cli-page-object/actions/click-on-text';
 export { fillable, fillable as selectable } from 'ember-cli-page-object/actions/fillable';
+export { focusable } from 'ember-cli-page-object/actions/focusable';
 export { visitable } from 'ember-cli-page-object/actions/visitable';
 
 export { contains } from 'ember-cli-page-object/predicates/contains';

--- a/tests/acceptance/default-properties-test.js
+++ b/tests/acceptance/default-properties-test.js
@@ -5,7 +5,8 @@
  moduleForAcceptance('Acceptance | default properties');
 
  var {
-   visitable
+   visitable,
+   hasClass
  } = PageObject;
 
  test('Adds default properties', function(assert) {
@@ -20,7 +21,9 @@
        scope: '.screen',
 
        expression: {
-         scope: 'input'
+         scope: 'input',
+
+         isFocused: hasClass('focused')
        },
 
        result: {
@@ -30,7 +33,14 @@
    });
 
    page
-     .visit()
+    .visit()
+    .screen.expression.focus();
+
+  andThen(function() {
+    assert.ok(page.screen.expression.isFocused);
+  });
+
+   page
      .clickOn('9')
      .one
      .click();

--- a/tests/dummy/app/controllers/calculator.js
+++ b/tests/dummy/app/controllers/calculator.js
@@ -7,6 +7,7 @@ export default Ember.Controller.extend({
     this.setProperties({
       result: '',
       expression: '',
+      expressionIsFocused: false,
       op: ''
     });
   },
@@ -45,6 +46,10 @@ export default Ember.Controller.extend({
           this.set('expression', result.toString());
           break;
       }
+    },
+
+    expressionFocused() {
+      this.set("expressionIsFocused", true);
     }
   }
 });

--- a/tests/dummy/app/templates/calculator.hbs
+++ b/tests/dummy/app/templates/calculator.hbs
@@ -1,6 +1,6 @@
 <div class="calculator">
   <div class="screen">
-    {{input value=expression}}
+    {{input value=expression focus-in="expressionFocused" class=(if expressionIsFocused 'focused' '') }}
     <div class="result">
       {{result}}
     </div>

--- a/tests/unit/actions/focusable-test.js
+++ b/tests/unit/actions/focusable-test.js
@@ -1,0 +1,149 @@
+import { test } from 'qunit';
+import { moduleFor, fixture } from '../test-helper';
+import { create, focusable } from '../../page-object';
+
+moduleFor('Unit | Propery | .focusable');
+
+test('calls Ember\'s triggerEvent helper with proper args', function(assert) {
+  fixture('<span></span>');
+  assert.expect(2);
+
+  let expectedSelector = 'span',
+      page;
+
+  window.triggerEvent = function(actualSelector, _, event) {
+    assert.equal(actualSelector, expectedSelector);
+    assert.equal(event, "focus");
+  };
+
+  page = create({
+    foo: focusable(expectedSelector)
+  });
+
+  page.foo();
+});
+
+test('looks for elements inside the scope', function(assert) {
+  fixture('<div class="scope"><span></span></div>');
+  assert.expect(1);
+
+  let page;
+
+  window.triggerEvent = function(actualSelector) {
+    assert.equal(actualSelector, '.scope span');
+  };
+
+  page = create({
+    foo: focusable('span', { scope: '.scope' })
+  });
+
+  page.foo();
+});
+
+test('looks for elements inside page\'s scope', function(assert) {
+  fixture('<div class="scope"><span></span></div>');
+  assert.expect(1);
+
+  let page;
+
+  window.triggerEvent = function(actualSelector) {
+    assert.equal(actualSelector, '.scope span');
+  };
+
+  page = create({
+    scope: '.scope',
+
+    foo: focusable('span')
+  });
+
+  page.foo();
+});
+
+test('resets scope', function(assert) {
+  fixture('<span></span>');
+  assert.expect(1);
+
+  let page;
+
+  window.triggerEvent = function(actualSelector) {
+    assert.equal(actualSelector, 'span');
+  };
+
+  page = create({
+    scope: '.scope',
+    foo: focusable('span', { resetScope: true })
+  });
+
+  page.foo();
+});
+
+test('returns target object', function(assert) {
+  fixture('<span></span>');
+  assert.expect(1);
+
+  let page;
+
+  window.triggerEvent = function() {};
+
+  page = create({
+    foo: focusable('span')
+  });
+
+  assert.equal(page.foo(), page);
+});
+
+test('finds element by index', function(assert) {
+  fixture('<span></span><span></span><span></span><span></span>');
+  assert.expect(1);
+
+  let expectedSelector = 'span:eq(3)',
+      page;
+
+  window.triggerEvent = function(actualSelector) {
+    assert.equal(actualSelector, expectedSelector);
+  };
+
+  page = create({
+    foo: focusable('span', { at: 3 })
+  });
+
+  page.foo();
+});
+
+test('looks for elements outside the testing container', function(assert) {
+  fixture('<span></span>', { useAlternateContainer: true });
+  assert.expect(1);
+
+  let expectedContext = '#alternate-ember-testing',
+      page;
+
+  window.triggerEvent = function(_, actualContext) {
+    assert.equal(actualContext, expectedContext);
+  };
+
+  page = create({
+    foo: focusable('span', { testContainer: expectedContext })
+  });
+
+  page.foo();
+});
+
+test("raises an error when the element doesn't exist", function(assert) {
+  assert.expect(1);
+
+  var done = assert.async();
+
+  let page = create({
+    foo: {
+      bar: {
+        baz: {
+          qux: focusable('button')
+        }
+      }
+    }
+  });
+
+  page.foo.bar.baz.qux().then().catch(error => {
+    assert.ok(/page\.foo\.bar\.baz\.qux/.test(error.toString()), 'Element not found');
+  }).finally(done);
+});


### PR DESCRIPTION
This pull request adds the `focus` property and it also includes it by default on every component.

```js
const page = PageObject.create({
  scope: '#page',
  name: {
    scope: 'input'
  }
};

page.name.focus(); // focuses on "#page input"
```