### PR TITLE
bugfix(nested-usage): Fixes nested addon usage by finding the host

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,13 +15,8 @@ module.exports = {
     }
   },
 
-  included: function(app) {
-    // see: https://github.com/ember-cli/ember-cli/issues/3718
-    if (typeof app.import !== 'function' && app.app) {
-      app = app.app;
-    }
-
-    this.app = app;
+  included: function() {
+    this.app = this._findHost();
 
     this._super.included.apply(this, arguments);
   },
@@ -36,5 +31,16 @@ module.exports = {
 
   _shouldIncludeFiles: function() {
     return !!this.app.tests;
+  },
+
+  _findHost() {
+    let current = this;
+    let app;
+
+    do {
+      app = current.app || app;
+    } while (current.parent.parent && (current = current.parent));
+
+    return app;
   }
 };


### PR DESCRIPTION
Only addons that are immediately included at the root level app actually get access to the app, but addons can also traverse their ancestry to find that root level addon. This adds a function based on the private [`findHost` function in ember-cli itself](https://github.com/ember-cli/ember-cli/blob/master/lib/models/addon.js#L613). While the method is private, other addons such as ember-test-selectors, ember-bootstrap, and [plenty of others](https://emberobserver.com/code-search?codeQuery=findHost) do use it, and since it's based on the tree structure that addons have it's pretty unlikely that it will break on us soon.

I can confirm that this fixes #337 locally, happy to try to add a test in node-tests as well if needed 