### PR TITLE
Add path param to `create` helper

### DIFF
--- a/addon/-private/create.js
+++ b/addon/-private/create.js
@@ -6,6 +6,7 @@ import { contains } from './properties/contains';
 import { clickOnText } from './properties/click-on-text';
 import { clickable } from './properties/clickable';
 import { fillable } from './properties/fillable';
+import { visitable } from './properties/visitable';
 import { render, setContext, removeContext } from './context';
 import { assign } from './helpers';
 
@@ -110,6 +111,24 @@ function buildObject(node, blueprintKey, blueprint, defaultBuilder) {
  * // selects an option
  * page.select('country', 'Uruguay');
  *
+ * @example Defining path
+ *
+ * const usersPage = PageObject.create('/users');
+ *
+ * // visits user page
+ * usersPage.visit();
+ *
+ * const userTasksPage = PageObject.create('/users/tasks', {
+ *  tasks: collection({
+ *    itemScope: '.tasks li',
+ *    item: {}
+ *  });
+ * });
+ *
+ * // get user's tasks
+ * userTasksPage.visit();
+ * userTasksPage.tasks().count
+ *
  * @public
  *
  * @param {Object} definition - PageObject definition
@@ -117,8 +136,27 @@ function buildObject(node, blueprintKey, blueprint, defaultBuilder) {
  * @param {Object} options - [private] Ceibo options. Do not use!
  * @return {PageObject}
  */
-export function create(definition, options = {}) {
+export function create(definitionOrUrl, definitionOrOptions, optionsOrNothing) {
+  let definition;
+  let url;
+  let options;
+
+  if (typeof (definitionOrUrl) === 'string') {
+    url = definitionOrUrl;
+    definition = definitionOrOptions || {};
+    options = optionsOrNothing || {};
+  } else {
+    url = false;
+    definition = definitionOrUrl;
+    options = definitionOrOptions || {};
+  }
+
   definition = assign({}, definition);
+
+  if (url) {
+    definition.visit = visitable(url);
+  }
+
   let { context } = definition;
   delete definition.context;
 

--- a/tests/unit/create-test.js
+++ b/tests/unit/create-test.js
@@ -16,6 +16,31 @@ test('creates new page object', function(assert) {
   assert.equal(page.bar.baz, 'another value');
 });
 
+test('generates default visit helper', function(assert) {
+  assert.expect(1);
+  let page = create('/foo');
+
+  window.visit = function(path) {
+    assert.equal(path, '/foo');
+  };
+
+  page.visit();
+});
+
+test('generates default visit helper plus a definition', function(assert) {
+  fixture('<span>dummy text</span>');
+  assert.expect(2);
+
+  let page = create('/foo', { foo: text('span') });
+
+  window.visit = function(path) {
+    assert.equal(path, '/foo');
+  };
+
+  page.visit();
+  assert.equal(page.foo, 'dummy text');
+});
+
 test('resets scope', function(assert) {
   fixture(`
     <div>


### PR DESCRIPTION
Allows to configure a path for the page object which auto-generates a
visitable helper. This commit augments the `create` helper to add an
optional first parameter.

```js
const page = create('/foo');

page.visit(); // navigates to /foo
```

You can pass a second parameter with the PO definition

```js
const page = create('/foo', { /* PO definition */ });
```