### PR TITLE
Add `none` helper

### DIFF
--- a/addon/-private/better-errors.js
+++ b/addon/-private/better-errors.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import Ceibo from 'ceibo';
 
 export const ELEMENT_NOT_FOUND = 'Element not found.';
+export const PROPERTY_NOT_FOUND = 'PageObject does not contain property';
 
 /**
  * Throws an error with a descriptive message.

--- a/addon/-private/helpers.js
+++ b/addon/-private/helpers.js
@@ -308,4 +308,12 @@ export function getProperty(object, pathToProp) {
   return typeof value === 'function' ? value.bind(propOwner) : value;
 }
 
+export function registerPropWithCustomFalsyValues(node, key, falsyValues) {
+  if (!node.hasOwnProperty('_propsWithCustomFalsyValues')) {
+    Ceibo.defineProperty(node, '_propsWithCustomFalsyValues', {});
+  }
+
+  node._propsWithCustomFalsyValues[key] = { falsyValues };
+}
+
 export const assign = Ember.assign || Ember.merge;

--- a/addon/-private/helpers.js
+++ b/addon/-private/helpers.js
@@ -308,12 +308,29 @@ export function getProperty(object, pathToProp) {
   return typeof value === 'function' ? value.bind(propOwner) : value;
 }
 
+export function getPropertyInfo(object, pathToProp) {
+  const pathSegments = pathToProp.split('.');
+
+  if (pathSegments.length === 1) {
+    return {
+      propOwner: object,
+      propKey: pathToProp
+    };
+  }
+
+  const pathToPropOwner = pathSegments.slice(0, -1).join('.');
+  return {
+    propOwner: get(object, pathToPropOwner),
+    propKey: pathSegments.slice(-1)[0]
+  };
+}
+
 export function registerPropWithCustomFalsyValues(node, key, falsyValues) {
   if (!node.hasOwnProperty('_propsWithCustomFalsyValues')) {
     Ceibo.defineProperty(node, '_propsWithCustomFalsyValues', {});
   }
 
-  node._propsWithCustomFalsyValues[key] = { falsyValues };
+  node._propsWithCustomFalsyValues[key] = falsyValues;
 }
 
 export const assign = Ember.assign || Ember.merge;

--- a/addon/-private/properties/attribute.js
+++ b/addon/-private/properties/attribute.js
@@ -76,7 +76,7 @@ export function attribute(attributeName, selector, userOptions = {}) {
     isDescriptor: true,
 
     setup(target, key) {
-      const falsyValues = ['false'].concat(userOptions.falsyValues);
+      const falsyValues = ['false'].concat(userOptions.falsyValues || []);
       registerPropWithCustomFalsyValues(target, key, falsyValues);
     },
 

--- a/addon/-private/properties/attribute.js
+++ b/addon/-private/properties/attribute.js
@@ -76,7 +76,7 @@ export function attribute(attributeName, selector, userOptions = {}) {
     isDescriptor: true,
 
     setup(target, key) {
-      const falsyValues = ['false'].concat(userOptions.falsyValues || []);
+      const falsyValues = ['false'].concat(userOptions.falsy || []);
       registerPropWithCustomFalsyValues(target, key, falsyValues);
     },
 

--- a/addon/-private/properties/attribute.js
+++ b/addon/-private/properties/attribute.js
@@ -1,4 +1,8 @@
-import { assign, map } from '../helpers';
+import {
+  assign,
+  map,
+  registerPropWithCustomFalsyValues
+} from '../helpers';
 import { getExecutionContext } from '../execution_context';
 
 /**
@@ -70,6 +74,11 @@ import { getExecutionContext } from '../execution_context';
 export function attribute(attributeName, selector, userOptions = {}) {
   return {
     isDescriptor: true,
+
+    setup(target, key) {
+      const falsyValues = ['false'].concat(userOptions.falsyValues);
+      registerPropWithCustomFalsyValues(target, key, falsyValues);
+    },
 
     get(key) {
       let executionContext = getExecutionContext(this);

--- a/addon/-private/properties/none.js
+++ b/addon/-private/properties/none.js
@@ -1,0 +1,57 @@
+import Ember from 'ember';
+
+import {
+  getProperty,
+  objectHasProperty
+} from '../helpers';
+import {
+  PROPERTY_NOT_FOUND,
+  throwBetterError
+} from '../better-errors';
+
+export function none(...pathsToProps) {
+  return {
+    isDescriptor: true,
+    get(key) {
+      for (let i = 0; i < pathsToProps.length; i++) {
+        const pathToProp = pathsToProps[i];
+
+        if (!objectHasProperty(this, pathToProp)) {
+          throwBetterError(this, key, `${PROPERTY_NOT_FOUND} \`${pathsToProps[i]}\`.`);
+        }
+
+        if (!_isFalsy(this, pathToProp)) {
+          return false;
+        }
+      }
+
+      return true;
+    }
+  };
+}
+
+function _isFalsy(node, key) {
+  let value = getProperty(node, key);
+
+  while (typeof value === 'function') {
+    value = value();
+  }
+
+  if (value && value.toArray) {
+    value = value.toArray();
+  }
+
+  const values = Array.isArray(value) ? value : [value];
+  const propsWithCustomFalsyValues = node._propsWithCustomFalsyValues || {};
+
+  if (propsWithCustomFalsyValues[key]) {
+    const falsyValues = propsWithCustomFalsyValues[key].falsyValues;
+    return values.every((val) => {
+      return !val || Ember.isEmpty(val) || falsyValues.indexOf(val) !== -1;
+    });
+  }
+
+  return values.every((val) => {
+    return !val || Ember.isEmpty(val);
+  });
+}

--- a/addon/-private/properties/none.js
+++ b/addon/-private/properties/none.js
@@ -10,6 +10,94 @@ import {
   throwBetterError
 } from '../better-errors';
 
+/**
+ * Returns `false` if all of the target properties pass the falsy criteria below.
+ * If a property returns an array of values due to the fact that it is defined
+ * with `{ multiple: true }`, all values must meet the falsy criteria.
+ *
+ * A property will be treated as truthy if its value is:
+ *   - `true`
+ *   - number !== 0
+ *   - object, even if it is empty
+ *   - non-empty string
+ *   - non-empty collection
+ *   - non-empty array, as long as some elements are treated as truthy
+ *   - a function that returns any of the above
+ *
+ * A property will be treated as falsy if its value is:
+ *    - `false`
+ *    - `null`
+ *    - `undefined`
+ *    - 0
+ *    - NAN
+ *    - empty string
+ *    - empty collection
+ *    - empty array
+ *    - non-empty array, if all elements are treated as falsy
+ *    - a function that returns any of the above
+ *
+ * Custom falsy values can be specified for the `attribute`, `property`,
+ * `text`, and `value` helpers.
+ *
+ * @example
+ *
+ * import { create } from 'ember-cli-page-object';
+ * import { none } from 'ember-cli-page-object/macros';
+ *
+ * const page = create({
+ *   rosterNames: collection({
+ *     itemScope: '.roster-name'
+ *   }),
+ *
+ *   addNameInputValue: value('input.add-name'),
+ *
+ *   addedNamesText: text('.added-names', { falsy: ['---'] }),
+ *
+ *   labelText: text('label'),
+ *
+ *   labelShowsNameCountDescriptor: {
+ *     isDescriptor: true,
+ *     get() {
+ *       return /There are \d* names on this roster/.test(this.labelText);
+ *     }
+ *   },
+ *
+ *   labelShowsNameCountFunction() {
+ *     return /There are \d* names on this roster/.test(this.labelText);
+ *   },
+ *
+ *   isRosterFormBlank: none(
+ *     'rosterNames',
+ *     'addNameInputValue',
+ *     'addedNamesText',
+ *     'labelShowsNameCountDescriptor',
+ *     'labelShowsNameCountFunction'
+ *    )
+ * });
+ *
+ * // <div class="roster">
+ * //   <label>Enter a name in the input below:</label>
+ * //   <input class="add-name">
+ * //   <div class="added-names">---</div>
+ * // </div>
+ *
+ * assert.equal(page.isRosterFormBlank, true, 'should be true because all properties are falsy');
+ *
+ * // <div class="roster">
+ * //   <label>Enter a name in the input below:</label>
+ * //   <input class="add-name">
+ * //   <div class="added-names">
+ * //     <div class="roster-name">Waldo Fred</div>
+ * //   </div>
+ * // </div>
+ *
+ * assert.equal(page.isRosterFormBlank, false, 'should be false because rosterNames is not empty');
+ *
+ * @param {string} pathsToProps - dot-separated paths to a properties specified on the PageObject
+ * @return {Descriptor}
+ *
+ * @throws Will throw an error if the PageObject does not have the specified properties.
+ */
 export function none(...pathsToProps) {
   return {
     isDescriptor: true,

--- a/addon/-private/properties/none.js
+++ b/addon/-private/properties/none.js
@@ -45,7 +45,7 @@ function _isFalsy(node, key) {
   const propsWithCustomFalsyValues = node._propsWithCustomFalsyValues || {};
 
   if (propsWithCustomFalsyValues[key]) {
-    const falsyValues = propsWithCustomFalsyValues[key].falsyValues;
+    const falsyValues = propsWithCustomFalsyValues[key];
     return values.every((val) => {
       return !val || Ember.isEmpty(val) || falsyValues.indexOf(val) !== -1;
     });

--- a/addon/-private/properties/property.js
+++ b/addon/-private/properties/property.js
@@ -1,4 +1,8 @@
-import { assign, map } from '../helpers';
+import {
+  assign,
+  map,
+  registerPropWithCustomFalsyValues
+} from '../helpers';
 import { getExecutionContext } from '../execution_context';
 
 /**
@@ -56,6 +60,12 @@ import { getExecutionContext } from '../execution_context';
 export function property(propertyName, selector, userOptions = {}) {
   return {
     isDescriptor: true,
+
+    setup(target, key) {
+      if (userOptions.falsyValues) {
+        registerPropWithCustomFalsyValues(target, key, userOptions.falsyValues);
+      }
+    },
 
     get(key) {
       let executionContext = getExecutionContext(this);

--- a/addon/-private/properties/property.js
+++ b/addon/-private/properties/property.js
@@ -62,8 +62,8 @@ export function property(propertyName, selector, userOptions = {}) {
     isDescriptor: true,
 
     setup(target, key) {
-      if (userOptions.falsyValues) {
-        registerPropWithCustomFalsyValues(target, key, userOptions.falsyValues);
+      if (userOptions.falsy) {
+        registerPropWithCustomFalsyValues(target, key, userOptions.falsy);
       }
     },
 

--- a/addon/-private/properties/text.js
+++ b/addon/-private/properties/text.js
@@ -1,4 +1,9 @@
-import { assign, map, normalizeText } from '../helpers';
+import {
+  assign,
+  map,
+  normalizeText,
+  registerPropWithCustomFalsyValues
+} from '../helpers';
 import { getExecutionContext } from '../execution_context';
 
 function identity(v) {
@@ -92,6 +97,12 @@ function identity(v) {
 export function text(selector, userOptions = {}) {
   return {
     isDescriptor: true,
+
+    setup(target, key) {
+      if (userOptions.falsyValues) {
+        registerPropWithCustomFalsyValues(target, key, userOptions.falsyValues);
+      }
+    },
 
     get(key) {
       let executionContext = getExecutionContext(this);

--- a/addon/-private/properties/text.js
+++ b/addon/-private/properties/text.js
@@ -99,8 +99,8 @@ export function text(selector, userOptions = {}) {
     isDescriptor: true,
 
     setup(target, key) {
-      if (userOptions.falsyValues) {
-        registerPropWithCustomFalsyValues(target, key, userOptions.falsyValues);
+      if (userOptions.falsy) {
+        registerPropWithCustomFalsyValues(target, key, userOptions.falsy);
       }
     },
 

--- a/addon/-private/properties/value.js
+++ b/addon/-private/properties/value.js
@@ -1,4 +1,8 @@
-import { assign, map } from '../helpers';
+import {
+  assign,
+  map,
+  registerPropWithCustomFalsyValues
+} from '../helpers';
 import { getExecutionContext } from '../execution_context';
 
 /**
@@ -79,6 +83,12 @@ import { getExecutionContext } from '../execution_context';
 export function value(selector, userOptions = {}) {
   return {
     isDescriptor: true,
+
+    setup(target, key) {
+      if (userOptions.falsyValues) {
+        registerPropWithCustomFalsyValues(target, key, userOptions.falsyValues);
+      }
+    },
 
     get(key) {
       let executionContext = getExecutionContext(this);

--- a/addon/-private/properties/value.js
+++ b/addon/-private/properties/value.js
@@ -85,8 +85,8 @@ export function value(selector, userOptions = {}) {
     isDescriptor: true,
 
     setup(target, key) {
-      if (userOptions.falsyValues) {
-        registerPropWithCustomFalsyValues(target, key, userOptions.falsyValues);
+      if (userOptions.falsy) {
+        registerPropWithCustomFalsyValues(target, key, userOptions.falsy);
       }
     },
 

--- a/addon/macros.js
+++ b/addon/macros.js
@@ -1,1 +1,2 @@
 export { alias } from './-private/properties/alias';
+export { none } from './-private/properties/none';

--- a/tests/unit/-private/properties/none-test.js
+++ b/tests/unit/-private/properties/none-test.js
@@ -765,25 +765,27 @@ moduleForProperty('none | handling properties with { multiple: true }', function
   });
 });
 
-moduleForProperty('none | handling aliased properties', function(test) {
-  test('returns true if any value is truthy', function(assert) {
-    assert.expect(1);
+moduleForProperty('none | handling nested properties', function(test) {
 
-    const page = create({
+  const page = create({
+    body: {
       span: {
         scope: 'span',
         activeAttrValue: attribute('data-active')
       },
+    },
+    controls: {
       checkbox: {
         scope: '[type="checkbox"]',
         isChecked: is(':checked')
       },
+    },
 
-      isSpanActive: alias('span.activeAttrValue'),
-      isChecked: alias('checkbox.isChecked'),
+    isPageInactive: none('body.span.activeAttrValue', 'controls.checkbox.isChecked')
+  });
 
-      isPageInactive: none('isSpanActive', 'isChecked')
-    });
+  test('returns true if any value is truthy', function(assert) {
+    assert.expect(1);
 
     this.adapter.createTemplate(this, page, `
       <input type="checkbox" checked>
@@ -796,21 +798,51 @@ moduleForProperty('none | handling aliased properties', function(test) {
   test('returns false if all values are falsy', function(assert) {
     assert.expect(1);
 
-    const page = create({
+    this.adapter.createTemplate(this, page, `
+      <input type="checkbox">
+      <span data-active="false"></span>
+    `);
+
+    assert.ok(page.isPageInactive);
+  });
+});
+
+moduleForProperty('none | handling aliased properties', function(test) {
+
+  const page = create({
+    body: {
       span: {
         scope: 'span',
         activeAttrValue: attribute('data-active')
       },
+    },
+    controls: {
       checkbox: {
         scope: '[type="checkbox"]',
         isChecked: is(':checked')
       },
+      isCheckboxChecked: alias('checkbox.isChecked')
+    },
 
-      isSpanActive: alias('span.activeAttrValue'),
-      isChecked: alias('checkbox.isChecked'),
+    isSpanActive: alias('body.span.activeAttrValue'),
+    isChecked: alias('controls.isCheckboxChecked'),
 
-      isPageInactive: none('isSpanActive', 'isChecked')
-    });
+    isPageInactive: none('isSpanActive', 'isChecked')
+  });
+
+  test('returns true if any value is truthy', function(assert) {
+    assert.expect(1);
+
+    this.adapter.createTemplate(this, page, `
+      <input type="checkbox" checked>
+      <span data-active="false"></span>
+    `);
+
+    assert.notOk(page.isPageInactive);
+  });
+
+  test('returns false if all values are falsy', function(assert) {
+    assert.expect(1);
 
     this.adapter.createTemplate(this, page, `
       <input type="checkbox">

--- a/tests/unit/-private/properties/none-test.js
+++ b/tests/unit/-private/properties/none-test.js
@@ -17,310 +17,232 @@ import { alias, none } from 'ember-cli-page-object/macros';
 
 moduleForProperty('none | handling `attribute` values', function(test) {
 
+  const PAGE = create({
+    activeAttrValue: attribute('data-active', 'button'),
+    isButtonInactive: none('activeAttrValue')
+  });
+
   test('treats "true" attribute value as truthy', function(assert) {
     assert.expect(1);
 
-    const page = create({
-      activeAttributeValue: attribute('data-active', 'button'),
-      isButtonInactive: none('activeAttributeValue')
-    });
+    this.adapter.createTemplate(this, PAGE, '<button data-active="true"></button>');
 
-    this.adapter.createTemplate(this, page, '<button data-active="true"></button>');
-
-    assert.notOk(page.isButtonInactive);
-  });
-
-  test('treats any string attribute value other than "false" as truthy', function(assert) {
-    assert.expect(1);
-
-    const page = create({
-      activeAttributeValue: attribute('data-active', 'button'),
-      isButtonInactive: none('activeAttributeValue')
-    });
-
-    this.adapter.createTemplate(this, page, '<button data-active="0"></button>');
-
-    assert.notOk(page.isButtonInactive);
+    assert.notOk(PAGE.isButtonInactive);
   });
 
   test('treats "false" attribute value as falsy', function(assert) {
     assert.expect(1);
 
-    const page = create({
-      activeAttributeValue: attribute('data-active', 'button'),
-      isButtonInactive: none('activeAttributeValue')
-    });
+    this.adapter.createTemplate(this, PAGE, '<button data-active="false"></button>');
 
-    this.adapter.createTemplate(this, page, '<button data-active="false"></button>');
+    assert.ok(PAGE.isButtonInactive);
+  });
 
-    assert.ok(page.isButtonInactive);
+  test('treats any string attribute value other than "false" as truthy', function(assert) {
+    assert.expect(1);
+
+    this.adapter.createTemplate(this, PAGE, '<button data-active="0"></button>');
+
+    assert.notOk(PAGE.isButtonInactive);
   });
 
   test('can handle custom falsy values', function(assert) {
-    assert.expect(6);
+    assert.expect(1);
 
     const page = create({
-      button1ActiveAttribute: attribute('data-active', '.button-1', {
-        falsy: ['no']
-      }),
-      isButton1Inactive: none('button1ActiveAttribute'),
-
-      button2ActiveAttribute: attribute('data-active', '.button-2', {
-        falsy: ['0']
-      }),
-      isButton2Inactive: none('button2ActiveAttribute'),
-
-      button3ActiveAttribute: attribute('data-active', '.button-3'),
-      isButton3Inactive: none('button2ActiveAttribute'),
+      activeAttrValue: attribute('data-active', 'button', { falsy: ['no'] }),
+      isButtonInactive: none('activeAttrValue')
     });
 
     this.adapter.createTemplate(this, page, `
-      <button class="button-1" data-active="no"></button>
-      <button class="button-2" data-active="0"></button>
-      <button class="button-3" data-active="false"></button>
+      <button data-active="no"></button>
     `);
 
-    assert.equal(page.button1ActiveAttribute, 'no');
-    assert.ok(page.isButton1Inactive);
-
-    assert.equal(page.button2ActiveAttribute, '0');
-    assert.ok(page.isButton2Inactive);
-
-    assert.equal(page.button3ActiveAttribute, 'false');
-    assert.ok(page.isButton3Inactive);
+    assert.ok(page.isButtonInactive);
   });
 });
 
 moduleForProperty('none | handling `property` values', function(test) {
 
+  const PAGE = create({
+    isBoxChecked: property('checked', '[type=checkbox]'),
+    isFormEmpty: none('isBoxChecked'),
+
+    autoCompleteProp: property('autocomplete', 'input'),
+    isAutocompleteOff: none('autoCompleteProp')
+  });
+
   test('treats true property value as truthy', function(assert) {
     assert.expect(2);
 
-    const page = create({
-      isBoxChecked: property('checked', '[type=checkbox]'),
-      isFormEmpty: none('isBoxChecked')
-    });
+    this.adapter.createTemplate(this, PAGE, '<input type="checkbox" checked>');
 
-    this.adapter.createTemplate(this, page, '<input type="checkbox" checked=true>');
-
-    assert.equal(page.isBoxChecked, true);
-    assert.notOk(page.isFormEmpty);
+    assert.equal(PAGE.isBoxChecked, true);
+    assert.notOk(PAGE.isFormEmpty);
   });
 
   test('treats false property value as falsy', function(assert) {
     assert.expect(2);
 
-    const page = create({
-      isBoxChecked: property('checked', '[type=checkbox]'),
-      isFormEmpty: none('isBoxChecked')
-    });
+    this.adapter.createTemplate(this, PAGE, '<input type="checkbox">');
 
-    this.adapter.createTemplate(this, page, '<input type="checkbox">');
+    assert.equal(PAGE.isBoxChecked, false);
+    assert.ok(PAGE.isFormEmpty);
+  });
 
-    assert.equal(page.isBoxChecked, false);
-    assert.ok(page.isFormEmpty);
+  test('treats non-empty string property value as truthy', function(assert) {
+    assert.expect(1);
+
+    this.adapter.createTemplate(this, PAGE, '<input type="text" autocomplete="foo">');
+
+    assert.notOk(PAGE.isAutocompleteOff);
   });
 
   test('treats empty string property value as falsy', function(assert) {
-    assert.expect(2);
+    assert.expect(1);
 
-    const page = create({
-      autoCompleteProp: property('autocomplete', 'input'),
-      inputAutoCompletes: none('autoCompleteProp')
-    });
+    this.adapter.createTemplate(this, PAGE, '<input type="text" autocomplete="">');
 
-    this.adapter.createTemplate(this, page, '<input type="text">');
-
-    assert.equal(page.autoCompleteProp, '');
-    assert.ok(page.inputAutoCompletes);
+    assert.ok(PAGE.isAutocompleteOff);
   });
 
   test('treats undefined property value as falsy', function(assert) {
     assert.expect(2);
 
     const page = create({
-      fooProperty: property('foo-made-up-property', '[type=checkbox]'),
-      isFormEmpty: none('fooProperty')
+      fooProp: property('data-foo', '[type=checkbox]'),
+      isCheckboxWithoutFoo: none('fooProp')
     });
 
     this.adapter.createTemplate(this, page, '<input type="checkbox">');
 
     assert.equal(page.fooProperty, undefined);
-    assert.ok(page.isFormEmpty);
+    assert.ok(page.isCheckboxWithoutFoo);
   });
 
-  test('can handle custom falsy property values', function (assert) {
-    assert.expect(6);
+  test('can handle custom falsy values', function (assert) {
+    assert.expect(1);
 
     const page = create({
-      input1AutocompleteProp: property('autocomplete', '.input-1', {
-        falsy: ['off']
-      }),
-      input1DoesNotAutocomplete: none('input1AutocompleteProp'),
-
-      input2AutocompleteProp: property('autocomplete', '.input-2', {
-        falsy: ['off']
-      }),
-      input2DoesNotAutocomplete: none('input2AutocompleteProp'),
-
-      input3AutocompleteProp: property('autocomplete', '.input-3', {
-        falsy: ['off']
-      }),
-      input3DoesNotAutoComplete: none('input3AutocompleteProp')
+      inputAutocompleteProp: property('autocomplete', 'input', { falsy: ['off'] }),
+      isAutocompleteOff: none('inputAutocompleteProp')
     });
 
     this.adapter.createTemplate(this, page, `
-      <input class="input-1" type="text">
-      <input class="input-2" type="text" autocomplete="off">
-      <input class="input-3" type="text" autocomplete="email">
+      <input type="text" autocomplete="off">
     `);
 
-    assert.equal(page.input1AutocompleteProp, '');
-    assert.ok(page.input1DoesNotAutocomplete);
-
-    assert.equal(page.input2AutocompleteProp, 'off');
-    assert.ok(page.input2DoesNotAutocomplete);
-
-    assert.equal(page.input3AutocompleteProp, 'email');
-    assert.notOk(page.input3DoesNotAutoComplete);
+    assert.ok(page.isAutocompleteOff);
   });
 });
 
 moduleForProperty('none | handling `text` values', function(test) {
 
+  const PAGE = create({
+    spanText: text('span'),
+    isSpanEmpty: none('spanText')
+  });
+
   test('treats non-empty text value as truthy', function(assert) {
     assert.expect(1);
 
-    const page = create({
-      buttonText: text('button'),
-      isButtonInactive: none('buttonText')
-    });
+    this.adapter.createTemplate(this, PAGE, '<span>Foo</span>');
 
-    this.adapter.createTemplate(this, page, '<button>Foo</button>');
-
-    assert.notOk(page.isButtonInactive);
+    assert.notOk(PAGE.isSpanEmpty);
   });
 
   test('treats "false" text value as truthy', function(assert) {
     assert.expect(1);
 
-    const page = create({
-      buttonText: text('button'),
-      isButtonInactive: none('buttonText')
-    });
+    this.adapter.createTemplate(this, PAGE, '<span>false</span>');
 
-    this.adapter.createTemplate(this, page, '<button>false</button>');
-
-    assert.notOk(page.isButtonInactive);
-  });
-
-  test('treats white space text value as falsy by default', function(assert) {
-    assert.expect(1);
-
-    const page = create({
-      buttonText: text('button'),
-      isButtonInactive: none('buttonText')
-    });
-
-    this.adapter.createTemplate(this, page, '<button>  </button>');
-    assert.ok(page.isButtonInactive);
-  });
-
-  test('treats white space text value as truthy if { normalize: false } is passed into options', function(assert) {
-    assert.expect(1);
-
-    const page = create({
-      buttonText: text('button', { normalize: false }),
-      isButtonInactive: none('buttonText')
-    });
-
-    this.adapter.createTemplate(this, page, '<button>  </button>');
-    assert.notOk(page.isButtonInactive);
+    assert.notOk(PAGE.isSpanEmpty);
   });
 
   test('treats empty string text value as falsy', function(assert) {
     assert.expect(1);
 
+    this.adapter.createTemplate(this, PAGE, '<span></span>');
+
+    assert.ok(PAGE.isSpanEmpty);
+  });
+
+  test('treats white space text value as falsy by default', function(assert) {
+    assert.expect(1);
+
+    this.adapter.createTemplate(this, PAGE, '<span>  </span>');
+
+    assert.ok(PAGE.isSpanEmpty);
+  });
+
+  test('treats white space text value as truthy with { normalize: false } option', function(assert) {
+    assert.expect(1);
+
     const page = create({
-      buttonText: text('button'),
-      isButtonInactive: none('buttonText')
+      spanText: text('span', { normalize: false }),
+      isSpanEmpty: none('spanText')
     });
 
-    this.adapter.createTemplate(this, page, '<button></button>');
+    this.adapter.createTemplate(this, page, '<span>  </span>');
 
-    assert.ok(page.isButtonInactive);
+    assert.notOk(page.isSpanEmpty);
   });
 
   test('can handle custom falsy values', function(assert) {
     assert.expect(1);
 
     const page = create({
-      buttonText: text('button', { falsy: ['---'] }),
-      isButtonInactive: none('buttonText')
+      spanText: text('span', { falsy: '---' }),
+      isSpanEmpty: none('spanText')
     });
 
-    this.adapter.createTemplate(this, page, '<button>---</button>');
+    this.adapter.createTemplate(this, page, '<span>---</span>');
 
-    assert.ok(page.isButtonInactive);
+    assert.ok(page.isSpanEmpty);
   });
 });
 
 moduleForProperty('none | handling `value` values', function(test) {
 
+  const PAGE = create({
+    inputValue: value('input'),
+    isInputEmpty: none('inputValue')
+  });
+
   test('treats non-empty string value as truthy', function(assert) {
     assert.expect(1);
 
-    const page = create({
-      inputValue: value('input'),
-      isInputEmpty: none('inputValue')
-    });
-
-    this.adapter.createTemplate(this, page, '<input type="text">');
+    this.adapter.createTemplate(this, PAGE, '<input type="text">');
     $('input').val('Lorem');
 
-    assert.notOk(page.isInputEmpty);
+    assert.notOk(PAGE.isInputEmpty);
   });
 
   test('treats "false" value as truthy', function(assert) {
     assert.expect(1);
 
-    const page = create({
-      inputValue: value('input'),
-      isInputEmpty: none('inputValue')
-    });
-
-    this.adapter.createTemplate(this, page, '<input type="text">');
+    this.adapter.createTemplate(this, PAGE, '<input type="text">');
     $('input').val('false');
 
-    assert.notOk(page.isInputEmpty);
+    assert.notOk(PAGE.isInputEmpty);
   });
 
   test('treats white space value as truthy', function(assert) {
     assert.expect(1);
 
-    const page = create({
-      inputValue: value('input'),
-      isInputEmpty: none('inputValue')
-    });
-
-    this.adapter.createTemplate(this, page, '<input type="text">');
+    this.adapter.createTemplate(this, PAGE, '<input type="text">');
     $('input').val('  ');
 
-    assert.notOk(page.isInputEmpty);
+    assert.notOk(PAGE.isInputEmpty);
   });
 
   test('treats empty string value as falsy', function(assert) {
     assert.expect(1);
 
-    const page = create({
-      inputValue: value('input'),
-      isInputEmpty: none('inputValue')
-    });
-
-    this.adapter.createTemplate(this, page, '<input type="text">');
+    this.adapter.createTemplate(this, PAGE, '<input type="text">');
     $('input').val('');
 
-    assert.ok(page.isInputEmpty);
+    assert.ok(PAGE.isInputEmpty);
   });
 
   test('can handle custom falsy values', function(assert) {
@@ -340,63 +262,51 @@ moduleForProperty('none | handling `value` values', function(test) {
 
 moduleForProperty('none | handling `count` values', function(test) {
 
+  const PAGE = create({
+    buttonCount: count('button'),
+    areButtonsAbsent: none('buttonCount')
+  });
+
   test('treates count value > 0 as truthy', function(assert) {
     assert.expect(1);
 
-    const page = create({
-      buttonCount: count('button'),
-      areButtonsAbsent: none('buttonCount')
-    });
+    this.adapter.createTemplate(this, PAGE, '<button></button>');
 
-    this.adapter.createTemplate(this, page, '<button></button>');
-
-    assert.notOk(page.areButtonsAbsent);
+    assert.notOk(PAGE.areButtonsAbsent);
   });
 
   test('treates count value === 0 as falsy', function(assert) {
     assert.expect(1);
 
-    const page = create({
-      buttonCount: count('button'),
-      areButtonsAbsent: none('buttonCount')
-    });
+    this.adapter.createTemplate(this, PAGE, '<div></div>');
 
-    this.adapter.createTemplate(this, page, '<div></div>');
-
-    assert.ok(page.areButtonsAbsent);
+    assert.ok(PAGE.areButtonsAbsent);
   });
 });
 
 moduleForProperty('none | handling `collection` values', function(test) {
 
+  const PAGE = create({
+    spans: collection({
+      itemScope: 'span'
+    }),
+    hasNoSpans: none('spans')
+  });
+
   test('treats empty collection as falsy', function(assert) {
     assert.expect(1);
 
-    const page = create({
-      foo: collection({
-        itemScope: 'span'
-      }),
-      isFooNone: none('foo')
-    });
+    this.adapter.createTemplate(this, PAGE, '<div>Lorem ipsum</div>');
 
-    this.adapter.createTemplate(this, page, '<div>Lorem ipsum</div>');
-
-    assert.ok(page.isFooNone);
+    assert.ok(PAGE.hasNoSpans);
   });
 
   test('treats non-empty collection as truthy', function(assert) {
     assert.expect(1);
 
-    const page = create({
-      foo: collection({
-        itemScope: 'div'
-      }),
-      isFooNone: none('foo')
-    });
+    this.adapter.createTemplate(this, PAGE, '<span>Lorem ipsum</span>');
 
-    this.adapter.createTemplate(this, page, '<div>Lorem ipsum</div>');
-
-    assert.notOk(page.isFooNone);
+    assert.notOk(PAGE.hasNoSpans);
   });
 });
 
@@ -583,15 +493,15 @@ moduleForProperty('none | handling function return values', function(test) {
       bar() {
         return null;
       },
-      isBartNone: none('bar'),
+      isBarNone: none('bar')
     });
 
     assert.ok(page.isFooNone);
-    assert.notOk(page.isBarNone);
+    assert.ok(page.isBarNone);
   });
 
   test('handles a function that returns an array', function(assert) {
-    assert.expect(2);
+    assert.expect(3);
 
     const page = create({
       foo() {
@@ -600,12 +510,37 @@ moduleForProperty('none | handling function return values', function(test) {
       isFooNone: none('foo'),
 
       bar() {
-        return ['lorem'];
+        return ['lorem', false];
       },
-      isBartNone: none('bar'),
+      isBarNone: none('bar'),
+
+      baz() {
+        return [null, undefined, 0, false, ''];
+      },
+      isBazNone: none('baz')
     });
 
     assert.ok(page.isFooNone);
+    assert.notOk(page.isBarNone);
+    assert.ok(page.isBazNone);
+  });
+
+  test('handles a function that returns an object', function(assert) {
+    assert.expect(2);
+
+    const page = create({
+      foo() {
+        return {};
+      },
+      isFooNone: none('foo'),
+
+      bar() {
+        return { hello: 'world' };
+      },
+      isBarNone: none('bar')
+    });
+
+    assert.notOk(page.isFooNone);
     assert.notOk(page.isBarNone);
   });
 
@@ -664,110 +599,87 @@ moduleForProperty('none | handling function return values', function(test) {
   });
 });
 
-moduleForProperty('none | handling multiple properties', function(test) {
+moduleForProperty('none | checking falsiness of multiple properties', function(test) {
+
+  const PAGE = create({
+    isSubmitButtonVisible: isVisible('.submit-button'),
+    labelText: text('label'),
+    areInstructionsShown: {
+      isDescriptor: true,
+      get() {
+        return this.labelText === 'I am the instructions';
+      }
+    },
+    isFormInSubmittedState: none('isSubmitButtonVisible', 'areInstructionsShown')
+  });
+
   test('returns false if all property values are falsy', function(assert) {
     assert.expect(3);
 
-    const page = create({
-      isSubmitButtonVisible: isVisible('.submit-button'),
-      instructionsText: text('label'),
-      areInstructionsShown: {
-        isDescriptor: true,
-        get() {
-          return this.instructionsText === 'Submit your info';
-        }
-      },
-      isFormDisabled: none('isSubmitButtonVisible', 'areInstructionsShown')
-    });
-
-    this.adapter.createTemplate(this, page, `
-      <label>Nothing to do here</label>
+    this.adapter.createTemplate(this, PAGE, `
+      <label>I am not the instructions</label>
       <button class="submit-button" hidden></button>
     `);
 
-    assert.equal(page.areInstructionsShown, false);
-    assert.equal(page.isSubmitButtonVisible, false);
-    assert.ok(page.isFormDisabled);
+    assert.equal(PAGE.areInstructionsShown, false);
+    assert.equal(PAGE.isSubmitButtonVisible, false);
+    assert.ok(PAGE.isFormInSubmittedState);
   });
 
   test('returns true if any property value is truthy', function(assert) {
     assert.expect(3);
 
-    const page = create({
-      isSubmitButtonVisible: isVisible('.submit-button'),
-      instructionsText: text('label'),
-      areInstructionsShown: {
-        isDescriptor: true,
-        get() {
-          return this.instructionsText === 'Submit your info';
-        }
-      },
-      isFormDisabled: none('areInstructionsShown', 'isSubmitButtonVisible')
-    });
-
-    this.adapter.createTemplate(this, page, `
-      <label>Nothing to do here</label>
+    this.adapter.createTemplate(this, PAGE, `
+      <label>I am not the instructions</label>
       <button class="submit-button"></button>
     `);
 
-    assert.equal(page.areInstructionsShown, false);
-    assert.equal(page.isSubmitButtonVisible, true);
-    assert.notOk(page.isFormDisabled);
+    assert.equal(PAGE.areInstructionsShown, false);
+    assert.equal(PAGE.isSubmitButtonVisible, true);
+    assert.notOk(PAGE.isFormInSubmittedState);
   });
 });
 
 moduleForProperty('none | handling properties with { multiple: true }', function(test) {
 
+  const PAGE = create({
+    activeSpanAttrValue: attribute('data-active', 'span', { multiple: true }),
+    spanText: text('span', { multiple: true }),
+    areSpansInactive: none('activeSpanAttrValue', 'spanText')
+  });
+
   test('returns true if any value is truthy', function(assert) {
-    assert.expect(4);
+    assert.expect(3);
 
-    const page = create({
-      activeSpanAttrValue: attribute('data-active', 'span', { multiple: true }),
-      spanText: text('span', { multiple: true }),
-      areBoxesChecked: is(':checked', '[type="checkbox"]', { multiple: true }),
-      isPageInactive: none('activeSpanAttrValue', 'spanText', 'areBoxesChecked')
-    });
-
-    this.adapter.createTemplate(this, page, `
-      <input type="checkbox">
-      <input type="checkbox" checked>
+    this.adapter.createTemplate(this, PAGE, `
       <span>Lorem</span>
       <span data-active=""></span>
       <span data-active="false"></span>
-      <span data-active=""></span>
     `);
 
-    assert.deepEqual(page.activeSpanAttrValue, [undefined, '', 'false', '']);
-    assert.deepEqual(page.spanText, ['Lorem', '', '', '']);
-    assert.equal(page.areBoxesChecked, false);
-    assert.notOk(page.isPageInactive);
+    assert.deepEqual(PAGE.activeSpanAttrValue, [undefined, '', 'false']);
+    assert.deepEqual(PAGE.spanText, ['Lorem', '', '']);
+    assert.notOk(PAGE.areSpansInactive);
   });
 
   test('returns false if all values are falsy', function(assert) {
-    assert.expect(1);
+    assert.expect(3);
 
-    const page = create({
-      activeSpanAttrValue: attribute('data-active', 'span', { multiple: true }),
-      spanText: text('span', { multiple: true }),
-      areBoxesChecked: is(':checked', '[type="checkbox"]', { multiple: true }),
-      isPageInactive: none('activeSpanAttrValue', 'spanText', 'areBoxesChecked')
-    });
-
-    this.adapter.createTemplate(this, page, `
-      <input type="checkbox">
-      <input type="checkbox">
+    this.adapter.createTemplate(this, PAGE, `
       <span></span>
       <span data-active=""></span>
       <span data-active="false"></span>
     `);
 
-    assert.ok(page.isPageInactive);
+    assert.deepEqual(PAGE.activeSpanAttrValue, [undefined, '', 'false']);
+    assert.deepEqual(PAGE.spanText, ['', '', '']);
+    assert.ok(PAGE.areSpansInactive);
   });
 });
 
 moduleForProperty('none | handling nested properties', function(test) {
 
-  const page = create({
+  const PAGE = create({
     body: {
       span: {
         scope: 'span',
@@ -787,29 +699,29 @@ moduleForProperty('none | handling nested properties', function(test) {
   test('returns true if any value is truthy', function(assert) {
     assert.expect(1);
 
-    this.adapter.createTemplate(this, page, `
+    this.adapter.createTemplate(this, PAGE, `
       <input type="checkbox" checked>
       <span data-active="false"></span>
     `);
 
-    assert.notOk(page.isPageInactive);
+    assert.notOk(PAGE.isPageInactive);
   });
 
   test('returns false if all values are falsy', function(assert) {
     assert.expect(1);
 
-    this.adapter.createTemplate(this, page, `
+    this.adapter.createTemplate(this, PAGE, `
       <input type="checkbox">
       <span data-active="false"></span>
     `);
 
-    assert.ok(page.isPageInactive);
+    assert.ok(PAGE.isPageInactive);
   });
 });
 
 moduleForProperty('none | handling aliased properties', function(test) {
 
-  const page = create({
+  const PAGE = create({
     body: {
       span: {
         scope: 'span',
@@ -833,22 +745,22 @@ moduleForProperty('none | handling aliased properties', function(test) {
   test('returns true if any value is truthy', function(assert) {
     assert.expect(1);
 
-    this.adapter.createTemplate(this, page, `
+    this.adapter.createTemplate(this, PAGE, `
       <input type="checkbox" checked>
       <span data-active="false"></span>
     `);
 
-    assert.notOk(page.isPageInactive);
+    assert.notOk(PAGE.isPageInactive);
   });
 
   test('returns false if all values are falsy', function(assert) {
     assert.expect(1);
 
-    this.adapter.createTemplate(this, page, `
+    this.adapter.createTemplate(this, PAGE, `
       <input type="checkbox">
       <span data-active="false"></span>
     `);
 
-    assert.ok(page.isPageInactive);
+    assert.ok(PAGE.isPageInactive);
   });
 });

--- a/tests/unit/-private/properties/none-test.js
+++ b/tests/unit/-private/properties/none-test.js
@@ -1,0 +1,766 @@
+import { moduleForProperty } from '../../../helpers/properties';
+import {
+  attribute,
+  create,
+  collection,
+  count,
+  hasClass,
+  is,
+  isHidden,
+  isVisible,
+  notHasClass,
+  property,
+  text,
+  value
+} from 'ember-cli-page-object';
+import { none } from 'ember-cli-page-object/macros';
+
+moduleForProperty('none | handling `attribute` values', function(test) {
+
+  test('treats "true" attribute value as truthy', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      activeAttributeValue: attribute('data-active', 'button'),
+      isButtonInactive: none('activeAttributeValue')
+    });
+
+    this.adapter.createTemplate(this, page, '<button data-active="true"></button>');
+
+    assert.notOk(page.isButtonInactive);
+  });
+
+  test('treats any string attribute value other than "false" as truthy', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      activeAttributeValue: attribute('data-active', 'button'),
+      isButtonInactive: none('activeAttributeValue')
+    });
+
+    this.adapter.createTemplate(this, page, '<button data-active="0"></button>');
+
+    assert.notOk(page.isButtonInactive);
+  });
+
+  test('treats "false" attribute value as falsy', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      activeAttributeValue: attribute('data-active', 'button'),
+      isButtonInactive: none('activeAttributeValue')
+    });
+
+    this.adapter.createTemplate(this, page, '<button data-active="false"></button>');
+
+    assert.ok(page.isButtonInactive);
+  });
+
+  test('can handle custom falsy values', function(assert) {
+    assert.expect(6);
+
+    const page = create({
+      button1ActiveAttribute: attribute('data-active', '.button-1', {
+        falsyValues: ['no']
+      }),
+      isButton1Inactive: none('button1ActiveAttribute'),
+
+      button2ActiveAttribute: attribute('data-active', '.button-2', {
+        falsyValues: ['0']
+      }),
+      isButton2Inactive: none('button2ActiveAttribute'),
+
+      button3ActiveAttribute: attribute('data-active', '.button-3'),
+      isButton3Inactive: none('button2ActiveAttribute'),
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <button class="button-1" data-active="no"></button>
+      <button class="button-2" data-active="0"></button>
+      <button class="button-3" data-active="false"></button>
+    `);
+
+    assert.equal(page.button1ActiveAttribute, 'no');
+    assert.ok(page.isButton1Inactive);
+
+    assert.equal(page.button2ActiveAttribute, '0');
+    assert.ok(page.isButton2Inactive);
+
+    assert.equal(page.button3ActiveAttribute, 'false');
+    assert.ok(page.isButton3Inactive);
+  });
+});
+
+moduleForProperty('none | handling `property` values', function(test) {
+
+  test('treats true property value as truthy', function(assert) {
+    assert.expect(2);
+
+    const page = create({
+      isBoxChecked: property('checked', '[type=checkbox]'),
+      isFormEmpty: none('isBoxChecked')
+    });
+
+    this.adapter.createTemplate(this, page, '<input type="checkbox" checked=true>');
+
+    assert.equal(page.isBoxChecked, true);
+    assert.notOk(page.isFormEmpty);
+  });
+
+  test('treats false property value as falsy', function(assert) {
+    assert.expect(2);
+
+    const page = create({
+      isBoxChecked: property('checked', '[type=checkbox]'),
+      isFormEmpty: none('isBoxChecked')
+    });
+
+    this.adapter.createTemplate(this, page, '<input type="checkbox">');
+
+    assert.equal(page.isBoxChecked, false);
+    assert.ok(page.isFormEmpty);
+  });
+
+  test('treats empty string property value as falsy', function(assert) {
+    assert.expect(2);
+
+    const page = create({
+      autoCompleteProp: property('autocomplete', 'input'),
+      inputAutoCompletes: none('autoCompleteProp')
+    });
+
+    this.adapter.createTemplate(this, page, '<input type="text">');
+
+    assert.equal(page.autoCompleteProp, '');
+    assert.ok(page.inputAutoCompletes);
+  });
+
+  test('treats undefined property value as falsy', function(assert) {
+    assert.expect(2);
+
+    const page = create({
+      fooProperty: property('foo-made-up-property', '[type=checkbox]'),
+      isFormEmpty: none('fooProperty')
+    });
+
+    this.adapter.createTemplate(this, page, '<input type="checkbox">');
+
+    assert.equal(page.fooProperty, undefined);
+    assert.ok(page.isFormEmpty);
+  });
+
+  test('can handle custom falsy property values', function (assert) {
+    assert.expect(6);
+
+    const page = create({
+      input1AutocompleteProp: property('autocomplete', '.input-1', {
+        falsyValues: ['off']
+      }),
+      input1DoesNotAutocomplete: none('input1AutocompleteProp'),
+
+      input2AutocompleteProp: property('autocomplete', '.input-2', {
+        falsyValues: ['off']
+      }),
+      input2DoesNotAutocomplete: none('input2AutocompleteProp'),
+
+      input3AutocompleteProp: property('autocomplete', '.input-3', {
+        falsyValues: ['off']
+      }),
+      input3DoesNotAutoComplete: none('input3AutocompleteProp')
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <input class="input-1" type="text">
+      <input class="input-2" type="text" autocomplete="off">
+      <input class="input-3" type="text" autocomplete="email">
+    `);
+
+    assert.equal(page.input1AutocompleteProp, '');
+    assert.ok(page.input1DoesNotAutocomplete);
+
+    assert.equal(page.input2AutocompleteProp, 'off');
+    assert.ok(page.input2DoesNotAutocomplete);
+
+    assert.equal(page.input3AutocompleteProp, 'email');
+    assert.notOk(page.input3DoesNotAutoComplete);
+  });
+});
+
+moduleForProperty('none | handling `text` values', function(test) {
+
+  test('treats non-empty text value as truthy', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      buttonText: text('button'),
+      isButtonInactive: none('buttonText')
+    });
+
+    this.adapter.createTemplate(this, page, '<button>Foo</button>');
+
+    assert.notOk(page.isButtonInactive);
+  });
+
+  test('treats "false" text value as truthy', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      buttonText: text('button'),
+      isButtonInactive: none('buttonText')
+    });
+
+    this.adapter.createTemplate(this, page, '<button>false</button>');
+
+    assert.notOk(page.isButtonInactive);
+  });
+
+  test('treats white space text value as falsy by default', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      buttonText: text('button'),
+      isButtonInactive: none('buttonText')
+    });
+
+    this.adapter.createTemplate(this, page, '<button>  </button>');
+    assert.ok(page.isButtonInactive);
+  });
+
+  test('treats white space text value as truthy if { normalize: false } is passed into options', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      buttonText: text('button', { normalize: false }),
+      isButtonInactive: none('buttonText')
+    });
+
+    this.adapter.createTemplate(this, page, '<button>  </button>');
+    assert.notOk(page.isButtonInactive);
+  });
+
+  test('treats empty string text value as falsy', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      buttonText: text('button'),
+      isButtonInactive: none('buttonText')
+    });
+
+    this.adapter.createTemplate(this, page, '<button></button>');
+
+    assert.ok(page.isButtonInactive);
+  });
+
+  test('can handle custom falsy values', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      buttonText: text('button', { falsyValues: ['---'] }),
+      isButtonInactive: none('buttonText')
+    });
+
+    this.adapter.createTemplate(this, page, '<button>---</button>');
+
+    assert.ok(page.isButtonInactive);
+  });
+});
+
+moduleForProperty('none | handling `value` values', function(test) {
+
+  test('treats non-empty string value as truthy', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      inputValue: value('input'),
+      isInputEmpty: none('inputValue')
+    });
+
+    this.adapter.createTemplate(this, page, '<input type="text">');
+    $('input').val('Lorem');
+
+    assert.notOk(page.isInputEmpty);
+  });
+
+  test('treats "false" value as truthy', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      inputValue: value('input'),
+      isInputEmpty: none('inputValue')
+    });
+
+    this.adapter.createTemplate(this, page, '<input type="text">');
+    $('input').val('false');
+
+    assert.notOk(page.isInputEmpty);
+  });
+
+  test('treats white space value as truthy', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      inputValue: value('input'),
+      isInputEmpty: none('inputValue')
+    });
+
+    this.adapter.createTemplate(this, page, '<input type="text">');
+    $('input').val('  ');
+
+    assert.notOk(page.isInputEmpty);
+  });
+
+  test('treats empty string value as falsy', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      inputValue: value('input'),
+      isInputEmpty: none('inputValue')
+    });
+
+    this.adapter.createTemplate(this, page, '<input type="text">');
+    $('input').val('');
+
+    assert.ok(page.isInputEmpty);
+  });
+
+  test('can handle custom falsy values', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      inputValue: value('input', { falsyValues: ['---'] }),
+      isInputEmpty: none('inputValue')
+    });
+
+    this.adapter.createTemplate(this, page, '<input type="text">');
+    $('input').val('---');
+
+    assert.ok(page.isInputEmpty);
+  });
+});
+
+moduleForProperty('none | handling `count` values', function(test) {
+
+  test('treates count value > 0 as truthy', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      buttonCount: count('button'),
+      areButtonsAbsent: none('buttonCount')
+    });
+
+    this.adapter.createTemplate(this, page, '<button></button>');
+
+    assert.notOk(page.areButtonsAbsent);
+  });
+
+  test('treates count value === 0 as falsy', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      buttonCount: count('button'),
+      areButtonsAbsent: none('buttonCount')
+    });
+
+    this.adapter.createTemplate(this, page, '<div></div>');
+
+    assert.ok(page.areButtonsAbsent);
+  });
+});
+
+moduleForProperty('none | handling `collection` values', function(test) {
+
+  test('treats empty collection as falsy', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      foo: collection({
+        itemScope: 'span'
+      }),
+      isFooNone: none('foo')
+    });
+
+    this.adapter.createTemplate(this, page, '<div>Lorem ipsum</div>');
+
+    assert.ok(page.isFooNone);
+  });
+
+  test('treats non-empty collection as truthy', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      foo: collection({
+        itemScope: 'div'
+      }),
+      isFooNone: none('foo')
+    });
+
+    this.adapter.createTemplate(this, page, '<div>Lorem ipsum</div>');
+
+    assert.notOk(page.isFooNone);
+  });
+});
+
+moduleForProperty('none | handling properties that return booleans', function(test) {
+  test('handles `isVisible` values', function(assert) {
+    assert.expect(2);
+
+    const page = create({
+      isButton1Visible: isVisible('.button-1'),
+      isButton1Hidden: none('isButton1Visible'),
+
+      isButton2Visible: isVisible('.button-2'),
+      isButton2Hidden: none('isButton2Visible')
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <div>
+        <button class="button-1" hidden>Submit</button>
+        <button class="button-2">Submit</button>
+      </div>
+    `);
+
+    assert.ok(page.isButton1Hidden);
+    assert.notOk(page.isButton2Hidden);
+  });
+
+  test('handles `isHidden` values', function(assert) {
+    assert.expect(2);
+
+    const page = create({
+      isButton1Hidden: isHidden('.button-1'),
+      isButton1Visible: none('isButton1Hidden'),
+
+      isButton2Hidden: isHidden('.button-2'),
+      isButton2Visible: none('isButton2Hidden')
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <div>
+        <button class="button-1">Submit</button>
+        <button class="button-2" hidden>Submit</button>
+      </div>
+    `);
+
+    assert.ok(page.isButton1Visible);
+    assert.notOk(page.isButton2Visible);
+  });
+
+  test('handles `hasClass` values', function(assert) {
+    assert.expect(2);
+
+    const page = create({
+      isButton1Active: hasClass('is-active', '.button-1'),
+      isButton1Inactive: none('isButton1Active'),
+
+      isButton2Active: hasClass('is-active', '.button-2'),
+      isButton2Inactive: none('isButton2Active')
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <div>
+        <button class="button-1">Submit</button>
+        <button class="button-2 is-active">Submit</button>
+      </div>
+    `);
+
+    assert.ok(page.isButton1Inactive);
+    assert.notOk(page.isButton2Inactive);
+  });
+
+  test('handles `notHasClass` values', function(assert) {
+    assert.expect(2);
+
+    const page = create({
+      isButton1Inactive: notHasClass('is-active', '.button-1'),
+      isButton1Active: none('isButton1Inactive'),
+
+      isButton2Inactive: notHasClass('is-active', '.button-2'),
+      isButton2Active: none('isButton2Inactive')
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <div>
+        <button class="button-1 is-active">Submit</button>
+        <button class="button-2">Submit</button>
+      </div>
+    `);
+
+    assert.ok(page.isButton1Active);
+    assert.notOk(page.isButton2Active);
+  });
+
+  test('handles `is` values', function(assert) {
+    assert.expect(2);
+
+    const page = create({
+      isButton1Disabled: is(':disabled', '.button-1'),
+      isButton1Enabled: none('isButton1Disabled'),
+
+      isButton2Disabled: is(':disabled', '.button-2'),
+      isButton2Enabled: none('isButton2Disabled')
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <div>
+        <button class="button-1">Submit</button>
+        <button class="button-2" disabled>Submit</button>
+      </div>
+    `);
+
+    assert.ok(page.isButton1Enabled);
+    assert.notOk(page.isButton2Enabled);
+  });
+});
+
+moduleForProperty('none | handling function return values', function(test) {
+
+  test('handles a function that returns a number', function(assert) {
+    assert.expect(2);
+
+    const page = create({
+      foo() {
+        return 0;
+      },
+      isFooNone: none('foo'),
+
+      bar() {
+        return 1;
+      },
+      isBarNone: none('bar')
+    });
+
+    assert.ok(page.isFooNone);
+    assert.notOk(page.isBarNone);
+  });
+
+  test('handles a function that returns a string', function(assert) {
+    assert.expect(2);
+
+    const page = create({
+      foo() {
+        return '';
+      },
+      isFooNone: none('foo'),
+
+      bar() {
+        return 'lorem';
+      },
+      isBarNone: none('bar')
+    });
+
+    assert.ok(page.isFooNone);
+    assert.notOk(page.isBarNone);
+  });
+
+  test('handles a function that returns a boolean', function(assert) {
+    assert.expect(2);
+
+    const page = create({
+      foo() {
+        return false;
+      },
+      isFooNone: none('foo'),
+
+      bar() {
+        return true;
+      },
+      isBarNone: none('bar')
+    });
+
+    assert.ok(page.isFooNone);
+    assert.notOk(page.isBarNone);
+  });
+
+  test('handles a function that returns null or undefined', function(assert) {
+    assert.expect(2);
+
+    const page = create({
+      foo() {
+        return undefined;
+      },
+      isFooNone: none('foo'),
+
+      bar() {
+        return null;
+      },
+      isBartNone: none('bar'),
+    });
+
+    assert.ok(page.isFooNone);
+    assert.notOk(page.isBarNone);
+  });
+
+  test('handles a function that returns an array', function(assert) {
+    assert.expect(2);
+
+    const page = create({
+      foo() {
+        return [];
+      },
+      isFooNone: none('foo'),
+
+      bar() {
+        return ['lorem'];
+      },
+      isBartNone: none('bar'),
+    });
+
+    assert.ok(page.isFooNone);
+    assert.notOk(page.isBarNone);
+  });
+
+  test('handles a function that returns a reference to a collection', function(assert) {
+    assert.expect(2);
+
+    const page = create({
+      spans: collection({
+        itemScope: 'span'
+      }),
+      foo() {
+        return this.spans;
+      },
+      isFooNone: none('foo'),
+
+      divs: collection({
+        itemScope: 'div'
+      }),
+      bar() {
+        return this.divs;
+      },
+      isBarNone: none('bar')
+    });
+
+    this.adapter.createTemplate(this, page, '<div>Lorem ipsum</div>');
+
+    assert.ok(page.isFooNone);
+    assert.notOk(page.isBarNone);
+  });
+
+  test('handles a function that returns the enumerable for a collection', function(assert) {
+    assert.expect(2);
+
+    const page = create({
+      spans: collection({
+        itemScope: 'span'
+      }),
+      foo() {
+        return this.spans();
+      },
+      isFooNone: none('foo'),
+
+      divs: collection({
+        itemScope: 'div'
+      }),
+      bar() {
+        return this.divs();
+      },
+      isBarNone: none('bar')
+    });
+
+    this.adapter.createTemplate(this, page, '<div>Lorem ipsum</div>');
+
+    assert.ok(page.isFooNone);
+    assert.notOk(page.isBarNone);
+  });
+});
+
+moduleForProperty('none | handling multiple properties', function(test) {
+  test('returns false if all property values are falsy', function(assert) {
+    assert.expect(3);
+
+    const page = create({
+      isSubmitButtonVisible: isVisible('.submit-button'),
+      instructionsText: text('label'),
+      areInstructionsShown: {
+        isDescriptor: true,
+        get() {
+          return this.instructionsText === 'Submit your info';
+        }
+      },
+      isFormDisabled: none('isSubmitButtonVisible', 'areInstructionsShown')
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <label>Nothing to do here</label>
+      <button class="submit-button" hidden></button>
+    `);
+
+    assert.equal(page.areInstructionsShown, false);
+    assert.equal(page.isSubmitButtonVisible, false);
+    assert.ok(page.isFormDisabled);
+  });
+
+  test('returns true if any property value is truthy', function(assert) {
+    assert.expect(3);
+
+    const page = create({
+      isSubmitButtonVisible: isVisible('.submit-button'),
+      instructionsText: text('label'),
+      areInstructionsShown: {
+        isDescriptor: true,
+        get() {
+          return this.instructionsText === 'Submit your info';
+        }
+      },
+      isFormDisabled: none('areInstructionsShown', 'isSubmitButtonVisible')
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <label>Nothing to do here</label>
+      <button class="submit-button"></button>
+    `);
+
+    assert.equal(page.areInstructionsShown, false);
+    assert.equal(page.isSubmitButtonVisible, true);
+    assert.notOk(page.isFormDisabled);
+  });
+});
+
+moduleForProperty('none | handling properties with { multiple: true }', function(test) {
+
+  test('returns true if any value is truthy', function(assert) {
+    assert.expect(4);
+
+    const page = create({
+      activeSpanAttrValue: attribute('data-active', 'span', { multiple: true }),
+      spanText: text('span', { multiple: true }),
+      areBoxesChecked: is(':checked', '[type="checkbox"]', { multiple: true }),
+      isPageInactive: none('activeSpanAttrValue', 'spanText', 'areBoxesChecked')
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <input type="checkbox">
+      <input type="checkbox" checked>
+      <span>Lorem</span>
+      <span data-active=""></span>
+      <span data-active="false"></span>
+      <span data-active=""></span>
+    `);
+
+    assert.deepEqual(page.activeSpanAttrValue, [undefined, '', 'false', '']);
+    assert.deepEqual(page.spanText, ['Lorem', '', '', '']);
+    assert.equal(page.areBoxesChecked, false);
+    assert.notOk(page.isPageInactive);
+  });
+
+  test('returns false if all values are falsy', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      activeSpanAttrValue: attribute('data-active', 'span', { multiple: true }),
+      spanText: text('span', { multiple: true }),
+      areBoxesChecked: is(':checked', '[type="checkbox"]', { multiple: true }),
+      isPageInactive: none('activeSpanAttrValue', 'spanText', 'areBoxesChecked')
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <input type="checkbox">
+      <input type="checkbox">
+      <span></span>
+      <span data-active=""></span>
+      <span data-active="false"></span>
+    `);
+
+    assert.ok(page.isPageInactive);
+  });
+});

--- a/tests/unit/-private/properties/none-test.js
+++ b/tests/unit/-private/properties/none-test.js
@@ -13,7 +13,7 @@ import {
   text,
   value
 } from 'ember-cli-page-object';
-import { none } from 'ember-cli-page-object/macros';
+import { alias, none } from 'ember-cli-page-object/macros';
 
 moduleForProperty('none | handling `attribute` values', function(test) {
 
@@ -758,6 +758,62 @@ moduleForProperty('none | handling properties with { multiple: true }', function
       <input type="checkbox">
       <span></span>
       <span data-active=""></span>
+      <span data-active="false"></span>
+    `);
+
+    assert.ok(page.isPageInactive);
+  });
+});
+
+moduleForProperty('none | handling aliased properties', function(test) {
+  test('returns true if any value is truthy', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      span: {
+        scope: 'span',
+        activeAttrValue: attribute('data-active')
+      },
+      checkbox: {
+        scope: '[type="checkbox"]',
+        isChecked: is(':checked')
+      },
+
+      isSpanActive: alias('span.activeAttrValue'),
+      isChecked: alias('checkbox.isChecked'),
+
+      isPageInactive: none('isSpanActive', 'isChecked')
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <input type="checkbox" checked>
+      <span data-active="false"></span>
+    `);
+
+    assert.notOk(page.isPageInactive);
+  });
+
+  test('returns false if all values are falsy', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      span: {
+        scope: 'span',
+        activeAttrValue: attribute('data-active')
+      },
+      checkbox: {
+        scope: '[type="checkbox"]',
+        isChecked: is(':checked')
+      },
+
+      isSpanActive: alias('span.activeAttrValue'),
+      isChecked: alias('checkbox.isChecked'),
+
+      isPageInactive: none('isSpanActive', 'isChecked')
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <input type="checkbox">
       <span data-active="false"></span>
     `);
 

--- a/tests/unit/-private/properties/none-test.js
+++ b/tests/unit/-private/properties/none-test.js
@@ -61,12 +61,12 @@ moduleForProperty('none | handling `attribute` values', function(test) {
 
     const page = create({
       button1ActiveAttribute: attribute('data-active', '.button-1', {
-        falsyValues: ['no']
+        falsy: ['no']
       }),
       isButton1Inactive: none('button1ActiveAttribute'),
 
       button2ActiveAttribute: attribute('data-active', '.button-2', {
-        falsyValues: ['0']
+        falsy: ['0']
       }),
       isButton2Inactive: none('button2ActiveAttribute'),
 
@@ -154,17 +154,17 @@ moduleForProperty('none | handling `property` values', function(test) {
 
     const page = create({
       input1AutocompleteProp: property('autocomplete', '.input-1', {
-        falsyValues: ['off']
+        falsy: ['off']
       }),
       input1DoesNotAutocomplete: none('input1AutocompleteProp'),
 
       input2AutocompleteProp: property('autocomplete', '.input-2', {
-        falsyValues: ['off']
+        falsy: ['off']
       }),
       input2DoesNotAutocomplete: none('input2AutocompleteProp'),
 
       input3AutocompleteProp: property('autocomplete', '.input-3', {
-        falsyValues: ['off']
+        falsy: ['off']
       }),
       input3DoesNotAutoComplete: none('input3AutocompleteProp')
     });
@@ -255,7 +255,7 @@ moduleForProperty('none | handling `text` values', function(test) {
     assert.expect(1);
 
     const page = create({
-      buttonText: text('button', { falsyValues: ['---'] }),
+      buttonText: text('button', { falsy: ['---'] }),
       isButtonInactive: none('buttonText')
     });
 
@@ -327,7 +327,7 @@ moduleForProperty('none | handling `value` values', function(test) {
     assert.expect(1);
 
     const page = create({
-      inputValue: value('input', { falsyValues: ['---'] }),
+      inputValue: value('input', { falsy: ['---'] }),
       isInputEmpty: none('inputValue')
     });
 


### PR DESCRIPTION
### Purpose
- Add `none` helper: 
  - Allows PageObject to define a property that depends on several other properties being falsy.
    - If all target properties are falsy, return `true`
    - If any target properties are truthy, return `false`
- Addresses https://github.com/san650/ember-cli-page-object/issues/299

### Approach
- For properties whose value is a boolean or a number, `none` simply checks whether the value of the property is truthy.
- For properties whose value can be a string (`attribute`, `property`, `text`, `value`):
  - Allow custom falsy values to be passed into the options for the helper (e.g., `'---'`, `'none'`, `'off'`)
  - `attribute`: Treat `"false"` as falsy
- For properties whose value is a collection:
  - Treat empty collections as falsy and non-empty collections as truthy.

### Test Coverage
- Unit tests for `none` helper

### Todo
- [ ] Verify and test use of `none` helper with **nested** properties
- [x] Verify and test use of `none` helper with **aliased** properties
- [ ] Add documentation

### Open Questions
- [ ] The unit test coverage is pretty detailed, but I feel like it has to be in order to ensure that nothing slips through the cracks. Are the tests reasonably readable? Does this level of coverage feel right, or am I overdoing it?
- [ ] What do we think of this approach of registering properties with custom falsy values so that the `none` helper can use that information?