### PR TITLE
Add ember-suave

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,4 @@
+{
+  "preset": "ember-suave",
+  "requireCamelCaseOrUpperCaseIdentifiers": false
+}

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "ember-export-application-global": "^1.0.4",
     "ember-load-initializers": "^0.5.0",
     "ember-resolver": "^2.0.3",
+    "ember-suave": "2.0.1",
     "ember-try": "^0.1.2",
     "glob": "^5.0.13",
     "loader.js": "^4.0.0",

--- a/tests/acceptance/actions-test.js
+++ b/tests/acceptance/actions-test.js
@@ -4,7 +4,7 @@ import PageObject from '../page-object';
 
 moduleForAcceptance('Acceptance | actions');
 
-var {
+let {
   clickOnText,
   clickable,
   fillable,
@@ -12,7 +12,7 @@ var {
   visitable
 } = PageObject;
 
-var page = PageObject.create({
+let page = PageObject.create({
   visit: visitable('/calculator'),
   keys: {
     clickOn: clickOnText('.numbers'),

--- a/tests/acceptance/default-properties-test.js
+++ b/tests/acceptance/default-properties-test.js
@@ -1,81 +1,81 @@
- import { test } from 'qunit';
- import moduleForAcceptance from '../helpers/module-for-acceptance';
- import PageObject from '../page-object';
+import { test } from 'qunit';
+import moduleForAcceptance from '../helpers/module-for-acceptance';
+import PageObject from '../page-object';
 
- moduleForAcceptance('Acceptance | default properties');
+moduleForAcceptance('Acceptance | default properties');
 
- var {
-   visitable
- } = PageObject;
+let {
+  visitable
+} = PageObject;
 
- test('Adds default properties', function(assert) {
-   var page = PageObject.create({
-     visit: visitable('/calculator'),
+test('Adds default properties', function(assert) {
+  let page = PageObject.create({
+    visit: visitable('/calculator'),
 
-     one: {
-       scope: '.numbers button:nth-of-type(1)'
-     },
+    one: {
+      scope: '.numbers button:nth-of-type(1)'
+    },
 
-     screen: {
-       scope: '.screen',
+    screen: {
+      scope: '.screen',
 
-       expression: {
-         scope: 'input'
-       },
+      expression: {
+        scope: 'input'
+      },
 
-       result: {
-         scope: '.result'
-       }
-     }
-   });
+      result: {
+        scope: '.result'
+      }
+    }
+  });
 
-   page
-     .visit()
-     .clickOn('9')
-     .one
-     .click();
+  page
+    .visit()
+    .clickOn('9')
+    .one
+    .click();
 
-   page.clickOn('=');
+  page.clickOn('=');
 
-   andThen(function() {
-     assert.equal(page.screen.result.text, '91', 'text');
-     assert.ok(page.screen.result.contains('91'), 'contains');
-     assert.ok(!page.screen.result.contains('99'), 'not contains');
-     assert.ok(page.screen.isVisible, 'isVisible');
-     assert.ok(!page.screen.isHidden, 'isHidden');
-   });
- });
+  andThen(function() {
+    assert.equal(page.screen.result.text, '91', 'text');
+    assert.ok(page.screen.result.contains('91'), 'contains');
+    assert.ok(!page.screen.result.contains('99'), 'not contains');
+    assert.ok(page.screen.isVisible, 'isVisible');
+    assert.ok(!page.screen.isHidden, 'isHidden');
+  });
+});
 
- test('Overrides default properties', function(assert) {
-   var page = PageObject.create({
-     dummy: {
-       isHidden() {
-         return 'isHidden';
-       },
-       isVisible() {
-         return 'isVisible';
-       },
-       clickOn() {
-         return 'clickOn';
-       },
-       click() {
-         return 'click';
-       },
-       contains() {
-         return 'contains';
-       },
-       text() {
-         return 'text';
-       }
-     }
-   });
+test('Overrides default properties', function(assert) {
+  let page = PageObject.create({
+    dummy: {
+      isHidden() {
+        return 'isHidden';
+      },
+      isVisible() {
+        return 'isVisible';
+      },
+      clickOn() {
+        return 'clickOn';
+      },
+      click() {
+        return 'click';
+      },
+      contains() {
+        return 'contains';
+      },
+      text() {
+        return 'text';
+      }
+    }
+  });
 
-   andThen(function() {
-     assert.equal(page.dummy.isHidden(), 'isHidden');
-     assert.equal(page.dummy.isVisible(), 'isVisible');
-     assert.equal(page.dummy.clickOn(), 'clickOn');
-     assert.equal(page.dummy.click(), 'click');
-     assert.equal(page.dummy.contains(), 'contains');
-     assert.equal(page.dummy.text(), 'text');
-   });
- });
+  andThen(function() {
+    assert.equal(page.dummy.isHidden(), 'isHidden');
+    assert.equal(page.dummy.isVisible(), 'isVisible');
+    assert.equal(page.dummy.clickOn(), 'clickOn');
+    assert.equal(page.dummy.click(), 'click');
+    assert.equal(page.dummy.contains(), 'contains');
+    assert.equal(page.dummy.text(), 'text');
+  });
+});

--- a/tests/dummy/app/components/calculating-device.js
+++ b/tests/dummy/app/components/calculating-device.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-var c = Ember.computed;
+let c = Ember.computed;
 
 export default Ember.Component.extend({
   result: '',
@@ -14,11 +14,11 @@ export default Ember.Component.extend({
 
   actions: {
     keyPress(key) {
-      var result = this.get('result'),
-          stack = this.get('stack'),
-          op = this.get('op');
+      let result = this.get('result');
+      let stack = this.get('stack');
+      let op = this.get('op');
 
-      switch(key) {
+      switch (key) {
         case '+':
         case '-':
         case '=':
@@ -30,7 +30,7 @@ export default Ember.Component.extend({
           break;
       }
 
-      switch(key) {
+      switch (key) {
         case '-':
           this.set('op', '-');
           break;

--- a/tests/dummy/app/controllers/calculator.js
+++ b/tests/dummy/app/controllers/calculator.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-var c = Ember.computed;
+let c = Ember.computed;
 
 export default Ember.Controller.extend({
   init() {
@@ -19,11 +19,11 @@ export default Ember.Controller.extend({
 
   actions: {
     keyPress(key) {
-      var result = this.get('expression'),
-          stack = this.get('stack'),
-          op = this.get('op');
+      let result = this.get('expression');
+      let stack = this.get('stack');
+      let op = this.get('op');
 
-      switch(key) {
+      switch (key) {
         case '+':
         case '-':
         case '=':
@@ -36,7 +36,7 @@ export default Ember.Controller.extend({
           break;
       }
 
-      switch(key) {
+      switch (key) {
         case '-':
           this.set('op', '-');
           break;

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,3 +1,5 @@
+// jscs: disable requireSpread
+
 import { module } from 'qunit';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';

--- a/tests/integration/actions-test.js
+++ b/tests/integration/actions-test.js
@@ -152,7 +152,7 @@ test('Chaining of actions on a component works', function(assert) {
 test('Queries and actions handle non-existant elements correctly', function(assert) {
   assert.expect(12);
 
-  const message = /Element not found./;
+  let message = /Element not found./;
   let template = createTemplate();
 
   page.render(template);
@@ -185,7 +185,7 @@ test('looks for elements outside the testing container', function(assert) {
 
   $('#alternate-ember-testing').html('<button>lorem</button><input>');
 
-  var page = PageObject.create({
+  let page = PageObject.create({
     context: this,
     clickOnText: clickOnText('button', { testContainer: '#alternate-ember-testing' }),
     clickable: clickable('button', { testContainer: '#alternate-ember-testing' }),

--- a/tests/integration/context-test.js
+++ b/tests/integration/context-test.js
@@ -10,7 +10,7 @@ moduleForComponent('calculating-device', 'Integration | context', {
 test('Test\'s `this` context\'s methods are accessible to the page object', function(assert) {
   assert.expect(2);
 
-  const page = PageObject.create({
+  let page = PageObject.create({
     context: this
   });
 
@@ -22,7 +22,7 @@ test('Test\'s `this` context\'s methods are accessible to the page object', func
 test('Test\'s `this.$()` is accessible by the page object', function(assert) {
   assert.expect(2);
 
-  const page = PageObject.create({
+  let page = PageObject.create({
     context: this
   });
 
@@ -35,7 +35,7 @@ test('Test\'s `this.$()` is accessible by the page object', function(assert) {
 test('`setContext(this)` and `removeContext()` set and remove the test context from the page', function(assert) {
   assert.expect(3);
 
-  const page = PageObject.create({});
+  let page = PageObject.create({});
 
   assert.notOk(page.context);
 
@@ -53,7 +53,7 @@ test('`render()` throws an error when no context has been set', function(assert)
 
   let errorMessage;
 
-  const page = PageObject.create({});
+  let page = PageObject.create({});
 
   assert.notOk(page.context);
 

--- a/tests/integration/default-properties-test.js
+++ b/tests/integration/default-properties-test.js
@@ -8,7 +8,7 @@ moduleForComponent('calculating-device', 'Integration | default properties', {
 });
 
 test('Adds default properties', function(assert) {
-  const page = PageObject.create({
+  let page = PageObject.create({
     context: this,
 
     one: {
@@ -34,7 +34,7 @@ test('Adds default properties', function(assert) {
 });
 
 test('Overrides default properties', function(assert) {
-  var page = PageObject.create({
+  let page = PageObject.create({
     context: this,
 
     dummy: {

--- a/tests/unit/actions/click-on-text-test.js
+++ b/tests/unit/actions/click-on-text-test.js
@@ -195,8 +195,8 @@ test('looks for elements outside the testing container', function(assert) {
 
   fixture('<button>Lorem</button>', { useAlternateContainer: true });
 
-  let expectedContext = '#alternate-ember-testing',
-      page;
+  let expectedContext = '#alternate-ember-testing';
+  let page;
 
   window.click = function(_, actualContext) {
     assert.equal(actualContext, expectedContext);
@@ -214,7 +214,7 @@ test('looks for elements outside the testing container', function(assert) {
 test("raises an error when the element doesn't exist", function(assert) {
   assert.expect(1);
 
-  var done = assert.async();
+  let done = assert.async();
 
   let page = create({
     foo: {
@@ -226,7 +226,7 @@ test("raises an error when the element doesn't exist", function(assert) {
     }
   });
 
-  page.foo.bar.baz.qux('Lorem').then().catch(error => {
+  page.foo.bar.baz.qux('Lorem').then().catch((error) => {
     assert.ok(/page\.foo\.bar\.baz\.qux/.test(error.toString()), 'Element not found');
   }).finally(done);
 });
@@ -255,7 +255,7 @@ test('raises an error when the element is not visible and `visible` is true', fu
     foo: clickOnText('button', { visible: true })
   });
 
-  page.foo('Click me').then().catch(error => {
+  page.foo('Click me').then().catch((error) => {
     assert.ok(/page\.foo/.test(error.toString()), 'Element not found');
   }).finally(done);
 });

--- a/tests/unit/actions/clickable-test.js
+++ b/tests/unit/actions/clickable-test.js
@@ -8,8 +8,8 @@ test('calls Ember\'s click helper', function(assert) {
   fixture('<span>Click me</span>');
   assert.expect(1);
 
-  let expectedSelector = 'span',
-      page;
+  let expectedSelector = 'span';
+  let page;
 
   window.click = function(actualSelector) {
     assert.equal(actualSelector, expectedSelector);
@@ -95,8 +95,8 @@ test('finds element by index', function(assert) {
   fixture('<span></span><span></span><span>Click me</span><span></span>');
   assert.expect(1);
 
-  let expectedSelector = 'span:eq(3)',
-      page;
+  let expectedSelector = 'span:eq(3)';
+  let page;
 
   window.click = function(actualSelector) {
     assert.equal(actualSelector, expectedSelector);
@@ -113,8 +113,8 @@ test('looks for elements outside the testing container', function(assert) {
   fixture('<span>Click me</span>', { useAlternateContainer: true });
   assert.expect(1);
 
-  let expectedContext = '#alternate-ember-testing',
-      page;
+  let expectedContext = '#alternate-ember-testing';
+  let page;
 
   window.click = function(_, actualContext) {
     assert.equal(actualContext, expectedContext);
@@ -130,7 +130,7 @@ test('looks for elements outside the testing container', function(assert) {
 test("raises an error when the element doesn't exist", function(assert) {
   assert.expect(1);
 
-  var done = assert.async();
+  let done = assert.async();
 
   let page = create({
     foo: {
@@ -142,7 +142,7 @@ test("raises an error when the element doesn't exist", function(assert) {
     }
   });
 
-  page.foo.bar.baz.qux().then().catch(error => {
+  page.foo.bar.baz.qux().then().catch((error) => {
     assert.ok(/page\.foo\.bar\.baz\.qux/.test(error.toString()), 'Element not found');
   }).finally(done);
 });
@@ -171,7 +171,7 @@ test('raises an error when the element is not visible and `visible` is true', fu
     foo: clickable('span', { visible: true })
   });
 
-  page.foo().then().catch(error => {
+  page.foo().then().catch((error) => {
     assert.ok(/page\.foo/.test(error.toString()), 'Element not found');
   }).finally(done);
 });

--- a/tests/unit/actions/fillable-test.js
+++ b/tests/unit/actions/fillable-test.js
@@ -8,10 +8,9 @@ test("calls Ember's fillIn helper", function(assert) {
   fixture('<input>');
   assert.expect(2);
 
-  let expectedSelector = 'input',
-      expectedText = 'dummy text',
-      page;
-
+  let expectedSelector = 'input';
+  let expectedText = 'dummy text';
+  let page;
 
   window.fillIn = function(actualSelector, actualText) {
     assert.equal(actualSelector, expectedSelector);
@@ -98,8 +97,8 @@ test('finds element by index', function(assert) {
   fixture('<input><input><input><input>');
   assert.expect(1);
 
-  let expectedSelector = 'input:eq(3)',
-      page;
+  let expectedSelector = 'input:eq(3)';
+  let page;
 
   window.fillIn = function(actualSelector) {
     assert.equal(actualSelector, expectedSelector);
@@ -116,10 +115,9 @@ test('is aliased to selectable', function(assert) {
   fixture('<input>');
   assert.expect(2);
 
-  let expectedSelector = 'input',
-      expectedText = 'dummy text',
-      page;
-
+  let expectedSelector = 'input';
+  let expectedText = 'dummy text';
+  let page;
 
   window.fillIn = function(actualSelector, actualText) {
     assert.equal(actualSelector, expectedSelector);
@@ -137,11 +135,10 @@ test('looks for elements outside the testing container', function(assert) {
   fixture('<input>', { useAlternateContainer: true });
   assert.expect(3);
 
-  let expectedContext = '#alternate-ember-testing',
-      expectedSelector = 'input',
-      expectedText = 'foo',
-      page;
-
+  let expectedContext = '#alternate-ember-testing';
+  let expectedSelector = 'input';
+  let expectedText = 'foo';
+  let page;
 
   window.fillIn = function(actualSelector, actualContext, actualText) {
     assert.equal(actualSelector, expectedSelector);
@@ -159,7 +156,7 @@ test('looks for elements outside the testing container', function(assert) {
 test("raises an error when the element doesn't exist", function(assert) {
   assert.expect(1);
 
-  var done = assert.async();
+  let done = assert.async();
 
   let page = create({
     foo: {
@@ -171,7 +168,7 @@ test("raises an error when the element doesn't exist", function(assert) {
     }
   });
 
-  page.foo.bar.baz.qux('lorem').then().catch(error => {
+  page.foo.bar.baz.qux('lorem').then().catch((error) => {
     assert.ok(/page\.foo\.bar\.baz\.qux/.test(error.toString()), 'Element not found');
   }).finally(done);
 });

--- a/tests/unit/actions/triggerable-test.js
+++ b/tests/unit/actions/triggerable-test.js
@@ -8,8 +8,8 @@ test('calls Ember\'s triggerEvent helper with proper args', function(assert) {
   fixture('<span></span>');
   assert.expect(2);
 
-  let expectedSelector = 'span',
-      page;
+  let expectedSelector = 'span';
+  let page;
 
   window.triggerEvent = function(actualSelector, _, event) {
     assert.equal(actualSelector, expectedSelector);
@@ -96,8 +96,8 @@ test('finds element by index', function(assert) {
   fixture('<span></span><span></span><span></span><span></span>');
   assert.expect(1);
 
-  let expectedSelector = 'span:eq(3)',
-      page;
+  let expectedSelector = 'span:eq(3)';
+  let page;
 
   window.triggerEvent = function(actualSelector) {
     assert.equal(actualSelector, expectedSelector);
@@ -114,8 +114,8 @@ test('looks for elements outside the testing container', function(assert) {
   fixture('<span></span>', { useAlternateContainer: true });
   assert.expect(1);
 
-  let expectedContext = '#alternate-ember-testing',
-      page;
+  let expectedContext = '#alternate-ember-testing';
+  let page;
 
   window.triggerEvent = function(_, actualContext) {
     assert.equal(actualContext, expectedContext);
@@ -131,7 +131,7 @@ test('looks for elements outside the testing container', function(assert) {
 test("raises an error when the element doesn't exist", function(assert) {
   assert.expect(1);
 
-  var done = assert.async();
+  let done = assert.async();
 
   let page = create({
     foo: {
@@ -143,7 +143,7 @@ test("raises an error when the element doesn't exist", function(assert) {
     }
   });
 
-  page.foo.bar.baz.qux().then().catch(error => {
+  page.foo.bar.baz.qux().then().catch((error) => {
     assert.ok(/page\.foo\.bar\.baz\.qux/.test(error.toString()), 'Element not found');
   }).finally(done);
 });

--- a/tests/unit/actions/visitable-test.js
+++ b/tests/unit/actions/visitable-test.js
@@ -65,7 +65,7 @@ test('appends query params to the path', function(assert) {
     foo: visitable('/dummy-page')
   });
 
-  page.foo({ hello: "world", lorem: "ipsum" });
+  page.foo({ hello: 'world', lorem: 'ipsum' });
 });
 
 test('accepts both dynamic segments and query params', function(assert) {
@@ -81,5 +81,5 @@ test('accepts both dynamic segments and query params', function(assert) {
     foo: visitable('/users/:user_id/:another_id')
   });
 
-  page.foo({ user_id: 1, another_id: 0, hello: "world", lorem: "ipsum" });
+  page.foo({ user_id: 1, another_id: 0, hello: 'world', lorem: 'ipsum' });
 });

--- a/tests/unit/components/collection-test.js
+++ b/tests/unit/components/collection-test.js
@@ -96,11 +96,11 @@ test('delegates configured methods to `toArray()`', function(assert) {
     })
   });
 
-  assert.deepEqual(page.foo().map(i => i.text), ['Lorem', 'Ipsum']);
+  assert.deepEqual(page.foo().map((i) => i.text), ['Lorem', 'Ipsum']);
   assert.deepEqual(page.foo().mapBy('text'), ['Lorem', 'Ipsum']);
 
-  assert.deepEqual(page.foo().filter(i => i.isSpecial).map(i => i.text), ['Lorem']);
-  assert.deepEqual(page.foo().filterBy('isSpecial').map(i => i.text), ['Lorem']);
+  assert.deepEqual(page.foo().filter((i) => i.isSpecial).map((i) => i.text), ['Lorem']);
+  assert.deepEqual(page.foo().filterBy('isSpecial').map((i) => i.text), ['Lorem']);
 });
 
 test('produces an iterator for items', function(assert) {
@@ -350,7 +350,9 @@ test("returns the page object path when item's element doesn't exist", function(
     }
   });
 
-  assert.throws(function() { return page.foo.bar(1).baz.qux; }, function(error) {
+  assert.throws(function() {
+    return page.foo.bar(1).baz.qux;
+  }, function(error) {
     return /page\.foo\.bar\(1\)\.baz\.qux/.test(error.message);
   });
 });
@@ -368,7 +370,9 @@ test("returns the page object path when collection's element doesn't exist", fun
     }
   });
 
-  assert.throws(function() { return page.foo.bar().baz.qux; }, function(error) {
+  assert.throws(function() {
+    return page.foo.bar().baz.qux;
+  }, function(error) {
     return /page\.foo\.bar\(\)\.baz\.qux/.test(error.message);
   });
 });

--- a/tests/unit/create-test.js
+++ b/tests/unit/create-test.js
@@ -5,7 +5,7 @@ import { create, text } from '../page-object';
 moduleFor('Unit | Property | .create');
 
 test('creates new page object', function(assert) {
-  var page = create({
+  let page = create({
     foo: 'a value',
     bar: {
       baz: 'another value'
@@ -23,7 +23,7 @@ test('resets scope', function(assert) {
     </div>
   `);
 
-  var page = create({
+  let page = create({
     scope: '.invalid-scope',
 
     foo: {
@@ -39,7 +39,7 @@ test('resets scope', function(assert) {
 test('generates .isVisible property', function(assert) {
   fixture('Lorem <span>ipsum</span>');
 
-  var page = create({
+  let page = create({
     scope: 'span',
     foo: {
     }
@@ -52,7 +52,7 @@ test('generates .isVisible property', function(assert) {
 test('generates .isHidden property', function(assert) {
   fixture('Lorem <span style="display:none">ipsum</span>');
 
-  var page = create({
+  let page = create({
     scope: 'span',
     foo: {
     }
@@ -62,9 +62,9 @@ test('generates .isHidden property', function(assert) {
   assert.ok(page.foo.isHidden, 'component is hidden');
 });
 
-['isVisible', 'isHidden', 'clickOn', 'click', 'contains', 'text'].forEach(prop => {
+['isVisible', 'isHidden', 'clickOn', 'click', 'contains', 'text'].forEach((prop) => {
   test(`does not override .${prop} property`, function(assert) {
-    var page = create({
+    let page = create({
       [prop]: 'foo bar'
     });
 
@@ -80,7 +80,7 @@ test('generates .clickOn property', function(assert) {
     assert.ok(true, 'click called');
   };
 
-  var page = create({
+  let page = create({
     foo: {
     }
   });
@@ -96,7 +96,7 @@ test('generates .click property', function(assert) {
     assert.ok(true, 'click called');
   };
 
-  var page = create({
+  let page = create({
     foo: {
       scope: 'button'
     }
@@ -108,7 +108,7 @@ test('generates .click property', function(assert) {
 test('generates .click property', function(assert) {
   fixture('Ipsum <span>Dolor</span>');
 
-  var page = create({
+  let page = create({
     foo: {
       scope: 'span'
     }
@@ -123,7 +123,7 @@ test('generates .text property', function(assert) {
     <div class="scope">Ipsum <span>Dolor</span></div>
   `);
 
-  var page = create({
+  let page = create({
     scope: '.scope',
     foo: {
       scope: 'span'
@@ -135,10 +135,10 @@ test('generates .text property', function(assert) {
 });
 
 test('generates .then property', function(assert) {
-  var page = create({
+  let page = create({
     foo: {}
   });
 
-  assert.ok(typeof(page.then) === 'function');
-  assert.ok(typeof(page.foo.then) === 'function');
+  assert.ok(typeof (page.then) === 'function');
+  assert.ok(typeof (page.foo.then) === 'function');
 });

--- a/tests/unit/queries/attribute-test.js
+++ b/tests/unit/queries/attribute-test.js
@@ -126,7 +126,7 @@ test('finds element by index', function(assert) {
 test('looks for elements outside the testing container', function(assert) {
   fixture('<input placeholder="a value">', { useAlternateContainer: true });
 
-  var page = create({
+  let page = create({
     foo: attribute('placeholder', ':input', { testContainer: '#alternate-ember-testing' })
   });
 

--- a/tests/unit/queries/count-test.js
+++ b/tests/unit/queries/count-test.js
@@ -86,7 +86,7 @@ test('resets multiple value', function(assert) {
 test('looks for elements outside the testing container', function(assert) {
   fixture('<span></span><span></span>', { useAlternateContainer: true });
 
-  var page = create({
+  let page = create({
     foo: count('span', { testContainer: '#alternate-ember-testing' })
   });
 

--- a/tests/unit/queries/is-test.js
+++ b/tests/unit/queries/is-test.js
@@ -114,12 +114,11 @@ test('finds element by index', function(assert) {
   assert.ok(page.foo);
 });
 
-
 test('looks for elements outside the testing container', function(assert) {
-  fixture('<h1 class="foo">lorem ipsum</h1>', { useAlternateContainer: true  });
+  fixture('<h1 class="foo">lorem ipsum</h1>', { useAlternateContainer: true });
 
-  var page = create({
-    foo: is('.foo', 'h1', { testContainer: '#alternate-ember-testing'  })
+  let page = create({
+    foo: is('.foo', 'h1', { testContainer: '#alternate-ember-testing' })
   });
 
   assert.equal(page.foo, true);

--- a/tests/unit/queries/property-test.js
+++ b/tests/unit/queries/property-test.js
@@ -116,7 +116,7 @@ test('finds element by index', function(assert) {
 test('looks for elements outside the testing container', function(assert) {
   fixture('<input checked>', { useAlternateContainer: true });
 
-  var page = create({
+  let page = create({
     foo: property('checked', ':input', { testContainer: '#alternate-ember-testing' })
   });
 

--- a/tests/unit/queries/text-test.js
+++ b/tests/unit/queries/text-test.js
@@ -28,7 +28,7 @@ test('removes white spaces from the beginning and end of the text', function(ass
 });
 
 test('normalizes inner text of the element containing newlines', function(assert) {
-  fixture(['<span>', 'Hello', 'multi-line', 'world!', '</span>'].join("\n"));
+  fixture(['<span>', 'Hello', 'multi-line', 'world!', '</span>'].join('\n'));
 
   let page = create({
     foo: text('span')
@@ -38,7 +38,7 @@ test('normalizes inner text of the element containing newlines', function(assert
 });
 
 test('avoid text normalization if normalize:false', function(assert) {
-  const denormalizedText = [' \n ', 'Hello', 'multi-line', 'world! ', '\t', '\n'].join('\n');
+  let denormalizedText = [' \n ', 'Hello', 'multi-line', 'world! ', '\t', '\n'].join('\n');
   fixture(`<span>${denormalizedText}</span>`);
 
   let page = create({
@@ -186,7 +186,7 @@ test('returns multiple values', function(assert) {
     </ul>
   `);
 
-  var page = create({
+  let page = create({
     foo: text('li', { multiple: true })
   });
 
@@ -196,7 +196,7 @@ test('returns multiple values', function(assert) {
 test('looks for elements outside the testing container', function(assert) {
   fixture('<h1>lorem ipsum</h1>', { useAlternateContainer: true });
 
-  var page = create({
+  let page = create({
     foo: text('h1', { testContainer: '#alternate-ember-testing' })
   });
 

--- a/tests/unit/queries/value-test.js
+++ b/tests/unit/queries/value-test.js
@@ -107,7 +107,7 @@ test('matches multiple elements with multiple: true option', function(assert) {
     foo: value('input', { multiple: true })
   });
 
-  assert.deepEqual(page.foo, ["lorem", "ipsum"]);
+  assert.deepEqual(page.foo, ['lorem', 'ipsum']);
 });
 
 test('finds element by index', function(assert) {
@@ -126,7 +126,7 @@ test('finds element by index', function(assert) {
 test('looks for elements outside the testing container', function(assert) {
   fixture('<input value="lorem">', { useAlternateContainer: true });
 
-  var page = create({
+  let page = create({
     foo: value('input', { testContainer: '#alternate-ember-testing' })
   });
 

--- a/tests/unit/test-helper.js
+++ b/tests/unit/test-helper.js
@@ -6,10 +6,10 @@ let application;
 
 export function moduleFor(helperName) {
   module(`${helperName}`, {
-    beforeEach: function() {
+    beforeEach() {
       application = startApp();
     },
-    afterEach: function() {
+    afterEach() {
       Ember.run(application, 'destroy');
 
       // Cleanup DOM


### PR DESCRIPTION
Fixes #180 

Fix some indentation issues
Change var to let
Remove multiple variable declarations
Add a space after the switch keyword
Disable requireSpread rule in tests/helpers/module-for-acceptance.js file
Change const to let when used inside functions, const should be used only at module level
Add parenthesis to the arrow functions
Remove multiple line breaks
Disable requireCamelCaseOrUpperCase rule in test_throws_if_not_multiple. It should be camel case but it used all over the project.