### PR TITLE
change property unit tests to assert against real DOM

### DIFF
--- a/tests/helpers/properties/acceptance-adapter.js
+++ b/tests/helpers/properties/acceptance-adapter.js
@@ -1,8 +1,9 @@
-import Ember from 'ember';
 import startApp from '../start-app';
 import { module as qunitModule } from 'qunit';
 
 export { test as testForAcceptance } from 'qunit';
+
+import Ember from 'ember';
 
 let noop = function() {};
 
@@ -20,16 +21,8 @@ export function AcceptanceAdapter(original) {
 AcceptanceAdapter.prototype = {
   name: 'acceptance',
 
-  click(fn) {
-    window.click = fn;
-  },
-
-  fillIn(fn) {
-    this.spy.fillIn = fn;
-  },
-
-  triggerEvent(fn /*selector, container, eventName, eventOptions*/) {
-    window.triggerEvent = fn;
+  $(selector, isAlternative) {
+    return Ember.$(selector, isAlternative ? '#alternate-ember-testing' : '#ember-testing');
   },
 
   visit(fn) {
@@ -38,8 +31,6 @@ AcceptanceAdapter.prototype = {
 
   revert() {
     this.original.prototype = Object.create(this.originalPrototype);
-    window.click = this.originalClick;
-    window.triggerEvent = this.originalTriggerEvent;
     window.visit = this.originalVisit;
   },
 
@@ -51,6 +42,10 @@ AcceptanceAdapter.prototype = {
     }
 
     fixture(template, options);
+  },
+
+  find() {
+    return this.original.find(...arguments);
   },
 
   throws(assert, block, expected, message) {

--- a/tests/helpers/properties/integration-adapter.js
+++ b/tests/helpers/properties/integration-adapter.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
 import { fixture } from './acceptance-adapter';
 export { moduleForComponent as moduleForIntegration, test as testForIntegration } from 'ember-qunit';
 import { expectEmberError } from '../../test-helper';
+
+import Ember from 'ember';
 
 export function IntegrationAdapter(original) {
   this.original = original;
@@ -14,16 +15,8 @@ export function IntegrationAdapter(original) {
 IntegrationAdapter.prototype = {
   name: 'integration',
 
-  click(fn) {
-    this.spy.click = fn;
-  },
-
-  fillIn(fn) {
-    this.spy.fillIn = fn;
-  },
-
-  triggerEvent(fn) {
-    this.spy.triggerEvent = fn;
+  $(selector, isAlternative) {
+    return Ember.$(selector, isAlternative ? '#alternate-ember-testing' : '#ember-testing');
   },
 
   revert() {
@@ -56,6 +49,10 @@ IntegrationAdapter.prototype = {
     Ember.run(() => {
       expectEmberError(assert, block, expected, message);
     });
+  },
+
+  find() {
+    return this.original.find(...arguments);
   },
 
   andThen(fn) {

--- a/tests/unit/-private/properties/alias-test.js
+++ b/tests/unit/-private/properties/alias-test.js
@@ -36,8 +36,8 @@ moduleForProperty('alias', function(test) {
 
     this.adapter.createTemplate(this, page, '<button>Click me</button>');
 
-    this.adapter.click((actualSelector) => {
-      assert.equal(actualSelector, expectedSelector);
+    this.adapter.$('button').on('click', function() {
+      assert.ok(true);
     });
 
     page.aliasedClickButton();
@@ -95,8 +95,8 @@ moduleForProperty('alias', function(test) {
 
     this.adapter.createTemplate(this, page, '<button>Click me</button>');
 
-    this.adapter.click((actualSelector) => {
-      assert.equal(actualSelector, expectedSelector);
+    this.adapter.$('button').on('click', function() {
+      assert.ok(true);
     });
 
     page.aliasedClickButton();
@@ -159,8 +159,8 @@ moduleForProperty('alias', function(test) {
 
     this.adapter.createTemplate(this, page, '<button>Click me</button>');
 
-    this.adapter.click((actualSelector) => {
-      assert.equal(actualSelector, expectedSelector);
+    this.adapter.$('button').on('click', function() {
+      assert.ok(true);
     });
 
     page.aliasedClickButton();

--- a/tests/unit/-private/properties/click-on-text-test.js
+++ b/tests/unit/-private/properties/click-on-text-test.js
@@ -234,6 +234,22 @@ moduleForProperty('clickOnText', function(test) {
     }, /page\.foo\.bar\.baz\.qux/, 'Element not found');
   });
 
+  test("doesn't raise an error when the element is not visible and `visible` is not set", function (assert) {
+    assert.expect(1);
+
+    let page = create({
+      foo: clickOnText('button')
+    });
+
+    this.adapter.createTemplate(this, page, '<button style="display:none">Click me</button>');
+
+    this.adapter.$('button').on('click', () => assert.ok(1));
+
+    page.foo('Click me');
+
+    return this.adapter.wait();
+  });
+
   test('raises an error when the element is not visible and `visible` is true', function(assert) {
     assert.expect(1);
 

--- a/tests/unit/-private/properties/click-on-text-test.js
+++ b/tests/unit/-private/properties/click-on-text-test.js
@@ -5,10 +5,7 @@ moduleForProperty('clickOnText', function(test) {
   test('calls click helper', function(assert) {
     assert.expect(2);
 
-    let expectedSelector;
-    let page;
-
-    page = create({
+    let page = create({
       foo: clickOnText('fieldset'),
       bar: clickOnText('button')
     });
@@ -20,28 +17,30 @@ moduleForProperty('clickOnText', function(test) {
       </fieldset>
     `);
 
-    this.adapter.click((actualSelector) => {
-      assert.equal(actualSelector, expectedSelector);
-    });
-
     this.adapter.andThen(() => {
-      expectedSelector = 'fieldset :contains("Lorem"):last';
+      this.adapter.$('fieldset :contains("Lorem"):last').one('click', function() {
+        assert.ok(true);
+      });
+
       page.foo('Lorem');
+
+      return this.adapter.wait();
     });
 
     this.adapter.andThen(() => {
-      expectedSelector = 'button:contains("Lorem")';
+      this.adapter.$('button:contains("Lorem")').one('click', function() {
+        assert.ok(true);
+      });
       page.bar('Lorem');
+
+      return this.adapter.wait();
     });
   });
 
   test('looks for elements inside the scope', function(assert) {
     assert.expect(2);
 
-    let expectedSelector;
-    let page;
-
-    page = create({
+    let page = create({
       foo: clickOnText('fieldset', { scope: '.scope' }),
       bar: clickOnText('button', { scope: '.scope' })
     });
@@ -55,18 +54,18 @@ moduleForProperty('clickOnText', function(test) {
       </div>
     `);
 
-    this.adapter.click((actualSelector) => {
-      assert.equal(actualSelector, expectedSelector);
-    });
-
     this.adapter.andThen(() => {
-      expectedSelector = '.scope fieldset :contains("Lorem"):last';
+      this.adapter.$('.scope fieldset :contains("Lorem"):last').one('click', () => assert.ok(1));
       page.foo('Lorem');
+
+      return this.adapter.wait();
     });
 
     this.adapter.andThen(() => {
-      expectedSelector = '.scope button:contains("Lorem")';
+      this.adapter.$('.scope button:contains("Lorem")').one('click', () => assert.ok(1));
       page.bar('Lorem');
+
+      return this.adapter.wait();
     });
 
     return this.adapter.wait();
@@ -75,10 +74,7 @@ moduleForProperty('clickOnText', function(test) {
   test("looks for elements inside page's scope", function(assert) {
     assert.expect(2);
 
-    let page;
-    let expectedSelector;
-
-    page = create({
+    let page = create({
       scope: '.scope',
       foo: clickOnText('fieldset'),
       bar: clickOnText('button')
@@ -93,28 +89,25 @@ moduleForProperty('clickOnText', function(test) {
       </div>
     `);
 
-    this.adapter.click((actualSelector) => {
-      assert.equal(actualSelector, expectedSelector);
-    });
-
     this.adapter.andThen(() => {
-      expectedSelector = '.scope fieldset :contains("Lorem"):last';
+      this.adapter.$('.scope fieldset :contains("Lorem"):last').one('click', () => assert.ok(1));
       page.foo('Lorem');
+
+      return this.adapter.wait();
     });
 
     this.adapter.andThen(() => {
-      expectedSelector = '.scope button:contains("Lorem")';
+      this.adapter.$('.scope button:contains("Lorem")').one('click', () => assert.ok(1));
       page.bar('Lorem');
+
+      return this.adapter.wait();
     });
   });
 
   test('resets scope', function(assert) {
     assert.expect(2);
 
-    let page;
-    let expectedSelector;
-
-    page = create({
+    let page = create({
       scope: '.scope',
       foo: clickOnText('fieldset', { resetScope: true }),
       bar: clickOnText('button', { resetScope: true })
@@ -127,18 +120,15 @@ moduleForProperty('clickOnText', function(test) {
       </fieldset>
     `);
 
-    this.adapter.click((actualSelector) => {
-      assert.equal(actualSelector, expectedSelector);
-    });
-
     this.adapter.andThen(() => {
-      expectedSelector = 'fieldset :contains("Lorem"):last';
+      this.adapter.$('fieldset :contains("Lorem"):last').one('click', () => assert.ok(1));
       page.foo('Lorem');
     });
 
     this.adapter.andThen(() => {
-      expectedSelector = 'button:contains("Lorem")';
+      this.adapter.$('button:contains("Lorem")').one('click', () => assert.ok(1));
       page.bar('Lorem');
+      return this.adapter.wait();
     });
   });
 
@@ -155,18 +145,13 @@ moduleForProperty('clickOnText', function(test) {
 
     this.adapter.createTemplate(this, page, '<button>dummy text</button>');
 
-    this.adapter.click(() => {});
-
     assert.equal(page.foo('dummy text'), page);
   });
 
   test('finds element by index', function(assert) {
     assert.expect(2);
 
-    let expectedSelector;
-    let page;
-
-    page = create({
+    let page = create({
       foo: clickOnText('fieldset', { at: 2 }),
       bar: clickOnText('button', { at: 2 })
     });
@@ -180,17 +165,13 @@ moduleForProperty('clickOnText', function(test) {
       </fieldset>
     `);
 
-    this.adapter.click((actualSelector) => {
-      assert.equal(actualSelector, expectedSelector);
-    });
-
     this.adapter.andThen(() => {
-      expectedSelector = 'fieldset :contains("Lorem"):eq(2)';
+      this.adapter.$('fieldset :contains("Lorem"):eq(2)').one('click', () => assert.ok(1));
       page.foo('Lorem');
     });
 
     this.adapter.andThen(() => {
-      expectedSelector = 'button:contains("Lorem"):eq(2)';
+      this.adapter.$('button:contains("Lorem"):eq(2)').one('click', () => assert.ok(1));
       page.bar('Lorem');
     });
   });
@@ -207,11 +188,8 @@ moduleForProperty('clickOnText', function(test) {
 
     this.adapter.createTemplate(this, page, '<button>Lorem</button>', { useAlternateContainer: true });
 
-    this.adapter.click((_, actualContext) => {
-      assert.equal(actualContext, expectedContext);
-    });
-
     this.adapter.andThen(() => {
+      this.adapter.$('button', true).one('click', () => assert.ok(1));
       page.foo('Lorem');
     });
   });
@@ -220,21 +198,19 @@ moduleForProperty('clickOnText', function(test) {
     assert.expect(1);
 
     let expectedContext = '#alternate-ember-testing';
-    let page;
-
-    page = create({
+    let page = create({
       testContainer: expectedContext,
       foo: clickOnText('button')
     });
 
     this.adapter.createTemplate(this, page, '<button>Lorem</button>', { useAlternateContainer: true });
-
-    this.adapter.click((_, actualContext) => {
-      assert.equal(actualContext, expectedContext);
-    });
+    this.adapter.createTemplate(this, page, '<button>Lorem</button>');
 
     this.adapter.andThen(() => {
+      this.adapter.$('button', true).one('click', () => assert.ok(1));
       page.foo('Lorem');
+
+      return this.adapter.wait();
     });
   });
 
@@ -256,24 +232,6 @@ moduleForProperty('clickOnText', function(test) {
     this.adapter.throws(assert, function() {
       return page.foo.bar.baz.qux('Lorem');
     }, /page\.foo\.bar\.baz\.qux/, 'Element not found');
-  });
-
-  test("doesn't raise an error when the element is not visible and `visible` is not set", function(assert) {
-    assert.expect(1);
-
-    let page = create({
-      foo: clickOnText('button')
-    });
-
-    this.adapter.createTemplate(this, page, '<button style="display:none">Click me</button>');
-
-    this.adapter.click(() => {
-      assert.ok(true, 'Element is clicked');
-    });
-
-    page.foo('Click me');
-
-    return this.adapter.wait();
   });
 
   test('raises an error when the element is not visible and `visible` is true', function(assert) {

--- a/tests/unit/-private/properties/click-on-text-test.js
+++ b/tests/unit/-private/properties/click-on-text-test.js
@@ -234,7 +234,7 @@ moduleForProperty('clickOnText', function(test) {
     }, /page\.foo\.bar\.baz\.qux/, 'Element not found');
   });
 
-  test("doesn't raise an error when the element is not visible and `visible` is not set", function (assert) {
+  test("doesn't raise an error when the element is not visible and `visible` is not set", function(assert) {
     assert.expect(1);
 
     let page = create({

--- a/tests/unit/-private/properties/clickable-test.js
+++ b/tests/unit/-private/properties/clickable-test.js
@@ -6,21 +6,18 @@ moduleForProperty('clickable', function(test) {
     assert.expect(1);
 
     let expectedSelector = 'button';
-    let page;
-
-    page = create({
+    let page = create({
       foo: clickable(expectedSelector)
     });
 
     this.adapter.createTemplate(this, page, '<button>Click me</button>');
 
-    this.adapter.click((actualSelector) => {
-      assert.equal(actualSelector, expectedSelector);
+    this.adapter.andThen(() => {
+      this.adapter.$(expectedSelector).one('click', () => assert.ok(1));
+      page.foo();
+
+      return this.adapter.wait();
     });
-
-    page.foo();
-
-    return this.adapter.wait();
   });
 
   test('looks for elements inside the scope', function(assert) {
@@ -35,13 +32,12 @@ moduleForProperty('clickable', function(test) {
 
     this.adapter.createTemplate(this, page, '<div class="scope"><span>Click me</span></div>');
 
-    this.adapter.click((actualSelector) => {
-      assert.equal(actualSelector, expectedSelector);
+    this.adapter.andThen(() => {
+      this.adapter.$(expectedSelector).one('click', () => assert.ok(1));
+      page.foo();
+
+      return this.adapter.wait();
     });
-
-    page.foo();
-
-    return this.adapter.wait();
   });
 
   test("looks for elements inside page's scope", function(assert) {
@@ -58,13 +54,12 @@ moduleForProperty('clickable', function(test) {
 
     this.adapter.createTemplate(this, page, '<div class="scope"><span>Click me</span></div>');
 
-    this.adapter.click((actualSelector) => {
-      assert.equal(actualSelector, expectedSelector);
+    return this.adapter.andThen(() => {
+      this.adapter.$(expectedSelector).one('click', () => assert.ok(1));
+      page.foo();
+
+      return this.adapter.wait();
     });
-
-    page.foo();
-
-    return this.adapter.wait();
   });
 
   test('resets scope', function(assert) {
@@ -80,27 +75,22 @@ moduleForProperty('clickable', function(test) {
 
     this.adapter.createTemplate(this, page, '<span>Click me</span>');
 
-    this.adapter.click((actualSelector) => {
-      assert.equal(actualSelector, expectedSelector);
+    return this.adapter.andThen(() => {
+      this.adapter.$(expectedSelector).one('click', () => assert.ok(1));
+      page.foo();
+
+      return this.adapter.wait();
     });
-
-    page.foo();
-
-    return this.adapter.wait();
   });
 
   test('returns target object', function(assert) {
     assert.expect(1);
 
-    let page;
-
-    page = create({
+    let page = create({
       foo: clickable('span')
     });
 
     this.adapter.createTemplate(this, page, '<span>Click me</span>');
-
-    this.adapter.click(function() {});
 
     assert.equal(page.foo(), page);
   });
@@ -109,21 +99,18 @@ moduleForProperty('clickable', function(test) {
     assert.expect(1);
 
     let expectedSelector = 'span:eq(3)';
-    let page;
-
-    page = create({
+    let page = create({
       foo: clickable('span', { at: 3 })
-    });
-
-    this.adapter.click((actualSelector) => {
-      assert.equal(actualSelector, expectedSelector);
     });
 
     this.adapter.createTemplate(this, page, '<span></span><span></span><span>Click me</span><span></span>');
 
-    page.foo();
+    return this.adapter.andThen(() => {
+      this.adapter.$(expectedSelector).one('click', () => assert.ok(1));
+      page.foo();
 
-    return this.adapter.wait();
+      return this.adapter.wait();
+    });
   });
 
   test('looks for elements outside the testing container', function(assert) {
@@ -138,13 +125,12 @@ moduleForProperty('clickable', function(test) {
 
     this.adapter.createTemplate(this, page, '<span>Click me</span>', { useAlternateContainer: true });
 
-    this.adapter.click((_, actualContext) => {
-      assert.equal(actualContext, expectedContext);
+    return this.adapter.andThen(() => {
+      this.adapter.$('span', expectedContext).one('click', () => assert.ok(1));
+      page.foo();
+
+      return this.adapter.wait();
     });
-
-    page.foo();
-
-    return this.adapter.wait();
   });
 
   test('looks for elements within test container specified at node level', function(assert) {
@@ -160,13 +146,12 @@ moduleForProperty('clickable', function(test) {
 
     this.adapter.createTemplate(this, page, '<span>Click me</span>', { useAlternateContainer: true });
 
-    this.adapter.click((_, actualContext) => {
-      assert.equal(actualContext, expectedContext);
+    return this.adapter.andThen(() => {
+      this.adapter.$('span', expectedContext).one('click', () => assert.ok(1));
+      page.foo();
+
+      return this.adapter.wait();
     });
-
-    page.foo();
-
-    return this.adapter.wait();
   });
 
   test("raises an error when the element doesn't exist", function(assert) {
@@ -200,13 +185,12 @@ moduleForProperty('clickable', function(test) {
 
     this.adapter.createTemplate(this, page, '<span style="display:none">Click me</span>');
 
-    this.adapter.click(() => {
-      assert.ok(true, 'Element is clicked');
+    return this.adapter.andThen(() => {
+      this.adapter.$('span').one('click', () => assert.ok(1));
+      page.foo();
+
+      return this.adapter.wait();
     });
-
-    page.foo();
-
-    return this.adapter.wait();
   });
 
   test('raises an error when the element is not visible and `visible` is true', function(assert) {

--- a/tests/unit/-private/properties/dsl-test.js
+++ b/tests/unit/-private/properties/dsl-test.js
@@ -50,13 +50,15 @@ moduleForProperty('dsl', function(test) {
 
     this.adapter.createTemplate(this, page, '<button>dummy text</button>');
 
-    this.adapter.click(() => {
-      assert.ok(true, 'click called');
+    return this.adapter.andThen(() => {
+      // text nodes don't support click events
+      // instead we check that click on text content propagates to the parent button
+      this.adapter.$('button').one('click', () => assert.ok(1));
+
+      page.foo.clickOn('dummy text');
+
+      return this.adapter.wait();
     });
-
-    page.foo.clickOn('dummy text');
-
-    return this.adapter.wait();
   });
 
   test('generates .click', function(assert) {
@@ -70,13 +72,13 @@ moduleForProperty('dsl', function(test) {
 
     this.adapter.createTemplate(this, page, '<button>dummy text</button>');
 
-    this.adapter.click(() => {
-      assert.ok(true, 'click called');
+    return this.adapter.andThen(() => {
+      this.adapter.$('button').one('click', () => assert.ok(1));
+
+      page.foo.click();
+
+      return this.adapter.wait();
     });
-
-    page.foo.click();
-
-    return this.adapter.wait();
   });
 
   test('generates .contains', function(assert) {
@@ -119,13 +121,11 @@ moduleForProperty('dsl', function(test) {
 
     this.adapter.createTemplate(this, page, '<input name="email">');
 
-    this.adapter.fillIn((selector, context, options, content) => {
-      assert.equal(content, 'lorem ipsum');
-    });
-
     page.foo.fillIn('lorem ipsum');
 
-    return this.adapter.wait();
+    return this.adapter.andThen(() => {
+      assert.equal(this.adapter.$('input').val(), 'lorem ipsum');
+    });
   });
 
   test('generates .select', function(assert) {
@@ -139,13 +139,11 @@ moduleForProperty('dsl', function(test) {
 
     this.adapter.createTemplate(this, page, '<input name="email">');
 
-    this.adapter.fillIn((selector, context, options, content) => {
-      assert.equal(content, 'lorem ipsum');
-    });
-
     page.foo.select('lorem ipsum');
 
-    return this.adapter.wait();
+    return this.adapter.andThen(() => {
+      assert.equal(this.adapter.$('input').val(), 'lorem ipsum');
+    });
   });
 
   test('generates .value', function(assert) {

--- a/tests/unit/-private/properties/triggerable-test.js
+++ b/tests/unit/-private/properties/triggerable-test.js
@@ -3,37 +3,37 @@ import { create, triggerable } from 'ember-cli-page-object';
 
 moduleForProperty('triggerable', function(test) {
   test("calls Ember's triggerEvent helper with proper args", function(assert) {
-    assert.expect(2);
+    assert.expect(1);
 
-    let expectedSelector = 'span';
+    let expectedSelector = 'input';
     let page = create({
       foo: triggerable('focus', expectedSelector)
     });
 
-    this.adapter.createTemplate(this, page, '<span></span>');
+    this.adapter.createTemplate(this, page, '<input />');
 
-    this.adapter.triggerEvent((actualSelector, _, event) => {
-      assert.equal(actualSelector, expectedSelector);
-      assert.equal(event, 'focus');
+    return this.adapter.andThen(() => {
+      // debugger
+      this.adapter.$(expectedSelector).on('focus', () => {
+        // debugger;
+        assert.ok(1);
+      });
+      page.foo();
+
+      return this.adapter.wait();
     });
-
-    page.foo();
-
-    return this.adapter.wait();
   });
 
   test("calls Ember's triggerEvent helper with static event options", function(assert) {
     assert.expect(1);
 
     let page = create({
-      foo: triggerable('keypress', 'span', { eventProperties: { keyCode: 13 } })
+      foo: triggerable('keypress', 'input', { eventProperties: { keyCode: 13 } })
     });
 
-    this.adapter.createTemplate(this, page, '<span></span>');
+    this.adapter.createTemplate(this, page, '<input />');
 
-    this.adapter.triggerEvent((actualSelector, _, event, options) => {
-      assert.equal(options.keyCode, 13);
-    });
+    this.adapter.$('input').on('keypress', (e) => assert.equal(e.keyCode, 13));
 
     page.foo();
 
@@ -44,14 +44,12 @@ moduleForProperty('triggerable', function(test) {
     assert.expect(1);
 
     let page = create({
-      foo: triggerable('keypress', 'span')
+      foo: triggerable('keypress', 'input')
     });
 
-    this.adapter.createTemplate(this, page, '<span></span>');
+    this.adapter.createTemplate(this, page, '<input />');
 
-    this.adapter.triggerEvent((actualSelector, _, event, options) => {
-      assert.equal(options.keyCode, 13);
-    });
+    this.adapter.$('input').on('keypress', (e) => assert.equal(e.keyCode, 13));
 
     page.foo({ keyCode: 13 });
 
@@ -62,16 +60,14 @@ moduleForProperty('triggerable', function(test) {
     assert.expect(1);
 
     let page = create({
-      foo: triggerable('keypress', 'span', {
+      foo: triggerable('keypress', 'input', {
         eventProperties: { keyCode: 0 }
       })
     });
 
-    this.adapter.createTemplate(this, page, '<span></span>');
+    this.adapter.createTemplate(this, page, '<input />');
 
-    this.adapter.triggerEvent((actualSelector, _, event, options) => {
-      assert.equal(options.keyCode, 13);
-    });
+    this.adapter.$('input').on('keypress', (e) => assert.equal(e.keyCode, 13));
 
     page.foo({ keyCode: 13 });
 
@@ -82,15 +78,12 @@ moduleForProperty('triggerable', function(test) {
     assert.expect(1);
 
     let page = create({
-      foo: triggerable('focus', 'span', { scope: '.scope' })
+      foo: triggerable('focus', 'input', { scope: '.scope' })
     });
 
-    this.adapter.createTemplate(this, page, '<div class="scope"><span></span></div>');
+    this.adapter.createTemplate(this, page, '<div class="scope"><input/></div>');
 
-    this.adapter.triggerEvent((actualSelector) => {
-      assert.equal(actualSelector, '.scope span');
-    });
-
+    this.adapter.$('.scope input').on('focus', () => assert.ok(1));
     page.foo();
 
     return this.adapter.wait();
@@ -102,13 +95,12 @@ moduleForProperty('triggerable', function(test) {
     let page = create({
       scope: '.scope',
 
-      foo: triggerable('focus', 'span')
+      foo: triggerable('focus', 'input')
     });
 
-    this.adapter.createTemplate(this, page, '<div class="scope"><span></span></div>');
-    this.adapter.triggerEvent((actualSelector) => {
-      assert.equal(actualSelector, '.scope span');
-    });
+    this.adapter.createTemplate(this, page, '<div class="scope"><input /></div>');
+
+    this.adapter.$('.scope input').on('focus', () => assert.ok(1));
 
     page.foo();
 
@@ -120,14 +112,12 @@ moduleForProperty('triggerable', function(test) {
 
     let page = create({
       scope: '.scope',
-      foo: triggerable('focus', 'span', { resetScope: true })
+      foo: triggerable('focus', 'input', { resetScope: true })
     });
 
-    this.adapter.createTemplate(this, page, '<span></span>');
+    this.adapter.createTemplate(this, page, '<input></input>');
 
-    this.adapter.triggerEvent((actualSelector) => {
-      assert.equal(actualSelector, 'span');
-    });
+    this.adapter.$('input').on('focus', () => assert.ok(1));
 
     page.foo();
 
@@ -138,11 +128,10 @@ moduleForProperty('triggerable', function(test) {
     assert.expect(1);
 
     let page = create({
-      foo: triggerable('focus', 'span')
+      foo: triggerable('focus', 'input')
     });
 
-    this.adapter.createTemplate(this, page, '<span></span>');
-    this.adapter.triggerEvent(() => {});
+    this.adapter.createTemplate(this, page, '<input/>');
 
     assert.equal(page.foo(), page);
   });
@@ -150,16 +139,14 @@ moduleForProperty('triggerable', function(test) {
   test('finds element by index', function(assert) {
     assert.expect(1);
 
-    let expectedSelector = 'span:eq(3)';
+    let expectedSelector = 'input:eq(3)';
     let page = create({
-      foo: triggerable('focus', 'span', { at: 3 })
+      foo: triggerable('focus', 'input', { at: 3 })
     });
 
-    this.adapter.createTemplate(this, page, '<span></span><span></span><span></span><span></span>');
-    this.adapter.triggerEvent((actualSelector) => {
-      assert.equal(actualSelector, expectedSelector);
-    });
+    this.adapter.createTemplate(this, page, '<input /><input /><input /><input />');
 
+    this.adapter.$(expectedSelector).on('focus', () => assert.ok(1));
     page.foo();
 
     return this.adapter.wait();
@@ -170,13 +157,12 @@ moduleForProperty('triggerable', function(test) {
 
     let expectedContext = '#alternate-ember-testing';
     let page = create({
-      foo: triggerable('focus', 'span', { testContainer: expectedContext })
+      foo: triggerable('focus', 'input', { testContainer: expectedContext })
     });
 
-    this.adapter.createTemplate(this, page, '<span></span>', { useAlternateContainer: true });
-    this.adapter.triggerEvent((_, actualContext) => {
-      assert.equal(actualContext, expectedContext);
-    });
+    this.adapter.createTemplate(this, page, '<input />', { useAlternateContainer: true });
+
+    this.adapter.$('input', expectedContext).on('focus', () => assert.ok(1));
 
     page.foo();
 
@@ -189,13 +175,12 @@ moduleForProperty('triggerable', function(test) {
     let expectedContext = '#alternate-ember-testing';
     let page = create({
       testContainer: expectedContext,
-      foo: triggerable('focus', 'span')
+      foo: triggerable('focus', 'input')
     });
 
-    this.adapter.createTemplate(this, page, '<span></span>', { useAlternateContainer: true });
-    this.adapter.triggerEvent((_, actualContext) => {
-      assert.equal(actualContext, expectedContext);
-    });
+    this.adapter.createTemplate(this, page, '<input />', { useAlternateContainer: true });
+
+    this.adapter.$('input', expectedContext).on('focus', () => assert.ok(1));
 
     page.foo();
 


### PR DESCRIPTION
Current approach for testing properties doesn't scale very well. For example it's impossible to run existing properties tests against alternative contexts like [native contexts](https://github.com/san650/ember-cli-page-object/pull/325).

The general idea of this pr is changing assertions like
```js
this.adapter.click((actualSelector) => assert.equal(actualSelector, expectedSelector));
```
to
```js
  this.adapter.$(expectedSelector).on('click', () => assert.ok(true));
```
This way we don't test internals of contexts anymore.

@san650 There is some work left to do here(mostly cleanup). Anyway I would appreciate your thoughts on this change. Does this approach make sense to you?