### PR TITLE
Use throwBetterError in alias helper

### DIFF
--- a/addon/-private/better-errors.js
+++ b/addon/-private/better-errors.js
@@ -3,7 +3,17 @@ import Ceibo from 'ceibo';
 
 export const ELEMENT_NOT_FOUND = 'Element not found.';
 
-export function throwBetterError(node, key, selector, msg) {
+/**
+ * Throws an error with a descriptive message.
+ *
+ * @param {Ceibo} node              PageObject node containing the property that triggered the error
+ * @param {string} key              Key of PageObject property tht triggered the error
+ * @param {string} msg              Error message
+ * @param {Object} options
+ * @param {string} options.selector Selector of element targeted by PageObject property
+ * @return {Ember.Error}
+ */
+export function throwBetterError(node, key, msg, { selector } = {}) {
   let path = [key];
   let current;
 
@@ -13,11 +23,11 @@ export function throwBetterError(node, key, selector, msg) {
 
   path[0] = 'page';
 
-  let fullErrorMessage = `${msg}
+  let fullErrorMessage = `${msg}\n\nPageObject: '${path.join('.')}'`;
 
-PageObject: '${path.join('.')}'
-  Selector: '${selector}'
-`;
+  if (selector) {
+    fullErrorMessage = `${fullErrorMessage}\n  Selector: '${selector}'`;
+  }
 
   throw new Ember.Error(fullErrorMessage);
 }

--- a/addon/-private/execution_context/acceptance.js
+++ b/addon/-private/execution_context/acceptance.js
@@ -66,7 +66,12 @@ AcceptanceExecutionContext.prototype = {
     let result = find(selector, options.testContainer || findClosestValue(this.pageObjectNode, 'testContainer'));
 
     if (result.length === 0) {
-      throwBetterError(this.pageObjectNode, options.pageObjectKey, selector, ELEMENT_NOT_FOUND);
+      throwBetterError(
+        this.pageObjectNode,
+        options.pageObjectKey,
+        ELEMENT_NOT_FOUND,
+        { selector }
+      );
     }
   },
 
@@ -92,7 +97,12 @@ AcceptanceExecutionContext.prototype = {
     result = find(selector, options.testContainer || findClosestValue(this.pageObjectNode, 'testContainer'));
 
     if (result.length === 0) {
-      throwBetterError(this.pageObjectNode, options.pageObjectKey, selector, ELEMENT_NOT_FOUND);
+      throwBetterError(
+        this.pageObjectNode,
+        options.pageObjectKey,
+        ELEMENT_NOT_FOUND,
+        { selector }
+      );
     }
 
     guardMultiple(result, selector, options.multiple);

--- a/addon/-private/execution_context/helpers.js
+++ b/addon/-private/execution_context/helpers.js
@@ -24,8 +24,8 @@ export function fillElement($selection, content, { selector, pageObjectNode, pag
     throwBetterError(
       pageObjectNode,
       pageObjectKey,
-      selector,
-      'Element cannot be filled because it has `contenteditable="false"`.'
+      'Element cannot be filled because it has `contenteditable="false"`.',
+      { selector }
     );
   } else {
     $selection.val(content);

--- a/addon/-private/execution_context/integration.js
+++ b/addon/-private/execution_context/integration.js
@@ -81,7 +81,12 @@ IntegrationExecutionContext.prototype = {
     }
 
     if (result.length === 0) {
-      throwBetterError(this.pageObjectNode, options.pageObjectKey, selector, ELEMENT_NOT_FOUND);
+      throwBetterError(
+        this.pageObjectNode,
+        options.pageObjectKey,
+        ELEMENT_NOT_FOUND,
+        { selector }
+      );
     }
   },
 
@@ -117,7 +122,12 @@ IntegrationExecutionContext.prototype = {
     guardMultiple(result, selector, options.multiple);
 
     if (result.length === 0) {
-      throwBetterError(this.pageObjectNode, options.pageObjectKey, selector, ELEMENT_NOT_FOUND);
+      throwBetterError(
+        this.pageObjectNode,
+        options.pageObjectKey,
+        ELEMENT_NOT_FOUND,
+        { selector }
+      );
     }
 
     return result;

--- a/addon/-private/properties/alias.js
+++ b/addon/-private/properties/alias.js
@@ -1,10 +1,11 @@
-import Ember from 'ember';
-
 import { getExecutionContext } from '../execution_context';
+import { throwBetterError } from '../better-errors';
 import {
   getProperty,
   objectHasProperty
 } from '../helpers';
+
+const ALIASED_PROP_NOT_FOUND = 'PageObject does not contain aliased property';
 
 /**
  * Returns the value of some other property on the PageObject.
@@ -74,9 +75,7 @@ export function alias(pathToProp, options = {}) {
 
     get(key) {
       if (!objectHasProperty(this, pathToProp)) {
-        throw new Ember.Error(
-          `\`${key}\`:\n PageObject does not contain aliased property \`${pathToProp}\`.`
-        );
+        throwBetterError(this, key, `${ALIASED_PROP_NOT_FOUND} \`${pathToProp}\`.`);
       }
 
       const value = getProperty(this, pathToProp);

--- a/tests/properties/alias-test.js
+++ b/tests/properties/alias-test.js
@@ -198,7 +198,8 @@ moduleForProperty('alias', function(test) {
 
     assert.throws(
       function() { return page.fooAlias; },
-      '`fooAlias`: PageObject does not contain aliased property `foo`.'
+      /PageObject does not contain aliased property `foo`/,
+      'Aliased property not found'
     );
   });
 
@@ -211,7 +212,8 @@ moduleForProperty('alias', function(test) {
 
     assert.throws(
       function() { return page.fooBarAlias; },
-      '`fooBarAlias`: PageObject does not contain aliased property `foo.bar`.'
+      /PageObject does not contain aliased property `foo.bar`/,
+      'Aliased property not found'
     );
   });
 


### PR DESCRIPTION
### Purpose
- Improve error-reporting of `alias` helper by using `throwBetterError`

### Approach
- `throwBetterError`: make `selector` part of an optional `options` parameter so that it can be excluded when there is no selector to include in the error message. 
- `alias`: use `throwBetterError` to build the `Ember.Error` thrown when an aliased property is not found on the page object.