### PR TITLE
Fill in by label

### DIFF
--- a/addon/-private/create.js
+++ b/addon/-private/create.js
@@ -5,6 +5,7 @@ import { isHidden } from './properties/is-hidden';
 import { contains } from './properties/contains';
 import { clickOnText } from './properties/click-on-text';
 import { clickable } from './properties/clickable';
+import { fillable } from './properties/fillable';
 import { render, setContext, removeContext } from './context';
 import { assign } from './helpers';
 
@@ -23,6 +24,8 @@ const defaultProperties = {
   text,
   clickOn: clickOnText,
   click: clickable,
+  fillIn: fillable,
+  select: fillable,
   then: thenDescriptor
 };
 
@@ -54,7 +57,7 @@ function buildObject(node, blueprintKey, blueprint, defaultBuilder) {
  *
  * By default, the resulting PageObject will respond to:
  *
- * - **Actions**: click, clickOn
+ * - **Actions**: click, clickOn, fillIn, select
  * - **Predicates**: contains, isHidden, isVisible
  * - **Queries**: text
  *
@@ -100,6 +103,12 @@ function buildObject(node, blueprintKey, blueprint, defaultBuilder) {
  *
  * // clicks button
  * page.clickOn('Press Me');
+ *
+ * // fills an input
+ * page.fillIn('name', 'John Doe');
+ *
+ * // selects an option
+ * page.select('country', 'Uruguay');
  *
  * @public
  *

--- a/tests/acceptance/actions-test.js
+++ b/tests/acceptance/actions-test.js
@@ -60,3 +60,57 @@ test('action chains act like a promise', function(assert) {
       assert.equal(page.screen, '12');
     });
 });
+
+test('fill in by attribute', function(assert) {
+  let page = PageObject.create({
+    visit: visitable('/inputs'),
+    fillIn: fillable()
+  });
+
+  page.visit();
+
+  page
+    .fillIn('input1', 'input 1')
+    .fillIn('input2', 'input 2')
+    .fillIn('input3', 'input 3')
+    .fillIn('input4', 'input 4')
+    .fillIn('input5', 'input 5');
+
+  andThen(function() {
+    assert.equal(find('.input1-value').val(), 'input 1');
+    assert.equal(find('.input2-value').val(), 'input 2');
+    assert.equal(find('.input3-value').val(), 'input 3');
+    assert.equal(find('.input4-value').val(), 'input 4');
+    assert.equal(find('.input5-value').val(), 'input 5');
+  });
+
+  page
+    .fillIn('textarea1', 'textarea 1')
+    .fillIn('textarea2', 'textarea 2')
+    .fillIn('textarea3', 'textarea 3')
+    .fillIn('textarea4', 'textarea 4')
+    .fillIn('textarea5', 'textarea 5');
+
+  andThen(function() {
+    assert.equal(find('.textarea1-value').val(), 'textarea 1');
+    assert.equal(find('.textarea2-value').val(), 'textarea 2');
+    assert.equal(find('.textarea3-value').val(), 'textarea 3');
+    assert.equal(find('.textarea4-value').val(), 'textarea 4');
+    assert.equal(find('.textarea5-value').val(), 'textarea 5');
+  });
+
+  page
+    .fillIn('select1', 'select 1 option 2')
+    .fillIn('select2', 'select 2 option 2')
+    .fillIn('select3', 'select 3 option 2')
+    .fillIn('select4', 'select 4 option 2')
+    .fillIn('select5', 'select 5 option 2');
+
+  andThen(function() {
+    assert.equal(find('.select1-value').val(), 'select 1 option 2');
+    assert.equal(find('.select2-value').val(), 'select 2 option 2');
+    assert.equal(find('.select3-value').val(), 'select 3 option 2');
+    assert.equal(find('.select4-value').val(), 'select 4 option 2');
+    assert.equal(find('.select5-value').val(), 'select 5 option 2');
+  });
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -7,6 +7,7 @@ const Router = Ember.Router.extend({
 
 Router.map(function() {
   this.route('calculator');
+  this.route('inputs');
 });
 
 export default Router;

--- a/tests/dummy/app/templates/inputs.hbs
+++ b/tests/dummy/app/templates/inputs.hbs
@@ -1,0 +1,34 @@
+<div class="inputs-and-selects">
+  <input name="input1"        class="input1-value">
+  <input id="input2"          class="input2-value">
+  <input placeholder="input3" class="input3-value">
+  <input data-test="input4"   class="input4-value">
+  <input aria-label="input5"  class="input5-value">
+
+  <textarea name="textarea1"        class="textarea1-value"></textarea>
+  <textarea id="textarea2"          class="textarea2-value"></textarea>
+  <textarea placeholder="textarea3" class="textarea3-value"></textarea>
+  <textarea data-test="textarea4"   class="textarea4-value"></textarea>
+  <textarea aria-label="textarea5"  class="textarea5-value"></textarea>
+
+  <select name="select1"        class="select1-value">
+    <option selected>select 1 option 1</option>
+    <option>select 1 option 2</option>
+  </select>
+  <select id="select2"          class="select2-value">
+    <option selected>select 2 option 1</option>
+    <option>select 2 option 2</option>
+  </select>
+  <select placeholder="select3" class="select3-value">
+    <option selected>select 3 option 1</option>
+    <option>select 3 option 2</option>
+  </select>
+  <select data-test="select4"   class="select4-value">
+    <option selected>select 4 option 1</option>
+    <option>select 4 option 2</option>
+  </select>
+  <select aria-label="select5"  class="select5-value">
+    <option selected>select 5 option 1</option>
+    <option>select 5 option 2</option>
+  </select>
+</div>

--- a/tests/properties/fillable-test.js
+++ b/tests/properties/fillable-test.js
@@ -23,6 +23,43 @@ moduleForProperty('fillable', function(test, adapter) {
     page.foo(expectedText);
   });
 
+  test('looks for inputs with data-test="clue" attributes', function(assert) {
+    let expectedText = 'dummy text';
+    let clue = 'clue';
+    let page;
+
+    page = create({
+      scope: '.scope',
+
+      foo: fillable()
+    });
+
+    adapter.createTemplate(this, page, '<div class="scope"><input data-test="clue"></div>');
+
+    adapter.fillIn((actualSelector, actualContext, actualText) => {
+      assert.ok(/.scope input\[data-test="clue"\]/.test(actualSelector));
+      assert.ok(/.scope input\[aria-label="clue"\]/.test(actualSelector));
+      assert.ok(/.scope input\[placeholder="clue"\]/.test(actualSelector));
+      assert.ok(/.scope input\[name="clue"\]/.test(actualSelector));
+      assert.ok(/.scope input#clue/.test(actualSelector));
+
+      assert.ok(/.scope textarea\[data-test="clue"\]/.test(actualSelector));
+      assert.ok(/.scope textarea\[aria-label="clue"\]/.test(actualSelector));
+      assert.ok(/.scope textarea\[placeholder="clue"\]/.test(actualSelector));
+      assert.ok(/.scope textarea\[name="clue"\]/.test(actualSelector));
+      assert.ok(/.scope textarea#clue/.test(actualSelector));
+
+      assert.ok(/.scope select\[data-test="clue"\]/.test(actualSelector));
+      assert.ok(/.scope select\[aria-label="clue"\]/.test(actualSelector));
+      assert.ok(/.scope select\[placeholder="clue"\]/.test(actualSelector));
+      assert.ok(/.scope select\[name="clue"\]/.test(actualSelector));
+      assert.ok(/.scope select#clue/.test(actualSelector));
+      assert.equal(actualText, expectedText);
+    });
+
+    page.foo(clue, expectedText);
+  });
+
   test('looks for elements inside the scope', function(assert) {
     assert.expect(1);
 

--- a/tests/unit/create-test.js
+++ b/tests/unit/create-test.js
@@ -62,7 +62,7 @@ test('generates .isHidden property', function(assert) {
   assert.ok(page.foo.isHidden, 'component is hidden');
 });
 
-['isVisible', 'isHidden', 'clickOn', 'click', 'contains', 'text'].forEach((prop) => {
+['isVisible', 'isHidden', 'clickOn', 'click', 'contains', 'text', 'fillIn', 'select'].forEach((prop) => {
   test(`does not override .${prop} property`, function(assert) {
     let page = create({
       [prop]: 'foo bar'
@@ -105,7 +105,7 @@ test('generates .click property', function(assert) {
   page.foo.click();
 });
 
-test('generates .click property', function(assert) {
+test('generates .contains property', function(assert) {
   fixture('Ipsum <span>Dolor</span>');
 
   let page = create({
@@ -132,6 +132,40 @@ test('generates .text property', function(assert) {
 
   assert.equal(page.text, 'Ipsum Dolor');
   assert.equal(page.foo.text, 'Dolor');
+});
+
+test('generates .fillIn property', function(assert) {
+  fixture('<input name="email">');
+  assert.expect(1);
+
+  window.fillIn = function(selector, text) {
+    assert.equal(text, 'lorem ipsum');
+  };
+
+  let page = create({
+    foo: {
+      scope: 'input'
+    }
+  });
+
+  page.foo.fillIn('lorem ipsum');
+});
+
+test('generates .select property', function(assert) {
+  fixture('<input name="email">');
+  assert.expect(1);
+
+  window.fillIn = function(selector, text) {
+    assert.equal(text, 'lorem ipsum');
+  };
+
+  let page = create({
+    foo: {
+      scope: 'input'
+    }
+  });
+
+  page.foo.select('lorem ipsum');
 });
 
 test('generates .then property', function(assert) {


### PR DESCRIPTION
This PR enhances the `fillable` property to support an additional `clue` parameter when filling a value. This value is used to filter the target input value.

It also adds `fillIn` and `select` as default properties to every page object component.

e.g.

```html
<input id="foo">
<input name="bar">
<input placeholder="baz">
```

```
const page = create({});

page
  .fillIn('foo', 'value for input foo')
  .fillIn('bar', 'value for input bar')
  .fillIn('baz', 'value for input baz');
```

Note that the first parameter is optional and if used, it will filter the target input.

Apart from working with `input`s, this works with `textarea`s and `select`s HTML elements, and the rules that are used to filter the elements are

```
.scope input[data-test="${clue}"],
.scope input[aria-label="${clue}"],
.scope input[placeholder="${clue}"],
.scope input[name="${clue}"],
.scope input#${clue}

.scope textarea[data-test="${clue}"],
.scope textarea[aria-label="${clue}"],
.scope textarea[placeholder="${clue}"],
.scope textarea[name="${clue}"],
.scope textarea#${clue}

.scope select[data-test="${clue}"],
.scope select[aria-label="${clue}"],
.scope select[placeholder="${clue}"],
.scope select[name="${clue}"],
.scope select#${clue}
```

More rules can be added on the future if this proves to be useful, What do you think? cc/ @juanazam @jeradg 