### PR TITLE
Pass event properties to triggerEvent helper

### DIFF
--- a/addon/actions/triggerable.js
+++ b/addon/actions/triggerable.js
@@ -1,13 +1,18 @@
 import Ember from 'ember';
 import { simpleFindElementWithAssert, buildSelector, getContext } from '../helpers';
 
-function triggerableInternal(tree, event, selector, options, context) {
-  var fullSelector = buildSelector(tree, selector, options);
+function triggerableInternal(tree, eventType, selector, options, context) {
+  var eventOptions = options.eventProperties,
+    fullSelector = buildSelector(tree, selector, options);
+
+  delete options.eventProperties;
 
   // Run this to validate if the element exists
   simpleFindElementWithAssert(tree, fullSelector, options)
 
   if (context) {
+    let event = Ember.$.Event(eventType, eventOptions);
+
     if (options.testContainer) {
       Ember.$(fullSelector, options.testContainer).trigger(event);
     } else {
@@ -15,7 +20,7 @@ function triggerableInternal(tree, event, selector, options, context) {
     }
   } else {
     /* global triggerEvent */
-    triggerEvent(fullSelector, options.testContainer, event);
+    triggerEvent(fullSelector, options.testContainer, eventType, eventOptions);
   }
 }
 
@@ -34,6 +39,18 @@ function triggerableInternal(tree, event, selector, options, context) {
  *
  * // focuses on element with selector '.name'
  * page.focus();
+ *
+ * @example
+ *
+ * // <input class="name">
+ * // <input class="email">
+ *
+ * const page = PageObject.create({
+ *   enter: triggerable('keypress', '.name', { eventProperties: { keyCode: 13 } })
+ * });
+ *
+ * // triggers keypress using enter key on element with selector '.name'
+ * page.enter();
  *
  * @example
  *
@@ -73,6 +90,7 @@ function triggerableInternal(tree, event, selector, options, context) {
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.resetScope - Ignore parent scope
  * @param {String} options.testContainer - Context where to search elements in the DOM
+ * @param {String} options.eventProperties - Event properties that will be passed to trigger function
  * @return {Descriptor}
 */
 export function triggerable(event, selector, options = {}) {

--- a/tests/unit/actions/triggerable-test.js
+++ b/tests/unit/actions/triggerable-test.js
@@ -23,6 +23,26 @@ test('calls Ember\'s triggerEvent helper with proper args', function(assert) {
   page.foo();
 });
 
+test('calls Ember\'s triggerEvent helper with event options', function(assert) {
+  fixture('<span></span>');
+  assert.expect(3);
+
+  let expectedSelector = 'span';
+  let page;
+
+  window.triggerEvent = function(actualSelector, _, event, options) {
+    assert.equal(actualSelector, expectedSelector);
+    assert.equal(event, 'keypress');
+    assert.equal(options.keyCode, 13);
+  };
+
+  page = create({
+    foo: triggerable('keypress', expectedSelector, { eventProperties: { keyCode: 13 } })
+  });
+
+  page.foo();
+});
+
 test('looks for elements inside the scope', function(assert) {
   fixture('<div class="scope"><span></span></div>');
   assert.expect(1);


### PR DESCRIPTION
Add `eventProperties` options to maintain compatibility with Ember's `triggerEvent` test helper.

After this pull request this will work:

```js
const page = PageObject.create({
  enter: triggerable('keypress', '.name', { eventProperties: { keyCode: 13 } })
});
```