### PR TITLE
Add test macro

### DIFF
--- a/addon/-private/properties/test.js
+++ b/addon/-private/properties/test.js
@@ -1,0 +1,123 @@
+import { throwBetterError } from '../better-errors';
+import {
+  getProperty,
+  objectHasProperty
+} from '../helpers';
+
+const NEEDS_CALLBACK = '`test` expects a function to be passed in as its second argument.';
+const TESTED_PROP_NOT_FOUND = 'PageObject does not contain property';
+
+/**
+ * Creates a node whose value is returned as `true` or `false` depending on
+ * whether the target PageObject property satisfies the test specified by
+ * the provided callback function.
+ *
+ * An arrow function can be passed in as the test function, but only if it
+ * does not expect to access other PageObject properties on `this`. If some
+ * reference is needed to other PageObject properties, a standard function
+ * should be passed in as the callback.
+ *
+ * @example
+ *
+ * // <input type="text" autocomplete="on">
+ *
+ * import { create } from 'ember-cli-page-object';
+ * import { test } from 'ember-cli-page-object/macros';
+ *
+ * const page = create({
+ *   inputAutocomplete: property('autocomplete', 'input'),
+ *   isAutocompleteEnabled: test('inputAutocomplete', function(val) {
+ *     return val === 'on';
+ *   })
+ * });
+ *
+ * // checks whether the top-level property `inputAutocomplete`
+ * // passes the test `val === 'on'`.
+ * assert.ok(page.isAutocompleteEnabled);
+ *
+ * @example
+ *
+ * // <input type="text" autocomplete="on">
+ *
+ * import { create } from 'ember-cli-page-object';
+ * import { test } from 'ember-cli-page-object/macros';
+ *
+ * const page = create({
+ *   form: {
+ *     inputAutocomplete: property('autocomplete', 'input'),
+ *   },
+ *   isAutocompleteEnabled: test('form.inputAutocomplete', function(val) {
+ *     return val === 'on';
+ *   })
+ * });
+ *
+ * // checks whether the nested property `form.inputAutocomplete`
+ * // passes the test `val === 'on'`.
+ * assert.ok(page.isAutocompleteEnabled);
+ *
+ * @example
+ *
+ * // <input type="text" autocomplete="on">
+ *
+ * import { create } from 'ember-cli-page-object';
+ * import { test } from 'ember-cli-page-object/macros';
+ *
+ * const page = create({
+ *   inputAutocomplete: property('autocomplete', 'input'),
+ *   isAutocompleteEnabled: test('inputAutocomplete', val => val === 'on')
+ * });
+ *
+ * // uses an arrow function to check whether `inputAutocomplete`
+ * // passes the test `val === 'on'`.
+ * assert.ok(page.isAutocompleteEnabled);
+ *
+ * @example
+ *
+ * // <div>
+ * //   <span>Enter Your Name Here:</span>
+ * //   {{input value=name}}
+ * // </div>
+ * // <div class="greeting">Hello, {{name}}</div>
+ *
+ * import { create } from 'ember-cli-page-object';
+ * import { test } from 'ember-cli-page-object/macros';
+ *
+ * const page = create({
+ *   nameInputValue: value('input'),
+ *   greetingText: text('.greeting'),
+ *   greetingTextIncludesName: test('greetingText', function(val) {
+ *     return val === 'Hello, ' + this.nameInputValue;
+ *   })
+ * });
+ *
+ * // uses a standard function to determine whether `page.greetingText`
+ * // passes the test `val === 'Hello, ' + this.nameInputValue`.
+ * assert.ok(page.greetingTextIncludesName);
+ *
+ * @public
+ *
+ * @param {string} pathToProp - dot-separated path to a property specified on the PageObject
+ * @param {Function} callback - function used to test the value of the target PageObject property
+ * @return {Descriptor}
+ *
+ * @throws Will throw an error if the PageObject does not have the property to test.
+ * @throws Will throw an error if a function is not passed in as the second argument.
+ */
+export function test(pathToProp, callback) {
+  return {
+    isDescriptor: true,
+
+    get(key) {
+      if (typeof callback !== 'function') {
+        throwBetterError(this, key, NEEDS_CALLBACK);
+      }
+
+      if (!objectHasProperty(this, pathToProp)) {
+        throwBetterError(this, key, `${TESTED_PROP_NOT_FOUND} \`${pathToProp}\`.`);
+      }
+
+      const value = getProperty(this, pathToProp);
+      return Boolean(callback.call(this, value));
+    }
+  };
+}

--- a/addon/macros.js
+++ b/addon/macros.js
@@ -1,1 +1,2 @@
 export { alias } from './-private/properties/alias';
+export { test } from './-private/properties/test';

--- a/tests/unit/-private/properties/alias-test.js
+++ b/tests/unit/-private/properties/alias-test.js
@@ -3,22 +3,26 @@ import {
   create,
   clickable,
   collection,
-  isVisible
+  isVisible,
+  text
 } from 'ember-cli-page-object';
-import { alias } from 'ember-cli-page-object/macros';
+import {
+  alias,
+  test as testMacro
+} from 'ember-cli-page-object/macros';
 
 moduleForProperty('alias', function(test) {
   test('can alias a top-level property', function(assert) {
     assert.expect(1);
 
     const page = create({
-      foo: isVisible('button'),
-      fooAlias: alias('foo')
+      isButtonVisible: isVisible('button'),
+      aliasedIsButtonVisible: alias('isButtonVisible')
     });
 
     this.adapter.createTemplate(this, page, '<button>Look at me</button>');
 
-    assert.ok(page.fooAlias);
+    assert.ok(page.aliasedIsButtonVisible);
   });
 
   test('can alias a top-level method', function(assert) {
@@ -26,8 +30,8 @@ moduleForProperty('alias', function(test) {
 
     const expectedSelector = 'button';
     const page = create({
-      foo: clickable(expectedSelector),
-      fooAlias: alias('foo')
+      clickButton: clickable(expectedSelector),
+      aliasedClickButton: alias('clickButton')
     });
 
     this.adapter.createTemplate(this, page, '<button>Click me</button>');
@@ -36,7 +40,7 @@ moduleForProperty('alias', function(test) {
       assert.equal(actualSelector, expectedSelector);
     });
 
-    page.fooAlias();
+    page.aliasedClickButton();
 
     return this.adapter.wait();
   });
@@ -45,36 +49,35 @@ moduleForProperty('alias', function(test) {
     assert.expect(1);
 
     const page = create({
-      foo: collection({
+      buttons: collection({
         itemScope: 'button'
       }),
-      fooCollection: alias('foo')
+      aliasedButtons: alias('buttons')
     });
 
-    this.adapter.createTemplate(
-      this,
-      page,
-      '<button>Button 1</button><button>Button 2</button>'
-    );
+    this.adapter.createTemplate(this, page, `
+      <button>Button 1</button>
+      <button>Button 2</button>
+    `);
 
-    assert.equal(page.fooCollection().count, 2);
+    assert.equal(page.aliasedButtons().count, 2);
   });
 
   test('can alias a nested property', function(assert) {
     assert.expect(1);
 
     const page = create({
-      foo: {
-        bar: {
+      form: {
+        button: {
           scope: 'button'
         }
       },
-      isFooBarVisible: alias('foo.bar.isVisible')
+      aliasedIsButtonVisible: alias('form.button.isVisible')
     });
 
     this.adapter.createTemplate(this, page, '<button>Look at me</button>');
 
-    assert.ok(page.isFooBarVisible);
+    assert.ok(page.aliasedIsButtonVisible);
   });
 
   test('can alias a nested method', function(assert) {
@@ -82,12 +85,12 @@ moduleForProperty('alias', function(test) {
 
     const expectedSelector = 'button';
     const page = create({
-      foo: {
-        bar: {
+      form: {
+        button: {
           scope: expectedSelector
         }
       },
-      clickFooBar: alias('foo.bar.click')
+      aliasedClickButton: alias('form.button.click')
     });
 
     this.adapter.createTemplate(this, page, '<button>Click me</button>');
@@ -96,7 +99,7 @@ moduleForProperty('alias', function(test) {
       assert.equal(actualSelector, expectedSelector);
     });
 
-    page.clickFooBar();
+    page.aliasedClickButton();
 
     return this.adapter.wait();
   });
@@ -105,12 +108,12 @@ moduleForProperty('alias', function(test) {
     assert.expect(1);
 
     const page = create({
-      foo: {
-        bar: collection({
+      form: {
+        buttons: collection({
           itemScope: 'button'
         })
       },
-      fooBarCollection: alias('foo.bar')
+      aliasedButtons: alias('form.buttons')
     });
 
     this.adapter.createTemplate(
@@ -119,25 +122,25 @@ moduleForProperty('alias', function(test) {
       '<button>Button 1</button><button>Button 2</button>'
     );
 
-    assert.equal(page.fooBarCollection().count, 2);
+    assert.equal(page.aliasedButtons().count, 2);
   });
 
   test('can alias an aliased property', function(assert) {
     assert.expect(1);
 
     const page = create({
-      foo: {
-        bar: {
+      form: {
+        button: {
           scope: 'button'
         },
-        isBarVisible: alias('bar.isVisible')
+        isButtonVisible: alias('button.isVisible')
       },
-      isFooBarVisible: alias('foo.isBarVisible')
+      aliasedIsButtonVisible: alias('form.isButtonVisible')
     });
 
     this.adapter.createTemplate(this, page, '<button>Look at me</button>');
 
-    assert.ok(page.isFooBarVisible);
+    assert.ok(page.aliasedIsButtonVisible);
   });
 
   test('can alias an aliased method', function(assert) {
@@ -145,13 +148,13 @@ moduleForProperty('alias', function(test) {
 
     const expectedSelector = 'button';
     const page = create({
-      foo: {
-        bar: {
+      form: {
+        button: {
           scope: expectedSelector
         },
-        clickBar: alias('bar.click')
+        clickButton: alias('button.click')
       },
-      clickFooBar: alias('foo.clickBar')
+      aliasedClickButton: alias('form.clickButton')
     });
 
     this.adapter.createTemplate(this, page, '<button>Click me</button>');
@@ -160,7 +163,7 @@ moduleForProperty('alias', function(test) {
       assert.equal(actualSelector, expectedSelector);
     });
 
-    page.clickFooBar();
+    page.aliasedClickButton();
 
     return this.adapter.wait();
   });
@@ -169,15 +172,15 @@ moduleForProperty('alias', function(test) {
     assert.expect(1);
 
     const page = create({
-      foo: {
-        bar: {
-          baz: collection({
+      form: {
+        controls: {
+          buttons: collection({
             itemScope: 'button'
           })
         },
-        barBazCollection: alias('bar.baz')
+        buttons: alias('controls.buttons')
       },
-      fooBarBazCollection: alias('foo.barBazCollection')
+      aliasedButtons: alias('form.buttons')
     });
 
     this.adapter.createTemplate(
@@ -186,7 +189,25 @@ moduleForProperty('alias', function(test) {
       '<button>Button 1</button><button>Button 2</button>'
     );
 
-    assert.equal(page.fooBarBazCollection().count, 2);
+    assert.equal(page.aliasedButtons().count, 2);
+  });
+
+  test('can alias a property created with the `test` macro', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      form: {
+        buttonText: text('button'),
+        buttonTest: testMacro('buttonText', function(value) {
+          return value === 'Submit';
+        }),
+      },
+      aliasedButtonTest: alias('form.buttonTest')
+    });
+
+    this.adapter.createTemplate(this, page, '<button>Submit</button>');
+
+    assert.ok(page.aliasedButtonTest);
   });
 
   test('throws error if alias targets nonexistent top-level property', function(assert) {
@@ -221,27 +242,27 @@ moduleForProperty('alias', function(test) {
     assert.expect(1);
 
     const page = create({
-      foo: isVisible('button'),
-      fooAlias: alias('foo')
+      isButtonVisible: isVisible('button'),
+      aliasedIsButtonVisible: alias('isButtonVisible')
     });
 
     this.adapter.createTemplate(this, page, '<span>No button here</span>');
 
-    assert.equal(page.fooAlias, false);
+    assert.equal(page.aliasedIsButtonVisible, false);
   });
 
   test('does not throw error if alias targets nested property with falsy value', function(assert) {
     assert.expect(1);
 
     const page = create({
-      foo: {
+      button: {
         scope: 'button'
       },
-      isFooVisible: alias('foo.isVisible')
+      aliasedIsButtonVisible: alias('button.isVisible')
     });
 
     this.adapter.createTemplate(this, page, '<span>No button here</span>');
 
-    assert.equal(page.isFooVisible, false);
+    assert.equal(page.aliasedIsButtonVisible, false);
   });
 });

--- a/tests/unit/-private/properties/test-test.js
+++ b/tests/unit/-private/properties/test-test.js
@@ -1,0 +1,118 @@
+import { moduleForProperty } from '../../../helpers/properties';
+import {
+  create,
+  property,
+  text,
+  value
+} from 'ember-cli-page-object';
+import { test as testMacro } from 'ember-cli-page-object/macros';
+
+moduleForProperty('test', function(test) {
+  test('can test a top-level property', function(assert) {
+    assert.expect(2);
+
+    const page = create({
+      inputAutocomplete: property('autocomplete', 'input'),
+      isAutocompleteDisabled: testMacro('inputAutocomplete', function(val) {
+        return val === 'off';
+      }),
+      isAutocompleteEnabled: testMacro('inputAutocomplete', function(val) {
+        return val === 'on';
+      })
+    });
+
+    this.adapter.createTemplate(this, page, '<input autocomplete="on">');
+
+    assert.notOk(page.isAutocompleteDisabled);
+    assert.ok(page.isAutocompleteEnabled);
+  });
+
+  test('can test a nested property', function(assert) {
+    assert.expect(2);
+
+    const page = create({
+      form: {
+        inputAutocomplete: property('autocomplete', 'input'),
+      },
+      isAutocompleteDisabled: testMacro('form.inputAutocomplete', function(val) {
+        return val === 'off';
+      }),
+      isAutocompleteEnabled: testMacro('form.inputAutocomplete', function(val) {
+        return val === 'on';
+      })
+    });
+
+    this.adapter.createTemplate(this, page, '<input autocomplete="on">');
+
+    assert.notOk(page.isAutocompleteDisabled);
+    assert.ok(page.isAutocompleteEnabled);
+  });
+
+  test('executes the callback function with the descriptor\'s context for `this`', function (assert) {
+    assert.expect(1);
+
+    const page = create({
+      nameInputValue: value('input'),
+      greetingText: text('.greeting'),
+      greetingTextIncludesName: testMacro('greetingText', function(val) {
+        return val === 'Hello, ' + this.nameInputValue;
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <div>
+        <span>Enter Your Name Here:</span>
+        <input type="text" value="Ember">
+      </div>
+      <div class="greeting">Hello, Ember</div>
+    `);
+
+    assert.ok(page.greetingTextIncludesName);
+  });
+
+  test('can handle an arrow callback function that does not reference properties of `this`', function (assert) {
+    assert.expect(2);
+
+    const page = create({
+      inputAutocomplete: property('autocomplete', 'input'),
+      isAutocompleteDisabled: testMacro('inputAutocomplete', val => val === 'off'),
+      isAutocompleteEnabled: testMacro('inputAutocomplete', val => val === 'on')
+    });
+
+    this.adapter.createTemplate(this, page, '<input autocomplete="on">');
+
+    assert.notOk(page.isAutocompleteDisabled);
+    assert.ok(page.isAutocompleteEnabled);
+  });
+
+  test('throws error if `test` targets a nonexistent property', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      isAutocompleteEnabled: testMacro('inputAutocomplete', function(val) {
+        return val === 'on';
+      })
+    });
+
+    assert.throws(
+      () => page.isAutocompleteEnabled,
+      /does not contain property `inputAutocomplete`/,
+      'Target property not found'
+    );
+  });
+
+  test('throws error if a callback function is not passed in', function(assert) {
+    assert.expect(1);
+
+    const page = create({
+      inputAutocomplete: property('autocomplete', 'input'),
+      isAutocompleteEnabled: testMacro('inputAutocomplete')
+    });
+
+    assert.throws(
+      () => page.isAutocompleteEnabled,
+      /expects a function/,
+      'Callback must be passed into `test` macro'
+    );
+  });
+});


### PR DESCRIPTION
### Purpose
Provide a way to create a PageObject property whose value depends on whether some other property satisfies some set of criteria. For example, given the following PageObject:
```javascript
const page  = create({
  inputAutocomplete: property('autocomplete', 'input')
});
```
... we might want to define a property called `isAutocompleteEnabled`, which should be true if `inputAutocomplete` equals `on`.
```javascript
const page = create({
  inputAutocomplete: property('autocomplete', 'input'),
  isAutocompleteEnabled: test('inputAutocomplete', val => val === 'on')
});
``` 

### Test Coverage
Happy path & error handling covered by unit tests