### PR TITLE
Test exports

### DIFF
--- a/test-support/page-object.js
+++ b/test-support/page-object.js
@@ -1,49 +1,23 @@
-import { create } from 'ember-cli-page-object/create';
+import { attribute }   from 'ember-cli-page-object'; export { attribute };
+import { clickOnText } from 'ember-cli-page-object'; export { clickOnText };
+import { clickable }   from 'ember-cli-page-object'; export { clickable };
+import { collection }  from 'ember-cli-page-object'; export { collection };
+import { contains }    from 'ember-cli-page-object'; export { contains };
+import { count }       from 'ember-cli-page-object'; export { count };
+import { create }      from 'ember-cli-page-object'; export { create };
+import { fillable }    from 'ember-cli-page-object'; export { fillable, fillable as selectable };
+import { hasClass }    from 'ember-cli-page-object'; export { hasClass };
+import { is }          from 'ember-cli-page-object'; export { is };
+import { isHidden }    from 'ember-cli-page-object'; export { isHidden };
+import { isVisible }   from 'ember-cli-page-object'; export { isVisible };
+import { notHasClass } from 'ember-cli-page-object'; export { notHasClass };
+import { property }    from 'ember-cli-page-object'; export { property };
+import { text }        from 'ember-cli-page-object'; export { text };
+import { triggerable } from 'ember-cli-page-object'; export { triggerable };
+import { value }       from 'ember-cli-page-object'; export { value };
+import { visitable }   from 'ember-cli-page-object'; export { visitable };
 
-import { collection } from 'ember-cli-page-object/collection';
-
-import { clickable } from 'ember-cli-page-object/actions/clickable';
-import { clickOnText } from 'ember-cli-page-object/actions/click-on-text';
-import { fillable, fillable as selectable } from 'ember-cli-page-object/actions/fillable';
-import { triggerable } from 'ember-cli-page-object/actions/triggerable';
-import { visitable } from 'ember-cli-page-object/actions/visitable';
-
-import { contains } from 'ember-cli-page-object/predicates/contains';
-import { hasClass } from 'ember-cli-page-object/predicates/has-class';
-import { isHidden } from 'ember-cli-page-object/predicates/is-hidden';
-import { isVisible } from 'ember-cli-page-object/predicates/is-visible';
-import { notHasClass } from 'ember-cli-page-object/predicates/not-has-class';
-
-import { attribute } from 'ember-cli-page-object/queries/attribute';
-import { count } from 'ember-cli-page-object/queries/count';
-import { is } from 'ember-cli-page-object/queries/is';
-import { text } from 'ember-cli-page-object/queries/text';
-import { value } from 'ember-cli-page-object/queries/value';
-
-export { create } from 'ember-cli-page-object/create';
-
-export { collection } from 'ember-cli-page-object/collection';
-
-export { clickable } from 'ember-cli-page-object/actions/clickable';
-export { clickOnText } from 'ember-cli-page-object/actions/click-on-text';
-export { fillable, fillable as selectable } from 'ember-cli-page-object/actions/fillable';
-export { triggerable } from 'ember-cli-page-object/actions/triggerable';
-export { visitable } from 'ember-cli-page-object/actions/visitable';
-
-export { contains } from 'ember-cli-page-object/predicates/contains';
-export { hasClass } from 'ember-cli-page-object/predicates/has-class';
-export { isHidden } from 'ember-cli-page-object/predicates/is-hidden';
-export { isVisible } from 'ember-cli-page-object/predicates/is-visible';
-export { notHasClass } from 'ember-cli-page-object/predicates/not-has-class';
-
-export { attribute } from 'ember-cli-page-object/queries/attribute';
-export { count } from 'ember-cli-page-object/queries/count';
-export { is } from 'ember-cli-page-object/queries/is';
-export { text } from 'ember-cli-page-object/queries/text';
-export { value } from 'ember-cli-page-object/queries/value';
-export { property } from 'ember-cli-page-object/queries/property';
-
-export { buildSelector, findElementWithAssert, findElement, getContext } from 'ember-cli-page-object/helpers';
+export { buildSelector, findElementWithAssert, findElement, getContext } from 'ember-cli-page-object';
 
 export default {
   attribute,
@@ -59,7 +33,8 @@ export default {
   isHidden,
   isVisible,
   notHasClass,
-  selectable,
+  property,
+  selectable: fillable,
   text,
   triggerable,
   value,

--- a/tests/unit/addon-exports-test.js
+++ b/tests/unit/addon-exports-test.js
@@ -1,0 +1,59 @@
+import { test, module } from 'qunit';
+
+module('Unit | Exports');
+
+/* global require */
+const Addon = require('ember-cli-page-object');
+const TestSupport = require('dummy/tests/page-object');
+
+const EXPECTED_METHODS = [
+  'attribute',
+  'clickOnText',
+  'clickable',
+  'collection',
+  'contains',
+  'count',
+  'create',
+  'fillable',
+  'hasClass',
+  'is',
+  'isHidden',
+  'isVisible',
+  'notHasClass',
+  'property',
+  'selectable',
+  'text',
+  'value',
+  'visitable'
+];
+
+const HELPER_METHODS = [
+  'buildSelector',
+  'getContext',
+  'findElement',
+  'findElementWithAssert'
+];
+
+EXPECTED_METHODS.forEach((method) => {
+  test(`imports PageObject.${method} from addon`, function(assert) {
+    assert.equal(typeof (Addon['default'][method]), 'function', `Imports PageObject.${method}`);
+  });
+});
+
+EXPECTED_METHODS.concat(HELPER_METHODS).forEach((method) => {
+  test(`imports { ${method} } from addon`, function(assert) {
+    assert.equal(typeof (Addon[method]), 'function', `Imports PageObject.${method}`);
+  });
+});
+
+EXPECTED_METHODS.forEach((method) => {
+  test(`imports PageObject.${method} from test-support`, function(assert) {
+    assert.equal(typeof (TestSupport['default'][method]), 'function', `Imports PageObject.${method}`);
+  });
+});
+
+EXPECTED_METHODS.concat(HELPER_METHODS).forEach((method) => {
+  test(`imports { ${method} } from test-support`, function(assert) {
+    assert.equal(typeof (TestSupport[method]), 'function', `Imports PageObject.${method}`);
+  });
+});


### PR DESCRIPTION
This PR adds tests to validate that we're exporting via:

* `import { foo } from 'ember-cli-page-object';`
* `import PageObject from 'ember-cli-page-object'; PageObject.foo`
* `import { foo } from 'my-app/tests/page-object'`;
* `import PageObject from 'my-app/tests/page-object'; PageObject.foo`