### PR TITLE
Use project's jquery if available

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,34 +26,15 @@ module.exports = {
     this.app = this._findHost();
 
     if (this._shouldIncludeFiles()) {
-      this.importJquery();
+      if (!this.app.vendorFiles['jquery.js']) {
+        this.import('vendor/ecpo-jquery/dist/jquery.js');
+        this.import('vendor/shims/ecpo-jquery.js');
+      } else {
+        this.import('vendor/shims/project-jquery.js');
+      }
     }
 
     this._super.included.apply(this, arguments);
-  },
-
-  /*
-   * Import an amd '-jquery' shim which is used by ember-cli-page-object internally
-   *
-   * We don't want ember-cli-page-object's jquery ocassionaly leak into a real application.
-   * The following combo of shims supposed to isolate `ember-cli-page-object`'s `jquery`
-   * from the rest of application and expose internal version via amd module.
-   */
-  importJquery: function() {
-    // jquery itself is included in the very beggining of vendor.js.
-    // At this point we don't have `define()` defined so we can't create an amd shim here.
-    //
-    // However we have to store reference to jquery and dispose it from the window
-    // in order to prevent its leakage to the application.
-    this.import('vendor/shims/ecpo-jquery-global.js', {
-      prepend: true
-    });
-    this.import('vendor/ecpo-jquery/dist/jquery.js', {
-      prepend: true
-    });
-
-    // finally define an amd shim for our internal jquery version
-    this.import('vendor/shims/ecpo-jquery.js');
   },
 
   treeFor: function(/*name*/) {

--- a/vendor/shims/ecpo-jquery-global.js
+++ b/vendor/shims/ecpo-jquery-global.js
@@ -1,9 +1,0 @@
-// Temporary store our own jquery version in a global variable for the further definition of amd module.
-// We can't define amd module here cause we don't have `define()` in the very beginning of vendor.js
-//
-// It's important to include this shim right after our own `jquery` is included.
-// This way we ensure nothing catches our own `jquery` and we can safely dispose it from the global `window`.
-(function() {
-  window.__ecpoJQuery__ = self['$'].noConflict();
-  delete self['jQuery'];
-})();

--- a/vendor/shims/ecpo-jquery.js
+++ b/vendor/shims/ecpo-jquery.js
@@ -1,12 +1,21 @@
-// Define an amd '-jquery' shim which is used by ember-cli-page-object internally
+// Define an amd module called "-jquery" 
+// which exposes jQuery bundeled with ember-cli-page-object.
+//
+// This mode is used when we deal with `jquery`-less apps.
 (function() {
-  var jquery = window.__ecpoJQuery__;
-  delete window.__ecpoJQuery__;
+  // prevent jquery provided by ember-cli-page-object
+  // to be set to `Ember.$` by Ember. 
+  var jq = self['$'].noConflict();
+  delete self['jQuery'];
 
   function vendorModule() {
     'use strict';
 
-    return { 'default': jquery };
+    if (!jq) {
+      throw new Error('Unable to find jQuery');
+    }
+
+    return { 'default': jq };
   }
 
   define('-jquery', [], vendorModule);

--- a/vendor/shims/ecpo-jquery.js
+++ b/vendor/shims/ecpo-jquery.js
@@ -1,5 +1,6 @@
-// Define an amd module called "-jquery" 
-// which exposes jQuery bundeled with ember-cli-page-object.
+// Define an amd module called "-jquery".
+// It expects that we have already imported our own version of jQuery
+// which is going to be used in ember-cli-page-oject internally.
 //
 // This mode is used when we deal with `jquery`-less apps.
 (function() {

--- a/vendor/shims/project-jquery.js
+++ b/vendor/shims/project-jquery.js
@@ -1,0 +1,15 @@
+// Map `jquery` from the app to an amd module called `-jquery` for internal usage
+(function() {
+  function vendorModule() {
+    'use strict';
+
+    var jq = self.jQuery;
+    if (!jq) {
+      throw new Error('Unable to find jQuery');
+    }
+
+    return { 'default': jq };
+  }
+
+  define('-jquery', [], vendorModule);
+})();


### PR DESCRIPTION
This should fix issues like the one described by @magistrula in slack:

> I ran my tests without calling `useNativeEvents`, and here’s what I’m observing: if I run my tests on `v.1.12.0`, some tests pass that expect an empty `div` not to be visible. If I run my tests on `v1.13.0-alpha.1`, those tests fail. However, this test fails in ember-cli-page-object if I checkout to `v1.12.0` and when I checkout to `v1.13.0-alpha.1`

Also it simplifies inclusion of `jquery`. Thanks to @pzuraq for the idea.