### PR TITLE
Add keyable property

### DIFF
--- a/addon/actions/keyable.js
+++ b/addon/actions/keyable.js
@@ -1,0 +1,102 @@
+import Ember from 'ember';
+import { simpleFindElementWithAssert, buildSelector, getContext } from '../helpers';
+
+function keyableInternal(tree, eventType, keyCode, selector, options, context) {
+  var eventOptions = options.eventProperties,
+    fullSelector = buildSelector(tree, selector, options);
+
+  delete options.eventProperties;
+
+  // Run this to validate if the element exists
+  simpleFindElementWithAssert(tree, fullSelector, options)
+
+  if (context) {
+    let event = Ember.$.Event(eventType, { keyCode });
+
+    if (options.testContainer) {
+      Ember.$(fullSelector, options.testContainer).trigger(event);
+    } else {
+      context.$(fullSelector).trigger(event);
+    }
+  } else {
+    /* global keyEvent */
+    keyEvent(fullSelector, options.testContainer, eventType, keyCode);
+  }
+}
+
+/**
+ *
+ * Triggers key event with specified key code on element matched by selector.
+ *
+ * @example
+ *
+ * // <input class="name">
+ * // <input class="email">
+ *
+ * const page = PageObject.create({
+ *   enter: keyable('keypress', 13, '.name', { scope: '.name' })
+ * });
+ *
+ * // triggers keypress using enter key on element with selector '.name'
+ * page.enter();
+ *
+ * @example
+ *
+ * // <div class="scope">
+ * //   <input class="name">
+ * // </div>
+ * // <input class="email">
+ *
+ * const page = PageObject.create({
+ *   enter: keyable('keypress', 13, '.name', { scope: '.scope' })
+ * });
+ *
+ * // triggers keypress using enter key on element with selector '.scope .name'
+ * page.enter();
+ *
+ * @example
+ *
+ * // <div class="scope">
+ * //   <input class="name">
+ * // </div>
+ * // <input class="email">
+ *
+ * const page = PageObject.create({
+ *   scope: '.scope',
+ *   enter: triggerable('keypress', 13, '.name')
+ * });
+ *
+ * // triggers keypress using enter key on element with selector '.scope button.continue'
+ * page.enter();
+ *
+ * @public
+ *
+ * @param {string} event - Key event to be triggered
+ * @param {string} keyCode - Key code that will be passed when triggering event
+ * @param {string} selector - CSS selector of the element on which the event will be triggered
+ * @param {Object} options - Additional options
+ * @param {string} options.scope - Nests provided scope within parent's scope
+ * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
+ * @param {boolean} options.resetScope - Ignore parent scope
+ * @param {String} options.testContainer - Context where to search elements in the DOM
+ * @return {Descriptor}
+*/
+export function keyable(event, keyCode, selector, options = {}) {
+  return {
+    isDescriptor: true,
+
+    get(key) {
+      return function() {
+        const context = getContext(this);
+
+        if (context) {
+          run(() => keyableInternal(this, event, keyCode, selector, { ...options, pageObjectKey: `${key}()` }, context));
+        } else {
+          wait().then(() => keyableInternal(this, event, keyCode, selector, { ...options, pageObjectKey: `${key}()` }));
+        }
+
+        return this;
+      };
+    }
+  };
+}

--- a/addon/actions/triggerable.js
+++ b/addon/actions/triggerable.js
@@ -1,13 +1,18 @@
 import Ember from 'ember';
 import { simpleFindElementWithAssert, buildSelector, getContext } from '../helpers';
 
-function triggerableInternal(tree, event, selector, options, context) {
-  var fullSelector = buildSelector(tree, selector, options);
+function triggerableInternal(tree, eventType, selector, options, context) {
+  var eventOptions = options.eventProperties,
+    fullSelector = buildSelector(tree, selector, options);
+
+  delete options.eventProperties;
 
   // Run this to validate if the element exists
   simpleFindElementWithAssert(tree, fullSelector, options)
 
   if (context) {
+    let event = Ember.$.Event(eventType, eventOptions);
+
     if (options.testContainer) {
       Ember.$(fullSelector, options.testContainer).trigger(event);
     } else {
@@ -15,7 +20,7 @@ function triggerableInternal(tree, event, selector, options, context) {
     }
   } else {
     /* global triggerEvent */
-    triggerEvent(fullSelector, options.testContainer, event);
+    triggerEvent(fullSelector, options.testContainer, eventType, eventOptions);
   }
 }
 
@@ -34,6 +39,18 @@ function triggerableInternal(tree, event, selector, options, context) {
  *
  * // focuses on element with selector '.name'
  * page.focus();
+ *
+ * @example
+ *
+ * // <input class="name">
+ * // <input class="email">
+ *
+ * const page = PageObject.create({
+ *   enter: triggerable('keypress', '.name', { eventProperties: { keyCode: 13 } })
+ * });
+ *
+ * // triggers keypress using enter key on element with selector '.name'
+ * page.enter();
  *
  * @example
  *
@@ -73,6 +90,7 @@ function triggerableInternal(tree, event, selector, options, context) {
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.resetScope - Ignore parent scope
  * @param {String} options.testContainer - Context where to search elements in the DOM
+ * @param {String} options.eventProperties - Event properties that will be passed to trigger function
  * @return {Descriptor}
 */
 export function triggerable(event, selector, options = {}) {

--- a/test-support/page-object.js
+++ b/test-support/page-object.js
@@ -5,6 +5,7 @@ import { collection } from 'ember-cli-page-object/collection';
 import { clickable } from 'ember-cli-page-object/actions/clickable';
 import { clickOnText } from 'ember-cli-page-object/actions/click-on-text';
 import { fillable, fillable as selectable } from 'ember-cli-page-object/actions/fillable';
+import { keyable } from 'ember-cli-page-object/actions/keyable';
 import { triggerable } from 'ember-cli-page-object/actions/triggerable';
 import { visitable } from 'ember-cli-page-object/actions/visitable';
 
@@ -27,6 +28,7 @@ export { collection } from 'ember-cli-page-object/collection';
 export { clickable } from 'ember-cli-page-object/actions/clickable';
 export { clickOnText } from 'ember-cli-page-object/actions/click-on-text';
 export { fillable, fillable as selectable } from 'ember-cli-page-object/actions/fillable';
+export { keyable } from 'ember-cli-page-object/actions/keyable';
 export { triggerable } from 'ember-cli-page-object/actions/triggerable';
 export { visitable } from 'ember-cli-page-object/actions/visitable';
 
@@ -58,6 +60,7 @@ export default {
   is,
   isHidden,
   isVisible,
+  keyable,
   notHasClass,
   selectable,
   text,

--- a/tests/unit/actions/keyable-test.js
+++ b/tests/unit/actions/keyable-test.js
@@ -1,0 +1,150 @@
+import { test } from 'qunit';
+import { moduleFor, fixture } from '../test-helper';
+import { create, keyable } from '../../page-object';
+
+moduleFor('Unit | Property | .keyable');
+
+test('calls Ember\'s keyEvent helper with proper args', function(assert) {
+  fixture('<span></span>');
+  assert.expect(3);
+
+  let expectedSelector = 'span';
+  let page;
+
+  window.keyEvent = function(actualSelector, _, event, keyCode) {
+    assert.equal(actualSelector, expectedSelector);
+    assert.equal(event, 'keypress');
+    assert.equal(keyCode, 13);
+  };
+
+  page = create({
+    foo: keyable('keypress', 13, expectedSelector)
+  });
+
+  page.foo();
+});
+
+test('looks for elements inside the scope', function(assert) {
+  fixture('<div class="scope"><span></span></div>');
+  assert.expect(1);
+
+  let page;
+
+  window.keyEvent = function(actualSelector) {
+    assert.equal(actualSelector, '.scope span');
+  };
+
+  page = create({
+    foo: keyable('keypress', 13, 'span', { scope: '.scope' })
+  });
+
+  page.foo();
+});
+
+test('looks for elements inside page\'s scope', function(assert) {
+  fixture('<div class="scope"><span></span></div>');
+  assert.expect(1);
+
+  let page;
+
+  window.keyEvent = function(actualSelector) {
+    assert.equal(actualSelector, '.scope span');
+  };
+
+  page = create({
+    scope: '.scope',
+
+    foo: keyable('keypress', 13, 'span')
+  });
+
+  page.foo();
+});
+
+test('resets scope', function(assert) {
+  fixture('<span></span>');
+  assert.expect(1);
+
+  let page;
+
+  window.keyEvent = function(actualSelector) {
+    assert.equal(actualSelector, 'span');
+  };
+
+  page = create({
+    scope: '.scope',
+    foo: keyable('keypress', 13, 'span', { resetScope: true })
+  });
+
+  page.foo();
+});
+
+test('returns target object', function(assert) {
+  fixture('<span></span>');
+  assert.expect(1);
+
+  let page;
+
+  window.keyEvent = function() {};
+
+  page = create({
+    foo: keyable('keypress', 13, 'span')
+  });
+
+  assert.equal(page.foo(), page);
+});
+
+test('finds element by index', function(assert) {
+  fixture('<span></span><span></span><span></span><span></span>');
+  assert.expect(1);
+
+  let expectedSelector = 'span:eq(3)';
+  let page;
+
+  window.keyEvent = function(actualSelector) {
+    assert.equal(actualSelector, expectedSelector);
+  };
+
+  page = create({
+    foo: keyable('keypress', 13, 'span', { at: 3 })
+  });
+
+  page.foo();
+});
+
+test('looks for elements outside the testing container', function(assert) {
+  fixture('<span></span>', { useAlternateContainer: true });
+  assert.expect(1);
+
+  let expectedContext = '#alternate-ember-testing';
+  let page;
+
+  window.keyEvent = function(_, actualContext) {
+    assert.equal(actualContext, expectedContext);
+  };
+
+  page = create({
+    foo: keyable('keypress', 13, 'span', { testContainer: expectedContext })
+  });
+
+  page.foo();
+});
+
+test("raises an error when the element doesn't exist", function(assert) {
+  assert.expect(1);
+
+  let done = assert.async();
+
+  let page = create({
+    foo: {
+      bar: {
+        baz: {
+          qux: keyable('keypress', 'button', 13)
+        }
+      }
+    }
+  });
+
+  page.foo.bar.baz.qux().then().catch((error) => {
+    assert.ok(/page\.foo\.bar\.baz\.qux/.test(error.toString()), 'Element not found');
+  }).finally(done);
+});

--- a/tests/unit/actions/triggerable-test.js
+++ b/tests/unit/actions/triggerable-test.js
@@ -23,6 +23,26 @@ test('calls Ember\'s triggerEvent helper with proper args', function(assert) {
   page.foo();
 });
 
+test('calls Ember\'s triggerEvent helper with event options', function(assert) {
+  fixture('<span></span>');
+  assert.expect(3);
+
+  let expectedSelector = 'span';
+  let page;
+
+  window.triggerEvent = function(actualSelector, _, event, options) {
+    assert.equal(actualSelector, expectedSelector);
+    assert.equal(event, 'keypress');
+    assert.equal(options.keyCode, 13);
+  };
+
+  page = create({
+    foo: triggerable('keypress', expectedSelector, { eventProperties: { keyCode: 13 } })
+  });
+
+  page.foo();
+});
+
 test('looks for elements inside the scope', function(assert) {
   fixture('<div class="scope"><span></span></div>');
   assert.expect(1);


### PR DESCRIPTION
Add keyable properties which maps to Ember's `keyEvent` testing helper.

``` js
page = create({
  foo: keyable('keypress', 13, 'span', { at: 3 })
});
```
