### PR TITLE
Make node-test run first in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,13 @@ cache:
     - node_modules
 
 env:
+  - EMBER_TRY_SCENARIO=node-tests
   - EMBER_TRY_SCENARIO=ember-1.12
   - EMBER_TRY_SCENARIO=ember-1.13
   - EMBER_TRY_SCENARIO=ember-lts-2.4
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
-  - EMBER_TRY_SCENARIO=node-tests
 
 matrix:
   fast_finish: true
@@ -25,10 +25,9 @@ matrix:
 
 before_install:
   - npm config set spin false
-  - npm install -g bower
+  - npm install -g bower phantomjs-prebuilt
   - bower --version
-  - npm install phantomjs-prebuilt
-  - node_modules/phantomjs-prebuilt/bin/phantomjs --version
+  - phantomjs --version
 
 install:
   - npm install


### PR DESCRIPTION
Right now `node-test` is the last build to start in Travis and it's also the slowest, by making it the first one to start we can reduce the overall time the CI takes to finish.