### PR TITLE
Do not use assert.throws when testing actions in integration tests

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -35,6 +35,17 @@ module.exports = {
       }
     },
     {
+      name: 'ember-lts-2.8',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#lts-2-8'
+        },
+        resolutions: {
+          'ember': 'lts-2-8'
+        }
+      }
+    },
+    {
       name: 'ember-release',
       bower: {
         dependencies: {

--- a/node-tests/blueprints/component-test-test.js
+++ b/node-tests/blueprints/component-test-test.js
@@ -11,9 +11,9 @@ var expect = require('ember-cli-blueprint-test-helpers/chai').expect;
 
 var generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
 
-describe('Acceptance: ember generate and destroy component-test', function() {
+describe('Blueprints: ember generate and destroy component-test', function() {
   setupTestHooks(this);
-  
+
   describe('Run default component-test blueprint', function() {
 
     it('component-test x-foo', function() {

--- a/node-tests/blueprints/page-object-component-test.js
+++ b/node-tests/blueprints/page-object-component-test.js
@@ -7,7 +7,7 @@ var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
 
 var expect = require('ember-cli-blueprint-test-helpers/chai').expect;
 
-describe('Blueprints: ember generate and destroy page-object', function() {
+describe('Blueprints: ember generate and destroy page-object-component', function() {
   setupTestHooks(this);
 
   it('generates a page-object component in an ember app', function() {

--- a/tests/helpers/properties/integration-adapter.js
+++ b/tests/helpers/properties/integration-adapter.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import { fixture } from './acceptance-adapter';
 export { moduleForComponent as moduleForIntegration, test as testForIntegration } from 'ember-qunit';
+import { expectEmberError } from '../../test-helper';
 
 export function IntegrationAdapter(original) {
   this.original = original;
@@ -52,7 +53,9 @@ IntegrationAdapter.prototype = {
   },
 
   throws(assert, block, expected, message) {
-    assert.throws(block, expected, message);
+    Ember.run(() => {
+      expectEmberError(assert, block, expected, message);
+    });
   },
 
   andThen(fn) {

--- a/tests/integration/actions-test.js
+++ b/tests/integration/actions-test.js
@@ -1,5 +1,7 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import { createTemplate } from './test-helper';
+import { expectEmberError } from '../test-helper';
 
 import PageObject, {
   collection,
@@ -16,6 +18,8 @@ import PageObject, {
   isHidden,
   isVisible
 } from 'dummy/tests/page-object';
+
+const { run } = Ember;
 
 const button = function(scope) {
   return {
@@ -157,15 +161,33 @@ test('Queries and actions handle non-existant elements correctly', function(asse
 
   page.render(template);
 
-  assert.throws(() => page.nonExistant.attribute(), message, 'attribute query did not throw an error');
-  assert.throws(() => page.nonExistant.clickOnText('qux'), message, 'clickOnText action did not throw an error');
-  assert.throws(() => page.nonExistant.clickable(), message, 'clickable action did not throw an error');
-  assert.throws(() => page.nonExistant.contains('something'), message, 'contains action did not throw an error');
-  assert.throws(() => page.nonExistant.fillable('baz'), message, 'fillable action did not throw an error');
-  assert.throws(() => page.nonExistant.hasClass, message, 'hasClass query did not throw an error');
-  assert.throws(() => page.nonExistant.notHasClass, message, 'notHasClass query did not throw an error');
-  assert.throws(() => page.nonExistant.text, message, 'text query did not throw an error');
-  assert.throws(() => page.nonExistant.value, message, 'value query did not throw an error');
+  run(() => {
+    assert.throws(() => page.nonExistant.attribute(), message, 'attribute query did not throw an error');
+  });
+  run(() => {
+    expectEmberError(assert, () => page.nonExistant.clickOnText('qux'), message, 'clickOnText action did not throw an error');
+  });
+  run(() => {
+    expectEmberError(assert, () => page.nonExistant.clickable(), message, 'clickable action did not throw an error');
+  });
+  run(() => {
+    assert.throws(() => page.nonExistant.contains('something'), message, 'contains action did not throw an error');
+  });
+  run(() => {
+    expectEmberError(assert, () => page.nonExistant.fillable('baz'), message, 'fillable action did not throw an error');
+  });
+  run(() => {
+    assert.throws(() => page.nonExistant.hasClass, message, 'hasClass query did not throw an error');
+  });
+  run(() => {
+    assert.throws(() => page.nonExistant.notHasClass, message, 'notHasClass query did not throw an error');
+  });
+  run(() => {
+    assert.throws(() => page.nonExistant.text, message, 'text query did not throw an error');
+  });
+  run(() => {
+    assert.throws(() => page.nonExistant.value, message, 'value query did not throw an error');
+  });
 
   assert.equal(page.nonExistant.count, 0);
   assert.equal(page.nonExistant.isHidden, true);

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,6 +1,45 @@
+import Ember from 'ember';
 import resolver from './helpers/resolver';
 import {
   setResolver
 } from 'ember-qunit';
 
 setResolver(resolver);
+
+
+// ember@2.11.3 introduces a (breaking?) change in how the errors are propagated
+// in backburner which causes some test that were previously working, to fail.
+//
+// See https://github.com/emberjs/ember.js/pull/14898#issuecomment-285510703
+
+// We need to use this hack to test with >= 2.11
+function useHack() {
+  var [major, minor] = Ember.VERSION.split('.');
+  major = Number(major);
+  minor = Number(minor);
+
+  return (major === 2 && minor >= 11) || major > 2;
+}
+
+export function expectEmberError(assert, callback, matcher, message) {
+  if (useHack()) {
+    let origTestAdapter = Ember.Test.adapter;
+    let testError;
+    let TestAdapter = Ember.Test.QUnitAdapter.extend({
+      exception(error) {
+        testError = error;
+      }
+    });
+
+    Ember.run(() => { Ember.Test.adapter = TestAdapter.create(); });
+    callback();
+    Ember.run(() => {
+      Ember.Test.adapter.destroy();
+    });
+    Ember.Test.adapter = origTestAdapter;
+
+    assert.ok(testError && testError.message.match(matcher), message);
+  } else {
+    assert.throws(callback, matcher, message);
+  }
+}


### PR DESCRIPTION
ember@2.11.3 introduces a (breaking?) change in how exceptions are
propagated in backburner which causes some test that were previously
working, to fail.

See https://github.com/emberjs/ember.js/pull/14898#issuecomment-285510703

Also fix some descriptions in blueprint tests