### PR TITLE
Add value as default component attribute

### DIFF
--- a/docs/v1.6.x/components.md
+++ b/docs/v1.6.x/components.md
@@ -65,6 +65,7 @@ By default, all components define some handy attributes and methods without bein
 * [isHidden](/docs/v1.6.x/api/properties#ishidden)
 * [select](/docs/v1.6.x/api/properties#selectable)
 * [text](/docs/v1.6.x/api/properties#text)
+* [value](/docs/v1.6.x/api/properties#value)
 
 <div class="alert alert-warning" role="alert">
   <strong>Note</strong> that these attributes will use the component scope as their selector.

--- a/docs/v1.7.x/components.md
+++ b/docs/v1.7.x/components.md
@@ -65,6 +65,7 @@ By default, all components define some handy attributes and methods without bein
 * [isHidden](/docs/v1.6.x/api/properties#ishidden)
 * [select](/docs/v1.6.x/api/properties#selectable)
 * [text](/docs/v1.6.x/api/properties#text)
+* [value](/docs/v1.7.x/api/value)
 
 <div class="alert alert-warning" role="alert">
   <strong>Note</strong> that these attributes will use the component scope as their selector.

--- a/docs/v1.8.x/components.md
+++ b/docs/v1.8.x/components.md
@@ -65,6 +65,7 @@ By default, all components define some handy attributes and methods without bein
 * [isHidden](/docs/v1.6.x/api/properties#ishidden)
 * [select](/docs/v1.6.x/api/properties#selectable)
 * [text](/docs/v1.6.x/api/properties#text)
+* [value](/docs/v1.8.x/api/value)
 
 <div class="alert alert-warning" role="alert">
   <strong>Note</strong> that these attributes will use the component scope as their selector.


### PR DESCRIPTION
This is true according to the 1.6.0 release notes:
https://github.com/san650/ember-cli-page-object/releases/tag/v1.6.0

Note that these don’t exactly align to the links in each file as I believe they are incorrect… another PR forthcoming.