### PR TITLE
throwBetterError logs error to console

### DIFF
--- a/addon/-private/better-errors.js
+++ b/addon/-private/better-errors.js
@@ -29,5 +29,6 @@ export function throwBetterError(node, key, msg, { selector } = {}) {
     fullErrorMessage = `${fullErrorMessage}\n  Selector: '${selector}'`;
   }
 
+  Ember.Logger.error(fullErrorMessage);
   throw new Ember.Error(fullErrorMessage);
 }

--- a/tests/unit/-private/better-errors-test.js
+++ b/tests/unit/-private/better-errors-test.js
@@ -1,0 +1,60 @@
+import Ember from 'ember';
+import { test, module } from 'qunit';
+import { create } from 'ember-cli-page-object';
+import {
+  throwBetterError
+} from 'ember-cli-page-object/-private/better-errors';
+
+const page = create({
+  foo: {
+    scope: '.foo',
+    bar: {
+      scope: '.bar',
+      focus() {}
+    }
+  }
+});
+
+module('Unit | throwBetterError');
+
+test('shows the expected error message when `selector` is not passed in', function(assert) {
+  assert.expect(1);
+
+  const fn = () => {
+    throwBetterError(page.foo.bar, 'focus', 'Oops!');
+  };
+  const expectedError = new Ember.Error(
+    "Oops!\n\nPageObject: 'page.foo.bar.focus'"
+  );
+
+  assert.throws(fn, expectedError, 'should show message & property path');
+});
+
+test('shows the expected error message when `selector` is passed in', function(assert) {
+  assert.expect(1);
+
+  const fn = () => {
+    throwBetterError(page.foo.bar, 'focus', 'Oops!', { selector: '.foo .bar' });
+  };
+  const expectedError = new Ember.Error(
+    "Oops!\n\nPageObject: 'page.foo.bar.focus'\n  Selector: '.foo .bar'"
+  );
+
+  assert.throws(fn, expectedError, 'should show message, property path, & selector');
+});
+
+test('logs the error to the console', function(assert) {
+  assert.expect(2);
+
+  const origEmberLoggerError = Ember.Logger.error;
+
+  try {
+    Ember.Logger.error = (msg) => {
+      assert.equal(msg, "Oops!\n\nPageObject: 'page.foo.bar.focus'");
+    };
+
+    assert.throws(() => throwBetterError(page.foo.bar, 'focus', 'Oops!'));
+  } finally {
+    Ember.Logger.error = origEmberLoggerError;
+  }
+});

--- a/tests/unit/-private/helpers-test.js
+++ b/tests/unit/-private/helpers-test.js
@@ -6,7 +6,7 @@ import {
   objectHasProperty
 } from 'ember-cli-page-object/-private/helpers';
 
-module('Unit | utils | fullScope');
+module('Unit | helpers | fullScope');
 
 let page = create({
   scope: '.calculator',
@@ -28,7 +28,7 @@ test('calculates full scope for components', function(assert) {
   assert.equal(fullScope(page.keyboard.numbers(0)), '.calculator .keyboard .numbers button:eq(0)');
 });
 
-module('Unit | utils | objectHasProperty');
+module('Unit | helpers | objectHasProperty');
 
 test('returns true when the object contains the property', function(assert) {
   const object = {
@@ -81,7 +81,7 @@ test('returns false when the object does not contain the property', function(ass
   assert.equal(objectHasProperty(object, 'baz.buzz.waldo.banana'), false, 'baz.buzz.waldo.banana');
 });
 
-module('Unit | utils | getProperty');
+module('Unit | helpers | getProperty');
 
 test('returns top-level property', function(assert) {
   const object = {

--- a/tests/unit/-private/properties/alias-test.js
+++ b/tests/unit/-private/properties/alias-test.js
@@ -1,4 +1,4 @@
-import { moduleForProperty } from '../helpers/properties';
+import { moduleForProperty } from '../../../helpers/properties';
 import {
   create,
   clickable,

--- a/tests/unit/-private/properties/attribute-test.js
+++ b/tests/unit/-private/properties/attribute-test.js
@@ -1,4 +1,4 @@
-import { moduleForProperty } from '../helpers/properties';
+import { moduleForProperty } from '../../../helpers/properties';
 import { create, attribute } from 'ember-cli-page-object';
 
 moduleForProperty('attribute', function(test) {

--- a/tests/unit/-private/properties/click-on-text-test.js
+++ b/tests/unit/-private/properties/click-on-text-test.js
@@ -1,4 +1,4 @@
-import { moduleForProperty } from '../helpers/properties';
+import { moduleForProperty } from '../../../helpers/properties';
 import { create, clickOnText } from 'ember-cli-page-object';
 
 moduleForProperty('clickOnText', function(test) {

--- a/tests/unit/-private/properties/clickable-test.js
+++ b/tests/unit/-private/properties/clickable-test.js
@@ -1,4 +1,4 @@
-import { moduleForProperty } from '../helpers/properties';
+import { moduleForProperty } from '../../../helpers/properties';
 import { create, clickable } from 'ember-cli-page-object';
 
 moduleForProperty('clickable', function(test) {

--- a/tests/unit/-private/properties/collection-test.js
+++ b/tests/unit/-private/properties/collection-test.js
@@ -1,6 +1,6 @@
-import { moduleForProperty } from '../helpers/properties';
+import { moduleForProperty } from '../../../helpers/properties';
 import { create, collection, text, hasClass } from 'ember-cli-page-object';
-import withIteratorSymbolDefined from '../helpers/with-iterator-symbol-defined';
+import withIteratorSymbolDefined from '../../../helpers/with-iterator-symbol-defined';
 
 moduleForProperty('collection', function(test) {
   test('generates a count property', function(assert) {

--- a/tests/unit/-private/properties/contains-test.js
+++ b/tests/unit/-private/properties/contains-test.js
@@ -1,4 +1,4 @@
-import { moduleForProperty } from '../helpers/properties';
+import { moduleForProperty } from '../../../helpers/properties';
 import { create, contains } from 'ember-cli-page-object';
 
 moduleForProperty('contains', function(test) {

--- a/tests/unit/-private/properties/count-test.js
+++ b/tests/unit/-private/properties/count-test.js
@@ -1,4 +1,4 @@
-import { moduleForProperty } from '../helpers/properties';
+import { moduleForProperty } from '../../../helpers/properties';
 import { create, count } from 'ember-cli-page-object';
 
 moduleForProperty('count', function(test) {

--- a/tests/unit/-private/properties/create-test.js
+++ b/tests/unit/-private/properties/create-test.js
@@ -1,4 +1,4 @@
-import { moduleForProperty } from '../helpers/properties';
+import { moduleForProperty } from '../../../helpers/properties';
 import { create, text } from 'ember-cli-page-object';
 
 moduleForProperty('create', function(test, adapter) {

--- a/tests/unit/-private/properties/dsl-test.js
+++ b/tests/unit/-private/properties/dsl-test.js
@@ -1,4 +1,4 @@
-import { moduleForProperty } from '../helpers/properties';
+import { moduleForProperty } from '../../../helpers/properties';
 import { create, collection } from 'ember-cli-page-object';
 
 moduleForProperty('dsl', function(test) {

--- a/tests/unit/-private/properties/fillable-test.js
+++ b/tests/unit/-private/properties/fillable-test.js
@@ -1,4 +1,4 @@
-import { moduleForProperty } from '../helpers/properties';
+import { moduleForProperty } from '../../../helpers/properties';
 import { create, fillable, selectable } from 'ember-cli-page-object';
 
 moduleForProperty('fillable', function(test) {

--- a/tests/unit/-private/properties/has-class-test.js
+++ b/tests/unit/-private/properties/has-class-test.js
@@ -1,4 +1,4 @@
-import { moduleForProperty } from '../helpers/properties';
+import { moduleForProperty } from '../../../helpers/properties';
 import { create, hasClass } from 'ember-cli-page-object';
 
 moduleForProperty('hasClass', function(test) {

--- a/tests/unit/-private/properties/is-hidden-test.js
+++ b/tests/unit/-private/properties/is-hidden-test.js
@@ -1,4 +1,4 @@
-import { moduleForProperty } from '../helpers/properties';
+import { moduleForProperty } from '../../../helpers/properties';
 import { create, isHidden } from 'ember-cli-page-object';
 
 moduleForProperty('isHidden', function(test) {

--- a/tests/unit/-private/properties/is-test.js
+++ b/tests/unit/-private/properties/is-test.js
@@ -1,4 +1,4 @@
-import { moduleForProperty } from '../helpers/properties';
+import { moduleForProperty } from '../../../helpers/properties';
 import { create, is } from 'ember-cli-page-object';
 
 moduleForProperty('is', function(test) {

--- a/tests/unit/-private/properties/is-visible-test.js
+++ b/tests/unit/-private/properties/is-visible-test.js
@@ -1,4 +1,4 @@
-import { moduleForProperty } from '../helpers/properties';
+import { moduleForProperty } from '../../../helpers/properties';
 import { create, isVisible } from 'ember-cli-page-object';
 
 moduleForProperty('isVisible', function(test) {

--- a/tests/unit/-private/properties/not-has-class-test.js
+++ b/tests/unit/-private/properties/not-has-class-test.js
@@ -1,4 +1,4 @@
-import { moduleForProperty } from '../helpers/properties';
+import { moduleForProperty } from '../../../helpers/properties';
 import { create, notHasClass } from 'ember-cli-page-object';
 
 moduleForProperty('notHasClass', function(test) {

--- a/tests/unit/-private/properties/property-test.js
+++ b/tests/unit/-private/properties/property-test.js
@@ -1,4 +1,4 @@
-import { moduleForProperty } from '../helpers/properties';
+import { moduleForProperty } from '../../../helpers/properties';
 import { create, property } from 'ember-cli-page-object';
 
 moduleForProperty('property', function(test) {

--- a/tests/unit/-private/properties/text-test.js
+++ b/tests/unit/-private/properties/text-test.js
@@ -1,4 +1,4 @@
-import { moduleForProperty } from '../helpers/properties';
+import { moduleForProperty } from '../../../helpers/properties';
 import { create, text } from 'ember-cli-page-object';
 
 moduleForProperty('text', function(test) {

--- a/tests/unit/-private/properties/triggerable-test.js
+++ b/tests/unit/-private/properties/triggerable-test.js
@@ -1,4 +1,4 @@
-import { moduleForProperty } from '../helpers/properties';
+import { moduleForProperty } from '../../../helpers/properties';
 import { create, triggerable } from 'ember-cli-page-object';
 
 moduleForProperty('triggerable', function(test) {

--- a/tests/unit/-private/properties/value-test.js
+++ b/tests/unit/-private/properties/value-test.js
@@ -1,4 +1,4 @@
-import { moduleForProperty } from '../helpers/properties';
+import { moduleForProperty } from '../../../helpers/properties';
 import { create, value } from 'ember-cli-page-object';
 
 moduleForProperty('value', function(test) {

--- a/tests/unit/-private/properties/visitable-test.js
+++ b/tests/unit/-private/properties/visitable-test.js
@@ -1,4 +1,4 @@
-import { moduleForProperty } from '../helpers/properties';
+import { moduleForProperty } from '../../../helpers/properties';
 import { create, visitable } from 'ember-cli-page-object';
 
 moduleForProperty('visitable', { acceptanceOnly: true }, function(test) {


### PR DESCRIPTION
### Purpose
- Ensure that `throwBetterError` logs an error to the console.
- Addresses #304 

### Approach
- Call `Ember.Logger.error` before throwing `Ember.Error`.

### Test Coverage
- Added unit tests for `throwBetterError`, which I probably should have done in #303, since `throwBetterError` now has some logic around whether or not to report a selector.
- I wasn't sure at first where to put the test for `throwBetterErrors`, so I reshuffled the `tests` folders a bit.

### Open Questions
- [x] Are these changes to the `tests` folder structure helpful/sensible?
- [x] I sort of arbitrarily decided on `Ember.Logger.error` rather than `console.error`. It doesn't make much of a difference either way...any reason to prefer one over the other?