### PR TITLE
Update to ember-cli@2.16

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,13 @@
+module.exports = {
+  root: true,
+  parserOptions: {
+    ecmaVersion: 2017,
+    sourceType: 'module'
+  },
+  extends: 'eslint:recommended',
+  env: {
+    browser: true
+  },
+  rules: {
+  }
+};

--- a/addon/-private/execution_context/helpers.js
+++ b/addon/-private/execution_context/helpers.js
@@ -24,8 +24,9 @@ export function fillElement($selection, content, { selector, pageObjectNode, pag
     throwBetterError(
       pageObjectNode,
       pageObjectKey,
-      'Element cannot be filled because it has `contenteditable="false"`.',
-      { selector }
+      'Element cannot be filled because it has `contenteditable="false"`.', {
+        selector
+      }
     );
   } else {
     $selection.val(content);

--- a/addon/-private/properties/collection.js
+++ b/addon/-private/properties/collection.js
@@ -1,3 +1,4 @@
+/* global Symbol */
 import Ember from 'ember';
 import { buildSelector, assign as mergeFunction } from '../helpers';
 import { create } from '../create';

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,5 @@
 {
   "name": "ember-cli-page-object",
   "dependencies": {
-    "ember": "~2.9.0",
-    "ember-cli-shims": "0.1.3"
   }
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,4 +1,4 @@
-/*jshint node:true*/
+/* eslint-env node */
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ember-ajax": "^3.0.0",
     "ember-cli": "~2.16.2",
     "ember-cli-addon-tests": "^0.4.2",
-    "ember-cli-blueprint-test-helpers": "0.13.0",
+    "ember-cli-blueprint-test-helpers": "^0.18.2",
     "ember-cli-code-coverage": "0.3.12",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-doc-server": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -2,65 +2,6 @@
   "name": "ember-cli-page-object",
   "version": "1.12.0",
   "description": "This ember-cli addon eases the construction of page objects on your acceptance and integration tests",
-  "homepage": "http://ember-cli-page-object.js.org",
-  "bugs": "https://github.com/san650/ember-cli-page-object/issues",
-  "directories": {
-    "doc": "doc",
-    "test": "tests"
-  },
-  "scripts": {
-    "build": "ember build",
-    "start": "ember server",
-    "test": "ember try:each",
-    "docs": "node ./docs",
-    "nodetest": "mocha node-tests --recursive"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/san650/ember-cli-page-object.git"
-  },
-  "engines": {
-    "node": ">= 0.12.0"
-  },
-  "author": "Santiago Ferreira",
-  "license": "MIT",
-  "devDependencies": {
-    "broccoli-asset-rev": "^2.4.5",
-    "chai": "^3.5.0",
-    "coveralls": "^2.13.1",
-    "documentation": "^3.0.4",
-    "ember-ajax": "^2.4.1",
-    "ember-cli": "2.9.1",
-    "ember-cli-addon-tests": "^0.4.2",
-    "ember-cli-app-version": "^2.0.0",
-    "ember-cli-blueprint-test-helpers": "0.13.0",
-    "ember-cli-code-coverage": "0.3.12",
-    "ember-cli-dependency-checker": "^1.3.0",
-    "ember-cli-doc-server": "1.1.0",
-    "ember-cli-htmlbars": "^1.0.10",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.3",
-    "ember-cli-inject-live-reload": "^1.4.1",
-    "ember-cli-jshint": "^1.0.4",
-    "ember-cli-qunit": "^3.0.1",
-    "ember-cli-release": "^0.2.9",
-    "ember-cli-sri": "^2.1.0",
-    "ember-cli-test-loader": "^1.1.0",
-    "ember-cli-uglify": "^1.2.0",
-    "ember-disable-prototype-extensions": "^1.1.0",
-    "ember-export-application-global": "^1.0.5",
-    "ember-load-initializers": "^0.5.1",
-    "ember-qunit-nice-errors": "1.1.1",
-    "ember-qunit-source-map": "1.1.0",
-    "ember-resolver": "^2.0.3",
-    "glob": "^5.0.13",
-    "loader.js": "^4.0.10",
-    "mkdirp": "^0.5.1",
-    "mocha": "^2.5.3",
-    "mocha-only-detector": "0.0.2",
-    "ncp": "^2.0.0",
-    "rimraf": "^2.5.2",
-    "sync-exec": "^0.6.2"
-  },
   "keywords": [
     "acceptance",
     "integration",
@@ -74,9 +15,26 @@
     "pageobject",
     "testing"
   ],
+  "license": "MIT",
+  "author": "Santiago Ferreira",
+  "directories": {
+    "doc": "doc",
+    "test": "tests"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/san650/ember-cli-page-object.git"
+  },
+  "scripts": {
+    "build": "ember build",
+    "start": "ember server",
+    "test": "ember try:each",
+    "docs": "node ./docs",
+    "nodetest": "mocha node-tests --recursive"
+  },
   "dependencies": {
     "ceibo": "~2.0.0",
-    "ember-cli-babel": "^5.1.7",
+    "ember-cli-babel": "^6.6.0",
     "ember-cli-get-component-path-option": "^1.0.0",
     "ember-cli-is-package-missing": "^1.0.0",
     "ember-cli-node-assets": "^0.1.2",
@@ -89,6 +47,47 @@
     "ember-test-helpers": "^0.6.3",
     "rsvp": "^3.2.1"
   },
+  "devDependencies": {
+    "broccoli-asset-rev": "^2.4.5",
+    "chai": "^3.5.0",
+    "coveralls": "^2.13.1",
+    "documentation": "^3.0.4",
+    "ember-ajax": "^3.0.0",
+    "ember-cli": "~2.16.2",
+    "ember-cli-addon-tests": "^0.4.2",
+    "ember-cli-blueprint-test-helpers": "0.13.0",
+    "ember-cli-code-coverage": "0.3.12",
+    "ember-cli-dependency-checker": "^2.0.0",
+    "ember-cli-doc-server": "1.1.0",
+    "ember-cli-eslint": "^4.0.0",
+    "ember-cli-htmlbars": "^2.0.1",
+    "ember-cli-htmlbars-inline-precompile": "^1.0.0",
+    "ember-cli-inject-live-reload": "^1.4.1",
+    "ember-cli-qunit": "^4.0.0",
+    "ember-cli-shims": "^1.1.0",
+    "ember-cli-sri": "^2.1.0",
+    "ember-cli-uglify": "^2.0.0",
+    "ember-disable-prototype-extensions": "^1.1.2",
+    "ember-export-application-global": "^2.0.0",
+    "ember-load-initializers": "^1.0.0",
+    "ember-qunit-nice-errors": "1.1.1",
+    "ember-qunit-source-map": "1.1.0",
+    "ember-resolver": "^4.0.0",
+    "ember-source": "~2.16.0",
+    "glob": "^5.0.13",
+    "loader.js": "^4.2.3",
+    "mkdirp": "^0.5.1",
+    "mocha": "^2.5.3",
+    "mocha-only-detector": "0.0.2",
+    "ncp": "^2.0.0",
+    "rimraf": "^2.5.2",
+    "sync-exec": "^0.6.2"
+  },
+  "engines": {
+    "node": "^4.5 || 6.* || >= 7.*"
+  },
+  "homepage": "http://ember-cli-page-object.js.org",
+  "bugs": "https://github.com/san650/ember-cli-page-object/issues",
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "after": [

--- a/testem.js
+++ b/testem.js
@@ -1,13 +1,22 @@
-/*jshint node:true*/
+/* eslint-env node */
 module.exports = {
-  "framework": "qunit",
-  "test_page": "tests/index.html?hidepassed",
-  "disable_watching": true,
-  "launch_in_ci": [
-    "PhantomJS"
+  test_page: 'tests/index.html?hidepassed',
+  disable_watching: true,
+  launch_in_ci: [
+    'Chrome'
   ],
-  "launch_in_dev": [
-    "PhantomJS",
-    "Chrome"
-  ]
+  launch_in_dev: [
+    'Chrome'
+  ],
+  browser_args: {
+    Chrome: {
+      mode: 'ci',
+      args: [
+        '--disable-gpu',
+        '--headless',
+        '--remote-debugging-port=9222',
+        '--window-size=1440,900'
+      ]
+    },
+  }
 };

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  env: {
+    embertest: true
+  }
+};

--- a/tests/acceptance/actions-test.js
+++ b/tests/acceptance/actions-test.js
@@ -80,7 +80,7 @@ test('action chains act like a promise', function(assert) {
       assert.equal(page.screen, '12');
     });
 
-  return wait();
+  return window.wait();
 });
 
 test('fill in by attribute', function(assert) {

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,13 +1,9 @@
-import Ember from 'ember';
+import Application from '@ember/application';
 import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
-let App;
-
-Ember.MODEL_FACTORY_INJECTIONS = true;
-
-App = Ember.Application.extend({
+const App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -9,8 +9,8 @@
 
     {{content-for "head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/dummy.css">
 
     {{content-for "head-footer"}}
   </head>

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,9 +1,10 @@
-/* jshint node: true */
+/* eslint-env node */
+'use strict';
 
 module.exports = function(environment) {
-  var ENV = {
+  let ENV = {
     modulePrefix: 'dummy',
-    environment: environment,
+    environment,
     rootURL: '/',
     locationType: 'auto',
     EmberENV: {
@@ -43,7 +44,7 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-
+    // here you can enable a production-specific feature
   }
 
   return ENV;

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -1,0 +1,9 @@
+/* eslint-env node */
+module.exports = {
+  browsers: [
+    'ie 9',
+    'last 1 Chrome versions',
+    'last 1 Firefox versions',
+    'last 1 Safari versions'
+  ]
+};

--- a/tests/expect-ember-error.js
+++ b/tests/expect-ember-error.js
@@ -1,0 +1,39 @@
+
+import Ember from 'ember';
+
+// ember@2.11.3 introduces a (breaking?) change in how the errors are propagated
+// in backburner which causes some test that were previously working, to fail.
+//
+// See https://github.com/emberjs/ember.js/pull/14898#issuecomment-285510703
+
+// We need to use this hack to test with >= 2.11
+function useHack() {
+  var [major, minor] = Ember.VERSION.split('.');
+  major = Number(major);
+  minor = Number(minor);
+
+  return (major === 2 && minor >= 11) || major > 2;
+}
+
+export default function expectEmberError(assert, callback, matcher, message) {
+  if (useHack()) {
+    let origTestAdapter = Ember.Test.adapter;
+    let testError;
+    let TestAdapter = Ember.Test.QUnitAdapter.extend({
+      exception(error) {
+        testError = error;
+      }
+    });
+
+    Ember.run(() => { Ember.Test.adapter = TestAdapter.create(); });
+    callback();
+    Ember.run(() => {
+      Ember.Test.adapter.destroy();
+    });
+    Ember.Test.adapter = origTestAdapter;
+
+    assert.ok(testError && testError.message.match(matcher), message);
+  } else {
+    assert.throws(callback, matcher, message);
+  }
+}

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
 
 export default function destroyApp(application) {
-  Ember.run(application, 'destroy');
+  run(application, 'destroy');
 }

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,9 +1,7 @@
 import { module } from 'qunit';
-import Ember from 'ember';
+import { resolve } from 'rsvp';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-
-const { RSVP: { Promise } } = Ember;
 
 export default function(name, options = {}) {
   module(name, {
@@ -17,7 +15,7 @@ export default function(name, options = {}) {
 
     afterEach() {
       let afterEach = options.afterEach && options.afterEach.apply(this, arguments);
-      return Promise.resolve(afterEach).then(() => destroyApp(this.application));
+      return resolve(afterEach).then(() => destroyApp(this.application));
     }
   });
 }

--- a/tests/helpers/properties.js
+++ b/tests/helpers/properties.js
@@ -10,7 +10,7 @@ export function moduleForProperty(name, cbOrOptions, cb) {
   // Generate acceptance tests
   moduleForAcceptance(`Acceptance mode | Property | ${name}`, {
     beforeEach() {
-      this.adapter = new AcceptanceAdapter(AcceptanceExecutionContext);
+      this.adapter = new AcceptanceAdapter(this, AcceptanceExecutionContext);
     },
 
     afterEach() {
@@ -27,7 +27,7 @@ export function moduleForProperty(name, cbOrOptions, cb) {
   moduleForIntegration('html-render', `Integration mode | Property | ${name}`, {
     integration: true,
     beforeEach() {
-      this.adapter = new IntegrationAdapter(IntegrationExecutionContext);
+      this.adapter = new IntegrationAdapter(this, IntegrationExecutionContext);
     },
     afterEach() {
       this.adapter.revert();

--- a/tests/helpers/properties/acceptance-adapter.js
+++ b/tests/helpers/properties/acceptance-adapter.js
@@ -7,7 +7,7 @@ import Ember from 'ember';
 
 let noop = function() {};
 
-export function AcceptanceAdapter(original) {
+export function AcceptanceAdapter(context, original) {
   this.original = original;
   this.originalPrototype = original.prototype;
   original.prototype = Object.create(this.originalPrototype);

--- a/tests/helpers/properties/acceptance-adapter.js
+++ b/tests/helpers/properties/acceptance-adapter.js
@@ -4,6 +4,7 @@ import { module as qunitModule } from 'qunit';
 export { test as testForAcceptance } from 'qunit';
 
 import Ember from 'ember';
+const { $ } = Ember;
 
 let noop = function() {};
 
@@ -38,6 +39,7 @@ AcceptanceAdapter.prototype = {
     template = template || '';
 
     if (!(test && page)) {
+      // eslint-disable-next-line no-console
       console.error('Missing parameters in adapter.createTemplate(testContext, pageObject, templateString)');
     }
 
@@ -61,7 +63,7 @@ AcceptanceAdapter.prototype = {
   },
 
   wait() {
-    return wait();
+    return window.wait();
   }
 };
 

--- a/tests/helpers/properties/integration-adapter.js
+++ b/tests/helpers/properties/integration-adapter.js
@@ -29,6 +29,7 @@ IntegrationAdapter.prototype = {
     template = template || '';
 
     if (!(test && page)) {
+      // eslint-disable-next-line no-console
       console.error('Missing parameters in adapter.createTemplate(testContext, pageObject, templateString)');
     }
 

--- a/tests/helpers/properties/integration-adapter.js
+++ b/tests/helpers/properties/integration-adapter.js
@@ -1,15 +1,17 @@
 import { fixture } from './acceptance-adapter';
 export { moduleForComponent as moduleForIntegration, test as testForIntegration } from 'ember-qunit';
 import expectEmberError from '../../expect-ember-error';
+import hbs from 'htmlbars-inline-precompile';
 
 import Ember from 'ember';
 
-export function IntegrationAdapter(original) {
+export function IntegrationAdapter(context, original) {
   this.original = original;
   this.originalPrototype = original.prototype;
 
   original.prototype = Object.create(this.originalPrototype);
   this.spy = original.prototype;
+  this.context = context;
 }
 
 IntegrationAdapter.prototype = {
@@ -39,10 +41,9 @@ IntegrationAdapter.prototype = {
       test.set('raw', template);
     }
 
-    let compiledTemplate = Ember.HTMLBars.compile('{{html-render html=raw}}');
-
     page.setContext(test);
-    page.render(compiledTemplate);
+
+    this.context.render(hbs`{{html-render html=raw}}`);
   },
 
   throws(assert, block, expected, message) {

--- a/tests/helpers/properties/integration-adapter.js
+++ b/tests/helpers/properties/integration-adapter.js
@@ -1,6 +1,6 @@
 import { fixture } from './acceptance-adapter';
 export { moduleForComponent as moduleForIntegration, test as testForIntegration } from 'ember-qunit';
-import { expectEmberError } from '../../test-helper';
+import expectEmberError from '../../expect-ember-error';
 
 import Ember from 'ember';
 

--- a/tests/integration/actions-test.js
+++ b/tests/integration/actions-test.js
@@ -109,8 +109,9 @@ moduleForComponent('calculating-device', 'Integration | actions', {
 test('Actions work when defined inside collections', function(assert) {
   let template = createCalculatorTemplate();
 
+  this.render(template);
+
   page
-    .render(template)
     .numbers(0)
     .click();
 
@@ -120,8 +121,9 @@ test('Actions work when defined inside collections', function(assert) {
 test('Chaining of actions inside a collection works', function(assert) {
   let template = createCalculatorTemplate();
 
+  this.render(template);
+
   page
-    .render(template)
     .numbers()
     .clickOn('1')
     .clickOn('2')
@@ -133,8 +135,9 @@ test('Chaining of actions inside a collection works', function(assert) {
 test('Chaining of actions on the root works', function(assert) {
   let template = createCalculatorTemplate();
 
+  this.render(template)
+
   page
-    .render(template)
     .clickOn('1')
     .clickOn('+')
     .clickOn('4')
@@ -150,8 +153,9 @@ test('Chaining of actions on the root works', function(assert) {
 test('Chaining of actions on a component works', function(assert) {
   let template = createCalculatorTemplate();
 
+  this.render(template)
+
   page
-    .render(template)
     .calculator
     .clickOn('1')
     .clickOn('+')
@@ -166,8 +170,9 @@ test('Chaining of actions on a component works', function(assert) {
 test('Chaining of aliased root actions works', function(assert) {
   let template = createCalculatorTemplate();
 
+  this.render(template)
+
   page
-    .render(template)
     .clickOnAlias('1')
     .clickOnAlias('4');
 
@@ -177,8 +182,9 @@ test('Chaining of aliased root actions works', function(assert) {
 test('Chaining of aliased component actions works', function(assert) {
   let template = createCalculatorTemplate();
 
+  this.render(template)
+
   page
-    .render(template)
     .clickOn('1')
     .clickPlusAlias()
     .clickOn('4')
@@ -190,7 +196,7 @@ test('Chaining of aliased component actions works', function(assert) {
 test('fill in by attribute', function(assert) {
   let template = createInputsTemplate();
 
-  page.render(template);
+  this.render(template);
 
   page
     .fillIn('input1', 'input 1')
@@ -251,7 +257,7 @@ test('Queries and actions handle non-existant elements correctly', function(asse
   let message = /Element not found./;
   let template = createCalculatorTemplate();
 
-  page.render(template);
+  this.render(template);
 
   run(() => {
     assert.throws(() => page.nonExistant.attribute(), message, 'attribute query did not throw an error');

--- a/tests/integration/actions-test.js
+++ b/tests/integration/actions-test.js
@@ -24,7 +24,7 @@ import PageObject, {
   isVisible
 } from 'dummy/tests/page-object';
 
-const { run } = Ember;
+const { run, $ } = Ember;
 
 const button = function(scope) {
   return {

--- a/tests/integration/actions-test.js
+++ b/tests/integration/actions-test.js
@@ -4,7 +4,7 @@ import {
   createCalculatorTemplate,
   createInputsTemplate
 } from './test-helper';
-import { expectEmberError } from '../test-helper';
+import expectEmberError from '../expect-ember-error';
 import { alias } from 'ember-cli-page-object/macros';
 
 import PageObject, {

--- a/tests/integration/default-properties-test.js
+++ b/tests/integration/default-properties-test.js
@@ -20,8 +20,9 @@ test('Adds default properties', function(assert) {
     }
   });
 
+  this.render(createCalculatorTemplate());
+
   page
-    .render(createCalculatorTemplate())
     .clickOn('9')
     .one
     .click();

--- a/tests/integration/test-helper.js
+++ b/tests/integration/test-helper.js
@@ -1,9 +1,9 @@
-import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
 
 export function createCalculatorTemplate() {
-  return Ember.HTMLBars.compile('{{calculating-device}}');
+  return hbs`{{calculating-device}}`;
 }
 
 export function createInputsTemplate() {
-  return Ember.HTMLBars.compile('{{input-elements}}');
+  return hbs`{{input-elements}}`;
 }

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -3,6 +3,7 @@ import resolver from './helpers/resolver';
 import {
   setResolver
 } from 'ember-qunit';
+import { start } from 'ember-cli-qunit';
 
 setResolver(resolver);
 
@@ -43,3 +44,5 @@ export function expectEmberError(assert, callback, matcher, message) {
     assert.throws(callback, matcher, message);
   }
 }
+
+start();


### PR DESCRIPTION
I've used `ember-cli-update` for update.
It also ran `ember-modules-codemod` to update `Ember` imports.

Notable changes:
 - new modules import
 - drop bower dependencies
 - jshint -> eslint
 - PhantomJS -> Chrome/Chrome Headless for CI
 - No usages of `Ember.HTMLBars.compile` and `page.render`. It replaced by`htmlbars-inline-prcompile` and `this.render()`.