### PR TITLE
Triggerable returns function with eventProperties parameter

### DIFF
--- a/addon/-private/properties/triggerable.js
+++ b/addon/-private/properties/triggerable.js
@@ -31,6 +31,18 @@ import { getExecutionContext } from '../execution_context';
  *
  * @example
  *
+ * // <input class="name">
+ * // <input class="email">
+ *
+ * const page = PageObject.create({
+ *   keydown: triggerable('keypress', '.name')
+ * });
+ *
+ * // triggers keypress using enter key on element with selector '.name'
+ * page.keydown({ which: 13 });
+ *
+ * @example
+ *
  * // <div class="scope">
  * //   <input class="name">
  * // </div>
@@ -55,7 +67,7 @@ import { getExecutionContext } from '../execution_context';
  *   focus: triggerable('focus', '.name')
  * });
  *
- * // clicks on element with selector '.scope button.continue'
+ * // focuses on element with selector '.scope .name'
  * page.focus();
  *
  * @public
@@ -75,17 +87,19 @@ export function triggerable(event, selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      return function() {
-        let executionContext = getExecutionContext(this);
-        let options = assign({ pageObjectKey: `${key}()` }, userOptions);
+      return function(eventProperties = {}) {
+        const executionContext = getExecutionContext(this);
+        const options = assign({ pageObjectKey: `${key}()` }, userOptions);
+        const staticEventProperties = assign({}, options.eventProperties);
 
         return executionContext.runAsync((context) => {
-          let fullSelector = buildSelector(this, selector, options);
-          let container =  options.testContainer || findClosestValue(this, 'testContainer');
+          const fullSelector = buildSelector(this, selector, options);
+          const container =  options.testContainer || findClosestValue(this, 'testContainer');
 
           context.assertElementExists(fullSelector, options);
 
-          context.triggerEvent(fullSelector, container, event, options.eventProperties);
+          const mergedEventProperties = assign(staticEventProperties, eventProperties);
+          context.triggerEvent(fullSelector, container, event, mergedEventProperties);
         });
       };
     }

--- a/tests/unit/-private/properties/triggerable-test.js
+++ b/tests/unit/-private/properties/triggerable-test.js
@@ -22,23 +22,58 @@ moduleForProperty('triggerable', function(test) {
     return this.adapter.wait();
   });
 
-  test("calls Ember's triggerEvent helper with event options", function(assert) {
-    assert.expect(3);
+  test("calls Ember's triggerEvent helper with static event options", function(assert) {
+    assert.expect(1);
 
-    let expectedSelector = 'span';
     let page = create({
-      foo: triggerable('keypress', expectedSelector, { eventProperties: { keyCode: 13 } })
+      foo: triggerable('keypress', 'span', { eventProperties: { keyCode: 13 } })
     });
 
     this.adapter.createTemplate(this, page, '<span></span>');
 
     this.adapter.triggerEvent((actualSelector, _, event, options) => {
-      assert.equal(actualSelector, expectedSelector);
-      assert.equal(event, 'keypress');
       assert.equal(options.keyCode, 13);
     });
 
     page.foo();
+
+    return this.adapter.wait();
+  });
+
+  test("calls Ember's triggerEvent helper with dynamic event options", function(assert) {
+    assert.expect(1);
+
+    let page = create({
+      foo: triggerable('keypress', 'span')
+    });
+
+    this.adapter.createTemplate(this, page, '<span></span>');
+
+    this.adapter.triggerEvent((actualSelector, _, event, options) => {
+      assert.equal(options.keyCode, 13);
+    });
+
+    page.foo({ keyCode: 13 });
+
+    return this.adapter.wait();
+  });
+
+  test("overrides static event options with dynamic event options", function(assert) {
+    assert.expect(1);
+
+    let page = create({
+      foo: triggerable('keypress', 'span', {
+        eventProperties: { keyCode: 0 }
+      })
+    });
+
+    this.adapter.createTemplate(this, page, '<span></span>');
+
+    this.adapter.triggerEvent((actualSelector, _, event, options) => {
+      assert.equal(options.keyCode, 13);
+    });
+
+    page.foo({ keyCode: 13 });
 
     return this.adapter.wait();
   });


### PR DESCRIPTION
### Purpose
Some events can be triggered without any specified properties (e.g., `mousedown`), but others require properties like `which` (e.g., `keydown`). `triggerable` currently requires event properties to be defined at the time when `triggerable` is called in the page object, but it is sometimes more convenient to specify event properties at the time when the triggerable descriptor is used in tests. This PR modifies `triggerable` to accept either static event properties defined at the time when `triggerable` is called in the page object or dynamic event properties passed in when the descriptor is accessed.

### Test Coverage
- New tests verify that `triggerable` descriptor applies the event properties.
- New tests verify that if event properties are specified both in the `triggerable` call and the `triggerable` descriptor call, the props passed into the descriptor are applied.

### Open Questions
- [ ] Is it appropriate for `triggerable` to have two different ways of receiving `eventProperties`? Would it be better to define a separate `dynamicTriggerable` helper?