### PR TITLE
Add triggerEvent property

### DIFF
--- a/addon/actions/triggerable.js
+++ b/addon/actions/triggerable.js
@@ -1,0 +1,96 @@
+import Ember from 'ember';
+import { simpleFindElementWithAssert, buildSelector, getContext } from '../helpers';
+
+function triggerableInternal(tree, event, selector, options, context) {
+  var fullSelector = buildSelector(tree, selector, options);
+
+  // Run this to validate if the element exists
+  simpleFindElementWithAssert(tree, fullSelector, options)
+
+  if (context) {
+    if (options.testContainer) {
+      Ember.$(fullSelector, options.testContainer).trigger(event);
+    } else {
+      context.$(fullSelector).trigger(event);
+    }
+  } else {
+    /* global triggerEvent */
+    triggerEvent(fullSelector, options.testContainer, event);
+  }
+}
+
+/**
+ *
+ * Triggers event on element matched by selector.
+ *
+ * @example
+ *
+ * // <input class="name">
+ * // <input class="email">
+ *
+ * const page = PageObject.create({
+ *   focus: triggerable('focus', '.name')
+ * });
+ *
+ * // focuses on element with selector '.name'
+ * page.focus();
+ *
+ * @example
+ *
+ * // <div class="scope">
+ * //   <input class="name">
+ * // </div>
+ * // <input class="email">
+ *
+ * const page = PageObject.create({
+ *   focus: triggerable('focus', '.name', { scope: '.scope' })
+ * });
+ *
+ * // focuses on element with selector '.scope .name'
+ * page.focus();
+ *
+ * @example
+ *
+ * // <div class="scope">
+ * //   <input class="name">
+ * // </div>
+ * // <input class="email">
+ *
+ * const page = PageObject.create({
+ *   scope: '.scope',
+ *   focus: triggerable('focus', '.name')
+ * });
+ *
+ * // clicks on element with selector '.scope button.continue'
+ * page.focus();
+ *
+ * @public
+ *
+ * @param {string} event - Event to be triggered
+ * @param {string} selector - CSS selector of the element on which the event will be triggered
+ * @param {Object} options - Additional options
+ * @param {string} options.scope - Nests provided scope within parent's scope
+ * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
+ * @param {boolean} options.resetScope - Ignore parent scope
+ * @param {String} options.testContainer - Context where to search elements in the DOM
+ * @return {Descriptor}
+*/
+export function triggerable(event, selector, options = {}) {
+  return {
+    isDescriptor: true,
+
+    get(key) {
+      return function() {
+        const context = getContext(this);
+
+        if (context) {
+          run(() => triggerableInternal(this, event, selector, { ...options, pageObjectKey: `${key}()` }, context));
+        } else {
+          wait().then(() => triggerableInternal(this, event, selector, { ...options, pageObjectKey: `${key}()` }));
+        }
+
+        return this;
+      };
+    }
+  };
+}

--- a/test-support/page-object.js
+++ b/test-support/page-object.js
@@ -5,6 +5,7 @@ import { collection } from 'ember-cli-page-object/collection';
 import { clickable } from 'ember-cli-page-object/actions/clickable';
 import { clickOnText } from 'ember-cli-page-object/actions/click-on-text';
 import { fillable, fillable as selectable } from 'ember-cli-page-object/actions/fillable';
+import { triggerable } from 'ember-cli-page-object/actions/triggerable';
 import { visitable } from 'ember-cli-page-object/actions/visitable';
 
 import { contains } from 'ember-cli-page-object/predicates/contains';
@@ -25,6 +26,7 @@ export { collection } from 'ember-cli-page-object/collection';
 export { clickable } from 'ember-cli-page-object/actions/clickable';
 export { clickOnText } from 'ember-cli-page-object/actions/click-on-text';
 export { fillable, fillable as selectable } from 'ember-cli-page-object/actions/fillable';
+export { triggerable } from 'ember-cli-page-object/actions/triggerable';
 export { visitable } from 'ember-cli-page-object/actions/visitable';
 
 export { contains } from 'ember-cli-page-object/predicates/contains';

--- a/tests/unit/actions/triggerable-test.js
+++ b/tests/unit/actions/triggerable-test.js
@@ -1,0 +1,149 @@
+import { test } from 'qunit';
+import { moduleFor, fixture } from '../test-helper';
+import { create, triggerable } from '../../page-object';
+
+moduleFor('Unit | Property | .triggerable');
+
+test('calls Ember\'s triggerEvent helper with proper args', function(assert) {
+  fixture('<span></span>');
+  assert.expect(2);
+
+  let expectedSelector = 'span',
+      page;
+
+  window.triggerEvent = function(actualSelector, _, event) {
+    assert.equal(actualSelector, expectedSelector);
+    assert.equal(event, 'focus');
+  };
+
+  page = create({
+    foo: triggerable('focus', expectedSelector)
+  });
+
+  page.foo();
+});
+
+test('looks for elements inside the scope', function(assert) {
+  fixture('<div class="scope"><span></span></div>');
+  assert.expect(1);
+
+  let page;
+
+  window.triggerEvent = function(actualSelector) {
+    assert.equal(actualSelector, '.scope span');
+  };
+
+  page = create({
+    foo: triggerable('focus', 'span', { scope: '.scope' })
+  });
+
+  page.foo();
+});
+
+test('looks for elements inside page\'s scope', function(assert) {
+  fixture('<div class="scope"><span></span></div>');
+  assert.expect(1);
+
+  let page;
+
+  window.triggerEvent = function(actualSelector) {
+    assert.equal(actualSelector, '.scope span');
+  };
+
+  page = create({
+    scope: '.scope',
+
+    foo: triggerable('focus', 'span')
+  });
+
+  page.foo();
+});
+
+test('resets scope', function(assert) {
+  fixture('<span></span>');
+  assert.expect(1);
+
+  let page;
+
+  window.triggerEvent = function(actualSelector) {
+    assert.equal(actualSelector, 'span');
+  };
+
+  page = create({
+    scope: '.scope',
+    foo: triggerable('focus', 'span', { resetScope: true })
+  });
+
+  page.foo();
+});
+
+test('returns target object', function(assert) {
+  fixture('<span></span>');
+  assert.expect(1);
+
+  let page;
+
+  window.triggerEvent = function() {};
+
+  page = create({
+    foo: triggerable('focus', 'span')
+  });
+
+  assert.equal(page.foo(), page);
+});
+
+test('finds element by index', function(assert) {
+  fixture('<span></span><span></span><span></span><span></span>');
+  assert.expect(1);
+
+  let expectedSelector = 'span:eq(3)',
+      page;
+
+  window.triggerEvent = function(actualSelector) {
+    assert.equal(actualSelector, expectedSelector);
+  };
+
+  page = create({
+    foo: triggerable('focus', 'span', { at: 3 })
+  });
+
+  page.foo();
+});
+
+test('looks for elements outside the testing container', function(assert) {
+  fixture('<span></span>', { useAlternateContainer: true });
+  assert.expect(1);
+
+  let expectedContext = '#alternate-ember-testing',
+      page;
+
+  window.triggerEvent = function(_, actualContext) {
+    assert.equal(actualContext, expectedContext);
+  };
+
+  page = create({
+    foo: triggerable('focus', 'span', { testContainer: expectedContext })
+  });
+
+  page.foo();
+});
+
+test("raises an error when the element doesn't exist", function(assert) {
+  assert.expect(1);
+
+  var done = assert.async();
+
+  let page = create({
+    foo: {
+      bar: {
+        baz: {
+          qux: triggerable('focus', 'button')
+        }
+      }
+    }
+  });
+
+  page.foo.bar.baz.qux().then().catch(error => {
+    assert.ok(/page\.foo\.bar\.baz\.qux/.test(error.toString()), 'Element not found');
+  }).finally(done);
+});


### PR DESCRIPTION

This pull request adds the focus property and it also includes it by default on every component.

```js
const page = PageObject.create({
  scope: '#page',
  
  focusOnName: triggerable('focus', 'input')
};

page.focusOnName(); // focuses on "#page input"
```
