### PR TITLE
feature(collection): Adds find and findBy array methods

### DIFF
--- a/addon/-private/properties/collection.js
+++ b/addon/-private/properties/collection.js
@@ -5,7 +5,7 @@ import { create } from '../create';
 import { count } from './count';
 import Ceibo from 'ceibo';
 
-const arrayDelegateMethods = ['map', 'filter', 'mapBy', 'filterBy', 'forEach'];
+const arrayDelegateMethods = ['map', 'filter', 'find', 'mapBy', 'filterBy', 'findBy', 'forEach'];
 
 function merge(target, ...objects) {
   objects.forEach((o) => mergeFunction(target, o));

--- a/tests/unit/-private/properties/collection-test.js
+++ b/tests/unit/-private/properties/collection-test.js
@@ -99,6 +99,10 @@ moduleForProperty('collection', function(test) {
 
     assert.deepEqual(page.foo().filter((i) => i.isSpecial).map((i) => i.text), ['Lorem']);
     assert.deepEqual(page.foo().filterBy('isSpecial').map((i) => i.text), ['Lorem']);
+
+    assert.deepEqual(page.foo().find((i) => i.isSpecial).text, 'Lorem');
+    assert.deepEqual(page.foo().findBy('isSpecial').text, 'Lorem');
+
     let textArray = [];
     page.foo().forEach((i) => {
       textArray.push(i.text);


### PR DESCRIPTION
This PR adds the `find` and `findBy` array methods, which make searching for a single item in an array much more convenient. It's a common use case that we want to search a list of items for some item that matches a particular criteria (`fullName === 'John Doe'`, etc.) and while we can currently do it with `filterBy`, it's just a little extra work to pull it out.