### PR TITLE
Add `as` property to DSL.

### DIFF
--- a/addon/-private/dsl.js
+++ b/addon/-private/dsl.js
@@ -15,6 +15,11 @@ const thenDescriptor = {
   }
 };
 
+const as = function(cb) {
+  cb(this);
+  return this;
+};
+
 const dsl = {
   contains: contains(),
   isHidden: isHidden(),
@@ -25,7 +30,8 @@ const dsl = {
   click: clickable(),
   fillIn: fillable(),
   select: fillable(),
-  then: thenDescriptor
+  then: thenDescriptor,
+  as
 };
 
 export default dsl;

--- a/tests/properties/dsl-test.js
+++ b/tests/properties/dsl-test.js
@@ -1,5 +1,5 @@
 import { moduleForProperty } from '../helpers/properties';
-import { create } from 'ember-cli-page-object';
+import { create, collection } from 'ember-cli-page-object';
 
 moduleForProperty('dsl', function(test) {
   test('generates .isVisible', function(assert) {
@@ -171,5 +171,68 @@ moduleForProperty('dsl', function(test) {
 
     assert.ok(typeof (page.then) === 'function');
     assert.ok(typeof (page.foo.then) === 'function');
+  });
+
+  test('generates .as', function(assert) {
+    assert.expect(2);
+
+    let page = create({
+      scope: 'span',
+      foo: {
+        baz: 'foobar'
+      }
+    });
+
+    this.adapter.createTemplate(this, page, 'Lorem <span>ipsum</span>');
+
+    let foo = page.foo.as(element => {
+      assert.equal(element.text, 'ipsum');
+    });
+
+    assert.equal(foo.baz, 'foobar');
+  });
+
+  test('generates .as when nested', function(assert) {
+    assert.expect(1);
+
+    let page = create({
+      scope: 'span',
+      foo: {
+        bar: {
+          scope: 'strong'
+        }
+      }
+    });
+
+    this.adapter.createTemplate(this, page, 'Lorem <span>ipsum <strong>dolor</strong></span>');
+
+    page.foo.bar.as(element => {
+      assert.equal(element.text, 'dolor');
+    });
+  });
+
+  test('generates .as in collections', function(assert) {
+    assert.expect(2);
+
+    let page = create({
+      items: collection({
+        itemScope: 'ul li'
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <ul>
+        <li>foo</li>
+        <li>bar</li>
+      </ul>
+    `);
+
+    page.items(0).as(item => {
+      assert.equal(item.text, 'foo');
+    });
+
+    page.items(1).as(item => {
+      assert.equal(item.text, 'bar');
+    });
   });
 });


### PR DESCRIPTION
Implements https://github.com/san650/ember-cli-page-object/issues/227.

It works on any page object node, not just collections.

Fixes #227.