### PR TITLE
Expose getContext

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -16,7 +16,7 @@ import { property }    from './queries/property';         export { property };
 import { text }        from './queries/text';             export { text };
 import { value }       from './queries/value';            export { value };
 
-export { buildSelector, findElementWithAssert, findElement } from './helpers';
+export { buildSelector, findElementWithAssert, findElement, getContext } from './helpers';
 
 export default {
   attribute,

--- a/test-support/page-object.js
+++ b/test-support/page-object.js
@@ -43,7 +43,7 @@ export { text } from 'ember-cli-page-object/queries/text';
 export { value } from 'ember-cli-page-object/queries/value';
 export { property } from 'ember-cli-page-object/queries/property';
 
-export { buildSelector, findElementWithAssert, findElement } from 'ember-cli-page-object/helpers';
+export { buildSelector, findElementWithAssert, findElement, getContext } from 'ember-cli-page-object/helpers';
 
 export default {
   attribute,


### PR DESCRIPTION
After upgrading to `1.3.0` from `1.1.0` I noticed that getContext wasn't available from `import { getContext } from 'ember-cli-page-object'` 

This PR fixes that :)