### PR TITLE
Correct property links to be in current version

### DIFF
--- a/docs/v1.7.x/api/create.md
+++ b/docs/v1.7.x/api/create.md
@@ -16,14 +16,14 @@ Creates a new PageObject.
 
 By default, the resulting PageObject will respond to:
 
-* [click](/docs/v1.6.x/api/properties#clickable)
-* [clickOn](/docs/v1.6.x/api/properties#clickontext)
-* [contains](/docs/v1.6.x/api/properties#contains)
-* [fillIn](/docs/v1.6.x/api/properties#fillable)
-* [isVisible](/docs/v1.6.x/api/properties#isvisible)
-* [isHidden](/docs/v1.6.x/api/properties#ishidden)
-* [select](/docs/v1.6.x/api/properties#selectable)
-* [text](/docs/v1.6.x/api/properties#text)
+* [click](/docs/v1.7.x/api/clickable)
+* [clickOn](/docs/v1.7.x/api/click-on-text)
+* [contains](/docs/v1.7.x/api/contains)
+* [fillIn](/docs/v1.7.x/api/fillable)
+* [isVisible](/docs/v1.7.x/api/is-visible)
+* [isHidden](/docs/v1.7.x/api/is-hidden)
+* [select](/docs/v1.7.x/api/selectable)
+* [text](/docs/v1.7.x/api/text)
 
 `definition` can include a key `context`, which is an
 optional integration test `this` context.

--- a/docs/v1.7.x/components.md
+++ b/docs/v1.7.x/components.md
@@ -57,14 +57,14 @@ andThen(function() {
 
 By default, all components define some handy attributes and methods without being explicitely declared.
 
-* [click](/docs/v1.6.x/api/properties#clickable)
-* [clickOn](/docs/v1.6.x/api/properties#clickontext)
-* [contains](/docs/v1.6.x/api/properties#contains)
-* [fillIn](/docs/v1.6.x/api/properties#fillable)
-* [isVisible](/docs/v1.6.x/api/properties#isvisible)
-* [isHidden](/docs/v1.6.x/api/properties#ishidden)
-* [select](/docs/v1.6.x/api/properties#selectable)
-* [text](/docs/v1.6.x/api/properties#text)
+* [click](/docs/v1.7.x/api/clickable)
+* [clickOn](/docs/v1.7.x/api/click-on-text)
+* [contains](/docs/v1.7.x/api/contains)
+* [fillIn](/docs/v1.7.x/api/fillable)
+* [isVisible](/docs/v1.7.x/api/is-visible)
+* [isHidden](/docs/v1.7.x/api/is-hidden)
+* [select](/docs/v1.7.x/api/selectable)
+* [text](/docs/v1.7.x/api/text)
 
 <div class="alert alert-warning" role="alert">
   <strong>Note</strong> that these attributes will use the component scope as their selector.

--- a/docs/v1.8.x/api/create.md
+++ b/docs/v1.8.x/api/create.md
@@ -16,14 +16,14 @@ Creates a new PageObject.
 
 By default, the resulting PageObject will respond to:
 
-* [click](/docs/v1.6.x/api/properties#clickable)
-* [clickOn](/docs/v1.6.x/api/properties#clickontext)
-* [contains](/docs/v1.6.x/api/properties#contains)
-* [fillIn](/docs/v1.6.x/api/properties#fillable)
-* [isVisible](/docs/v1.6.x/api/properties#isvisible)
-* [isHidden](/docs/v1.6.x/api/properties#ishidden)
-* [select](/docs/v1.6.x/api/properties#selectable)
-* [text](/docs/v1.6.x/api/properties#text)
+* [click](/docs/v1.8.x/api/clickable)
+* [clickOn](/docs/v1.8.x/api/click-on-text)
+* [contains](/docs/v1.8.x/api/contains)
+* [fillIn](/docs/v1.8.x/api/fillable)
+* [isVisible](/docs/v1.8.x/api/is-visible)
+* [isHidden](/docs/v1.8.x/api/is-hidden)
+* [select](/docs/v1.8.x/api/selectable)
+* [text](/docs/v1.8.x/api/text)
 
 `definition` can include a key `context`, which is an
 optional integration test `this` context.

--- a/docs/v1.8.x/components.md
+++ b/docs/v1.8.x/components.md
@@ -57,14 +57,14 @@ andThen(function() {
 
 By default, all components define some handy attributes and methods without being explicitely declared.
 
-* [click](/docs/v1.6.x/api/properties#clickable)
-* [clickOn](/docs/v1.6.x/api/properties#clickontext)
-* [contains](/docs/v1.6.x/api/properties#contains)
-* [fillIn](/docs/v1.6.x/api/properties#fillable)
-* [isVisible](/docs/v1.6.x/api/properties#isvisible)
-* [isHidden](/docs/v1.6.x/api/properties#ishidden)
-* [select](/docs/v1.6.x/api/properties#selectable)
-* [text](/docs/v1.6.x/api/properties#text)
+* [click](/docs/v1.8.x/api/clickable)
+* [clickOn](/docs/v1.8.x/api/click-on-text)
+* [contains](/docs/v1.8.x/api/contains)
+* [fillIn](/docs/v1.8.x/api/fillable)
+* [isVisible](/docs/v1.8.x/api/is-visible)
+* [isHidden](/docs/v1.8.x/api/is-hidden)
+* [select](/docs/v1.8.x/api/selectable)
+* [text](/docs/v1.8.x/api/text)
 
 <div class="alert alert-warning" role="alert">
   <strong>Note</strong> that these attributes will use the component scope as their selector.


### PR DESCRIPTION
Hey, it seemed to me that these links should be within the version you’re currently looking at, rather than always to 1.6.x, do you agree?