### PR TITLE
add node-tests to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
+  - EMBER_TRY_SCENARIO=node-tests
 
 matrix:
   fast_finish: true

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -66,6 +66,13 @@ module.exports = {
           'ember': 'canary'
         }
       }
+    },
+    {
+      name: 'node-tests',
+      command: 'npm run nodetest',
+      bower: {
+        dependencies: {}
+      }
     }
   ]
 };


### PR DESCRIPTION
This should run `npm run nodetest` on Travis as a separate parallel job.