### PR TITLE
Make visibility validation optional for clickable and click-on-text

### DIFF
--- a/addon/actions/click-on-text.js
+++ b/addon/actions/click-on-text.js
@@ -117,6 +117,7 @@ function clickOnTextInternal(tree, selector, textToClick, options, context) {
  * @param {Object} options - Additional options
  * @param {string} options.scope - Nests provided scope within parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
+ * @param {boolean} options.visible - Make the action to raise an error if the element is not visible
  * @param {boolean} options.resetScope - Override parent's scope
  * @param {String} options.testContainer - Context where to search elements in the DOM
  * @return {Descriptor}

--- a/addon/actions/clickable.js
+++ b/addon/actions/clickable.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { simpleFindVisibleElementWithAssert, buildSelector, getContext } from '../helpers';
+import { simpleFindElementWithAssert, buildSelector, getContext } from '../helpers';
 
 var { run } = Ember;
 
@@ -7,7 +7,7 @@ function clickableInternal(tree, selector, options, context) {
   var fullSelector = buildSelector(tree, selector, options);
 
   // Run this to validate if the element exists and it is visible
-  simpleFindVisibleElementWithAssert(tree, fullSelector, options)
+  simpleFindElementWithAssert(tree, fullSelector, options);
 
   if (context) {
     if (options.testContainer) {
@@ -71,6 +71,7 @@ function clickableInternal(tree, selector, options, context) {
  * @param {Object} options - Additional options
  * @param {string} options.scope - Nests provided scope within parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
+ * @param {boolean} options.visible - Make the action to raise an error if the element is not visible
  * @param {boolean} options.resetScope - Ignore parent scope
  * @param {String} options.testContainer - Context where to search elements in the DOM
  * @return {Descriptor}

--- a/addon/helpers.js
+++ b/addon/helpers.js
@@ -29,6 +29,10 @@ class Selector {
   calculateFilters() {
     var filters = [];
 
+    if (this.targetFilters.visible) {
+      filters.push(`:visible`);
+    }
+
     if (this.targetFilters.contains) {
       filters.push(`:contains("${this.targetFilters.contains}")`);
     }
@@ -113,6 +117,7 @@ function guardMultiple(items, selector, supportMultiple) {
  * @param {string} options.contains - Filter by using :contains('foo') pseudo-class
  * @param {number} options.at - Filter by index using :eq(x) pseudo-class
  * @param {boolean} options.last - Filter by using :last pseudo-class
+ * @param {boolean} options.visible - Filter by using :visible pseudo-class
  * @return {string} Fully qualified selector
  */
 export function buildSelector(node, targetSelector, options) {
@@ -150,6 +155,7 @@ PageObject: '${path.join('.')}'
  * @param {string} options.contains - Filter by using :contains('foo') pseudo-class
  * @param {number} options.at - Filter by index using :eq(x) pseudo-class
  * @param {boolean} options.last - Filter by using :last pseudo-class
+ * @param {boolean} options.visible - Filter by using :visible pseudo-class
  * @param {boolean} options.multiple - Specify if built selector can match multiple elements.
  * @param {String} options.testContainer - Context where to search elements in the DOM
  * @param {String} options.pageObjectKey - Used in the error message when the element is not found
@@ -199,22 +205,6 @@ export function simpleFindElementWithAssert(node, selector, options = {}) {
 }
 
 /**
- * The difference with simpleFindElementWithAssert is that this function also checks
- * if the elements are visible
- * @private
- */
-export function simpleFindVisibleElementWithAssert(node, selector, options = {}) {
-  let result = simpleFindElementWithAssert(...arguments);
-
-  assert(
-    `"${selector}" matched but the elements are not visible.`,
-    result.is(':visible')
-  );
-
-  return result;
-}
-
-/**
  * Returns a jQuery element (can be an empty jQuery result)
  *
  * @public
@@ -226,6 +216,7 @@ export function simpleFindVisibleElementWithAssert(node, selector, options = {})
  * @param {string} options.contains - Filter by using :contains('foo') pseudo-class
  * @param {number} options.at - Filter by index using :eq(x) pseudo-class
  * @param {boolean} options.last - Filter by using :last pseudo-class
+ * @param {boolean} options.visible - Filter by using :visible pseudo-class
  * @param {boolean} options.multiple - Specify if built selector can match multiple elements.
  * @param {String} options.testContainer - Context where to search elements in the DOM
  * @return {Object} jQuery object

--- a/tests/unit/actions/click-on-text-test.js
+++ b/tests/unit/actions/click-on-text-test.js
@@ -230,3 +230,32 @@ test("raises an error when the element doesn't exist", function(assert) {
     assert.ok(/page\.foo\.bar\.baz\.qux/.test(error.toString()), 'Element not found');
   }).finally(done);
 });
+
+test("doesn't raise an error when the element is not visible and `visible` is not set", function(assert) {
+  fixture('<button style="display:none">Click me</button>');
+  assert.expect(1);
+
+  window.click = function() {
+    assert.ok(true, 'Element is clicked');
+  };
+
+  let page = create({
+    foo: clickOnText('button')
+  });
+
+  page.foo('Click me');
+});
+
+test('raises an error when the element is not visible and `visible` is true', function(assert) {
+  fixture('<button style="display:none">Click me</button>');
+  assert.expect(1);
+
+  let done = assert.async();
+  let page = create({
+    foo: clickOnText('button', { visible: true })
+  });
+
+  page.foo('Click me').then().catch(error => {
+    assert.ok(/page\.foo/.test(error.toString()), 'Element not found');
+  }).finally(done);
+});

--- a/tests/unit/actions/clickable-test.js
+++ b/tests/unit/actions/clickable-test.js
@@ -147,16 +147,31 @@ test("raises an error when the element doesn't exist", function(assert) {
   }).finally(done);
 });
 
-test("raises an error when the element is not visible", function(assert) {
+test("doesn't raise an error when the element is not visible and `visible` is not set", function(assert) {
+  fixture('<span style="display:none">Click me</span>');
+  assert.expect(1);
+
+  window.click = function() {
+    assert.ok(true, 'Element is clicked');
+  };
+
+  let page = create({
+    foo: clickable('span')
+  });
+
+  page.foo();
+});
+
+test('raises an error when the element is not visible and `visible` is true', function(assert) {
   fixture('<span style="display:none">Click me</span>');
   assert.expect(1);
 
   let done = assert.async();
   let page = create({
-    foo: clickable('span')
+    foo: clickable('span', { visible: true })
   });
 
   page.foo().then().catch(error => {
-    assert.ok(/elements are not visible/.test(error.toString()), 'Element not visible');
+    assert.ok(/page\.foo/.test(error.toString()), 'Element not found');
   }).finally(done);
 });


### PR DESCRIPTION
And to maintain backwards compatibility we set this option to false.

Fixes #6 