### PR TITLE
Fix jsdoc lining errors

### DIFF
--- a/addon/-private/extend/find-element-with-assert.js
+++ b/addon/-private/extend/find-element-with-assert.js
@@ -28,8 +28,8 @@ import { getExecutionContext } from '../execution_context';
  * @param {boolean} options.last - Filter by using :last pseudo-class
  * @param {boolean} options.visible - Filter by using :visible pseudo-class
  * @param {boolean} options.multiple - Specify if built selector can match multiple elements.
- * @param {String} options.testContainer - Context where to search elements in the DOM
- * @param {String} options.pageObjectKey - Used in the error message when the element is not found
+ * @param {string} options.testContainer - Context where to search elements in the DOM
+ * @param {string} options.pageObjectKey - Used in the error message when the element is not found
  * @return {Object} jQuery object
  *
  * @throws Will throw an error if no element matches selector

--- a/addon/-private/extend/find-element.js
+++ b/addon/-private/extend/find-element.js
@@ -28,7 +28,7 @@ import { getExecutionContext } from '../execution_context';
  * @param {boolean} options.last - Filter by using :last pseudo-class
  * @param {boolean} options.visible - Filter by using :visible pseudo-class
  * @param {boolean} options.multiple - Specify if built selector can match multiple elements.
- * @param {String} options.testContainer - Context where to search elements in the DOM
+ * @param {string} options.testContainer - Context where to search elements in the DOM
  * @return {Object} jQuery object
  *
  * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set

--- a/addon/-private/helpers.js
+++ b/addon/-private/helpers.js
@@ -237,7 +237,7 @@ export function fullScope(node) {
  * node.
  *
  * @param {Ceibo} node - Node of the tree
- * @param {String} property - Property to look for
+ * @param {string} property - Property to look for
  * @return {?Object} The value of property on closest node to the given node
  */
 export function findClosestValue(node, property) {

--- a/addon/-private/properties/attribute.js
+++ b/addon/-private/properties/attribute.js
@@ -61,7 +61,7 @@ import { getExecutionContext } from '../execution_context';
  * @param {boolean} options.resetScope - Override parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.multiple - If set, the function will return an array of values
- * @param {String} options.testContainer - Context where to search elements in the DOM
+ * @param {string} options.testContainer - Context where to search elements in the DOM
  * @return {Descriptor}
  *
  * @throws Will throw an error if no element matches selector

--- a/addon/-private/properties/click-on-text.js
+++ b/addon/-private/properties/click-on-text.js
@@ -75,7 +75,7 @@ import { buildSelector } from './click-on-text/helpers';
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.visible - Make the action to raise an error if the element is not visible
  * @param {boolean} options.resetScope - Override parent's scope
- * @param {String} options.testContainer - Context where to search elements in the DOM
+ * @param {string} options.testContainer - Context where to search elements in the DOM
  * @return {Descriptor}
  */
 export function clickOnText(selector, userOptions = {}) {

--- a/addon/-private/properties/clickable.js
+++ b/addon/-private/properties/clickable.js
@@ -53,7 +53,7 @@ import { getExecutionContext } from '../execution_context';
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.visible - Make the action to raise an error if the element is not visible
  * @param {boolean} options.resetScope - Ignore parent scope
- * @param {String} options.testContainer - Context where to search elements in the DOM
+ * @param {string} options.testContainer - Context where to search elements in the DOM
  * @return {Descriptor}
  */
 export function clickable(selector, userOptions = {}) {

--- a/addon/-private/properties/collection.js
+++ b/addon/-private/properties/collection.js
@@ -198,7 +198,7 @@ function iteratorMethod() {
  * @param {Object} definition - Collection definition
  * @param {string} definition.scope - Nests provided scope within parent's scope
  * @param {boolean} definition.resetScope - Override parent's scope
- * @param {String} definition.itemScope - CSS selector
+ * @param {string} definition.itemScope - CSS selector
  * @param {Object} definition.item - Item definition
  * @return {Descriptor}
  */

--- a/addon/-private/properties/contains.js
+++ b/addon/-private/properties/contains.js
@@ -75,7 +75,7 @@ import { getExecutionContext } from '../execution_context';
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.resetScope - Override parent's scope
  * @param {boolean} options.multiple - Check if all elements matched by selector contain the subtext
- * @param {String} options.testContainer - Context where to search elements in the DOM
+ * @param {string} options.testContainer - Context where to search elements in the DOM
  * @return {Descriptor}
  *
  * @throws Will throw an error if no element matches selector

--- a/addon/-private/properties/count.js
+++ b/addon/-private/properties/count.js
@@ -68,7 +68,7 @@ import { getExecutionContext } from '../execution_context';
  * @param {Object} options - Additional options
  * @param {string} options.scope - Add scope
  * @param {boolean} options.resetScope - Ignore parent scope
- * @param {String} options.testContainer - Context where to search elements in the DOM
+ * @param {string} options.testContainer - Context where to search elements in the DOM
  * @return {Descriptor}
  */
 export function count(selector, userOptions = {}) {

--- a/addon/-private/properties/fillable.js
+++ b/addon/-private/properties/fillable.js
@@ -16,7 +16,7 @@ import { getExecutionContext } from '../execution_context';
  * @param {string} options.scope - Nests provided scope within parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.resetScope - Override parent's scope
- * @param {String} options.testContainer - Context where to search elements in the DOM
+ * @param {string} options.testContainer - Context where to search elements in the DOM
  * @return {Descriptor}
  */
 
@@ -101,7 +101,7 @@ import { getExecutionContext } from '../execution_context';
  * @param {string} options.scope - Nests provided scope within parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.resetScope - Override parent's scope
- * @param {String} options.testContainer - Context where to search elements in the DOM
+ * @param {string} options.testContainer - Context where to search elements in the DOM
  * @return {Descriptor}
  */
 export function fillable(selector, userOptions = {}) {

--- a/addon/-private/properties/has-class.js
+++ b/addon/-private/properties/has-class.js
@@ -76,7 +76,7 @@ import { getExecutionContext } from '../execution_context';
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.resetScope - Override parent's scope
  * @param {boolean} options.multiple - Check if all elements matched by selector have the CSS class
- * @param {String} options.testContainer - Context where to search elements in the DOM
+ * @param {string} options.testContainer - Context where to search elements in the DOM
  * @return {Descriptor}
  *
  * @throws Will throw an error if no element matches selector

--- a/addon/-private/properties/is-hidden.js
+++ b/addon/-private/properties/is-hidden.js
@@ -82,7 +82,7 @@ import { getExecutionContext } from '../execution_context';
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.resetScope - Override parent's scope
  * @param {boolean} options.multiple - Check if all elements matched by selector are hidden
- * @param {String} options.testContainer - Context where to search elements in the DOM
+ * @param {string} options.testContainer - Context where to search elements in the DOM
  * @return {Descriptor}
  *
  * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set

--- a/addon/-private/properties/is-visible.js
+++ b/addon/-private/properties/is-visible.js
@@ -88,7 +88,7 @@ import { getExecutionContext } from '../execution_context';
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.resetScope - Override parent's scope
  * @param {boolean} options.multiple - Check if all elements matched by selector are visible
- * @param {String} options.testContainer - Context where to search elements in the DOM
+ * @param {string} options.testContainer - Context where to search elements in the DOM
  * @return {Descriptor}
  *
  * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set

--- a/addon/-private/properties/is.js
+++ b/addon/-private/properties/is.js
@@ -36,7 +36,7 @@ import { getExecutionContext } from '../execution_context';
  * @param {boolean} options.resetScope - Override parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.multiple - If set, the function will return an array of values
- * @param {String} options.testContainer - Context where to search elements in the DOM
+ * @param {string} options.testContainer - Context where to search elements in the DOM
  * @return {Descriptor}
  *
  * @throws Will throw an error if no element matches selector

--- a/addon/-private/properties/not-has-class.js
+++ b/addon/-private/properties/not-has-class.js
@@ -80,7 +80,7 @@ import { getExecutionContext } from '../execution_context';
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.resetScope - Override parent's scope
  * @param {boolean} options.multiple - Check if all elements matched by selector don't have the CSS class
- * @param {String} options.testContainer - Context where to search elements in the DOM
+ * @param {string} options.testContainer - Context where to search elements in the DOM
  * @return {Descriptor}
  *
  * @throws Will throw an error if no element matches selector

--- a/addon/-private/properties/text.js
+++ b/addon/-private/properties/text.js
@@ -83,7 +83,7 @@ function identity(v) {
  * @param {boolean} options.resetScope - Override parent's scope
  * @param {boolean} options.multiple - Return an array of values
  * @param {boolean} options.normalize - Set to `false` to avoid text normalization
- * @param {String} options.testContainer - Context where to search elements in the DOM
+ * @param {string} options.testContainer - Context where to search elements in the DOM
  * @return {Descriptor}
  *
  * @throws Will throw an error if no element matches selector

--- a/addon/-private/properties/triggerable.js
+++ b/addon/-private/properties/triggerable.js
@@ -66,8 +66,8 @@ import { getExecutionContext } from '../execution_context';
  * @param {string} options.scope - Nests provided scope within parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.resetScope - Ignore parent scope
- * @param {String} options.testContainer - Context where to search elements in the DOM
- * @param {String} options.eventProperties - Event properties that will be passed to trigger function
+ * @param {string} options.testContainer - Context where to search elements in the DOM
+ * @param {string} options.eventProperties - Event properties that will be passed to trigger function
  * @return {Descriptor}
 */
 export function triggerable(event, selector, userOptions = {}) {

--- a/addon/-private/properties/value.js
+++ b/addon/-private/properties/value.js
@@ -58,7 +58,7 @@ import { getExecutionContext } from '../execution_context';
  * @param {boolean} options.resetScope - Override parent's scope
  * @param {number} options.at - Reduce the set of matched elements to the one at the specified index
  * @param {boolean} options.multiple - If set, the function will return an array of values
- * @param {String} options.testContainer - Context where to search elements in the DOM
+ * @param {string} options.testContainer - Context where to search elements in the DOM
  * @return {Descriptor}
  *
  * @throws Will throw an error if no element matches selector


### PR DESCRIPTION
The linter can be run like `find addon -type f -name '*.js' -exec node node_modules/documentation/bin/documentation.js --lint --shallow {} \;`