### PR TITLE
feat(collection): Exposes a new Collection API 

### DIFF
--- a/addon/-private/properties/collection.js
+++ b/addon/-private/properties/collection.js
@@ -1,113 +1,23 @@
-/* global Symbol */
-import Ember from 'ember';
-import { buildSelector, assign as mergeFunction } from '../helpers';
-import { create } from '../create';
-import { count } from './count';
-import Ceibo from 'ceibo';
+import { deprecate } from '@ember/application/deprecations';
 
-const arrayDelegateMethods = ['map', 'filter', 'mapBy', 'filterBy', 'forEach'];
-
-function merge(target, ...objects) {
-  objects.forEach((o) => mergeFunction(target, o));
-
-  return target;
-}
-
-function generateEnumerable(node, definition, item, key) {
-  let enumerable = merge({}, definition);
-
-  if (typeof (enumerable.count) === 'undefined') {
-    enumerable.count = count(item.itemScope);
-  }
-
-  if (typeof (enumerable.toArray) === 'undefined') {
-    enumerable.toArray = toArrayMethod(node, item, key);
-    arrayDelegateMethods.forEach((method) => delegateToArray(enumerable, method));
-  }
-
-  let collection = create(enumerable, { parent: node });
-
-  if (typeof (Symbol) !== 'undefined' && Symbol.iterator) {
-    collection[Symbol.iterator] = iteratorMethod;
-  }
-
-  // Change the key of the root node
-  Ceibo.meta(collection).key = `${key}()`;
-
-  return collection;
-}
-
-function generateItem(node, index, definition, key) {
-  let filters = merge({}, { scope: definition.scope, at: index });
-  let scope = buildSelector({}, definition.itemScope, filters);
-
-  let tree = create(
-    merge(
-      {
-        testContainer: definition.testContainer
-      },
-      definition.item,
-      {
-        scope,
-        resetScope: definition.resetScope
-      }
-    ), { parent: node });
-
-  // Change the key of the root node
-  Ceibo.meta(tree).key = `${key}(${index})`;
-
-  return tree;
-}
-
-function toArrayMethod(node, definition, key) {
-  return function() {
-    let array = Ember.A();
-    let index;
-    let count;
-
-    for (index = 0, count = this.count; index < count; index++) {
-      array.push(generateItem(node, index, definition, key));
-    }
-
-    return array;
-  };
-}
-
-function delegateToArray(enumerable, method) {
-  if (typeof (enumerable[method]) === 'undefined') {
-    enumerable[method] = function(...args) {
-      return this.toArray()[method](...args);
-    };
-  }
-}
-
-function iteratorMethod() {
-  let i = 0;
-  let items = this.toArray();
-  let next = () => ({ done: i >= items.length, value: items[i++] });
-
-  return { next };
-}
+import { collection as mainCollection } from './collection/main';
+import { collection as legacyCollection } from './collection/legacy';
 
 /**
  * @public
  *
- * Creates a component that represents a collection of items. The collection is zero-indexed.
+ * Creates a enumerable that represents a collection of items. The collection is zero-indexed
+ * and has the following public methods and properties:
  *
- * When called with an index, the method returns the matching item.
- *
- * When called without an index, the the object returned behaves as a regular PageObject with a few additional properties and methods:
- *
- * - `count` - the number of items in the collection
+ * - `length` - The number of items in the collection.
+ * - `objectAt()` - Returns the page for the item at the specified index.
+ * - `filter()` - Filters the items in the array and returns the ones which match the predicate function.
+ * - `filterBy()` - Filters the items of the array by the specified property, returning all that are truthy or that match an optional value.
+ * - `forEach()` - Runs a function for each item in the collection
+ * - `map()` - maps over the elements of the collection
+ * - `mapBy()` - maps over the elements of the collecton by the specified property
  * - `toArray()` - returns an array containing all the items in the collection
  * - `[Symbol.iterator]()` - if supported by the environment, this allows the collection to be iterated with `for/of` and spread with `...` like a normal array
- *
- * Collection objects also delegate the following methods to `toArray()` for ease of consumption:
- * - `map`
- * - `mapBy`
- * - `filter`
- * - `filterBy`
- * - `forEach`
  *
  * @example
  *
@@ -127,21 +37,15 @@ function iteratorMethod() {
  *
  * const page = PageObject.create({
  *   users: collection({
- *     itemScope: 'table tr',
- *
- *     item: {
- *       firstName: text('td', { at: 0 }),
- *       lastName: text('td', { at: 1 })
- *     },
- *
- *     caption: text('caption')
+ *     scope: 'table tr',
+ *     firstName: text('td', { at: 0 }),
+ *     lastName: text('td', { at: 1 })
  *   })
  * });
  *
- * assert.equal(page.users().count, 2);
- * assert.equal(page.users().caption, 'List of users');
- * assert.equal(page.users(1).firstName, 'John');
- * assert.equal(page.users(1).lastName, 'Doe');
+ * assert.equal(page.users.length, 2);
+ * assert.equal(page.users.objectAt(1).firstName, 'John');
+ * assert.equal(page.users.objectAt(1).lastName, 'Doe');
  *
  * @example
  *
@@ -166,19 +70,16 @@ function iteratorMethod() {
  * // </div>
  *
  * const page = PageObject.create({
+ *   scope: '.admins',
+ *
  *   users: collection({
- *     scope: '.admins',
- *
- *     itemScope: 'table tr',
- *
- *     item: {
- *       firstName: text('td', { at: 0 }),
- *       lastName: text('td', { at: 1 })
- *     }
+ *     scope: 'table tr',
+ *     firstName: text('td', { at: 0 }),
+ *     lastName: text('td', { at: 1 })
  *   })
  * });
  *
- * assert.equal(page.users().count, 2);
+ * assert.equal(page.users.length, 2);
  *
  * @example
  *
@@ -186,58 +87,41 @@ function iteratorMethod() {
  * //   <caption>User Index</caption>
  * //   <tbody>
  * //     <tr>
- * //       <td>Doe</td>
- * //     </tr>
+ * //         <td>Mary<td>
+ * //         <td>Watson</td>
+ * //       </tr>
+ * //       <tr>
+ * //         <td>John<td>
+ * //         <td>Doe</td>
+ * //       </tr>
  * //   </tbody>
  * // </table>
  *
  * const page = PageObject.create({
+ *   scope: 'table',
+ *
  *   users: PageObject.collection({
- *     scope: 'table',
- *     itemScope: 'tr',
- *
- *     item: {
- *       firstName: text('td', { at: 0 })
- *     },
- *
- *     caption: PageObject.text('caption')
+ *     scope: 'tr',
+ *     firstName: text('td', { at: 0 }),
+ *     lastName: text('td', { at: 1 }),
  *   })
  * });
  *
- * assert.equal(page.users().caption, 'User Index');
+ * let john = page.users.filter((item) => item.firstName === 'John' )[0];
+ * assert.equal(john.lastName, 'Doe');
  *
  * @param {Object} definition - Collection definition
- * @param {string} definition.scope - Nests provided scope within parent's scope
- * @param {boolean} definition.resetScope - Override parent's scope
- * @param {string} definition.itemScope - CSS selector
- * @param {Object} definition.item - Item definition
  * @return {Descriptor}
  */
 export function collection(definition) {
-  definition = mergeFunction({}, definition);
+  if ('itemScope' in definition) {
+    deprecate('You are currently using the legacy collection API, check the documentation to see how to upgrade to the new API.', false, {
+      id: 'ember-cli-page-object.old-collection-api',
+      until: '2.0.0'
+    });
 
-  let item = {
-    scope: definition.scope,
-    itemScope: definition.itemScope,
-    resetScope: definition.resetScope,
-    item: definition.item,
-    testContainer: definition.testContainer
-  };
-
-  delete definition.item;
-  delete definition.itemScope;
-
-  return {
-    isDescriptor: true,
-
-    get(key) {
-      return (index) => {
-        if (typeof (index) === 'number') {
-          return generateItem(this, index, item, key);
-        } else {
-          return generateEnumerable(this, definition, item, key);
-        }
-      };
-    }
-  };
+    return legacyCollection(definition);
+  } else {
+    return mainCollection(definition);
+  }
 }

--- a/addon/-private/properties/collection/legacy.js
+++ b/addon/-private/properties/collection/legacy.js
@@ -1,0 +1,119 @@
+/* global Symbol */
+import Ember from 'ember';
+import { buildSelector, assign as mergeFunction } from '../../helpers';
+import { create } from '../../create';
+import { count } from '../count';
+import Ceibo from 'ceibo';
+
+const arrayDelegateMethods = ['map', 'filter', 'mapBy', 'filterBy', 'forEach'];
+
+function merge(target, ...objects) {
+  objects.forEach((o) => mergeFunction(target, o));
+
+  return target;
+}
+
+function generateEnumerable(node, definition, item, key) {
+  let enumerable = merge({}, definition);
+
+  if (typeof (enumerable.count) === 'undefined') {
+    enumerable.count = count(item.itemScope);
+  }
+
+  if (typeof (enumerable.toArray) === 'undefined') {
+    enumerable.toArray = toArrayMethod(node, item, key);
+    arrayDelegateMethods.forEach((method) => delegateToArray(enumerable, method));
+  }
+
+  let collection = create(enumerable, { parent: node });
+
+  if (typeof (Symbol) !== 'undefined' && Symbol.iterator) {
+    collection[Symbol.iterator] = iteratorMethod;
+  }
+
+  // Change the key of the root node
+  Ceibo.meta(collection).key = `${key}()`;
+
+  return collection;
+}
+
+function generateItem(node, index, definition, key) {
+  let filters = merge({}, { scope: definition.scope, at: index });
+  let scope = buildSelector({}, definition.itemScope, filters);
+
+  let tree = create(
+    merge(
+      {
+        testContainer: definition.testContainer
+      },
+      definition.item,
+      {
+        scope,
+        resetScope: definition.resetScope
+      }
+    ), { parent: node });
+
+  // Change the key of the root node
+  Ceibo.meta(tree).key = `${key}(${index})`;
+
+  return tree;
+}
+
+function toArrayMethod(node, definition, key) {
+  return function() {
+    let array = Ember.A();
+    let index;
+    let count;
+
+    for (index = 0, count = this.count; index < count; index++) {
+      array.push(generateItem(node, index, definition, key));
+    }
+
+    return array;
+  };
+}
+
+function delegateToArray(enumerable, method) {
+  if (typeof (enumerable[method]) === 'undefined') {
+    enumerable[method] = function(...args) {
+      return this.toArray()[method](...args);
+    };
+  }
+}
+
+function iteratorMethod() {
+  let i = 0;
+  let items = this.toArray();
+  let next = () => ({ done: i >= items.length, value: items[i++] });
+
+  return { next };
+}
+
+export function collection(definition) {
+  definition = mergeFunction({}, definition);
+
+  let item = {
+    scope: definition.scope,
+    itemScope: definition.itemScope,
+    resetScope: definition.resetScope,
+    item: definition.item,
+    testContainer: definition.testContainer
+  };
+
+  delete definition.item;
+  delete definition.itemScope;
+
+  return {
+    isDescriptor: true,
+
+    get(key) {
+      return (index) => {
+        if (typeof (index) === 'number') {
+          return generateItem(this, index, item, key);
+        } else {
+          return generateEnumerable(this, definition, item, key);
+        }
+      };
+    }
+  };
+}

--- a/addon/-private/properties/collection/main.js
+++ b/addon/-private/properties/collection/main.js
@@ -2,6 +2,10 @@
 import Ember from 'ember';
 import { buildSelector, assign } from '../../helpers';
 import { create } from '../../create';
+import {
+  ELEMENT_NOT_FOUND,
+  throwBetterError
+} from '../../better-errors';
 import { count } from '../count';
 import Ceibo from 'ceibo';
 
@@ -42,7 +46,18 @@ export class Collection {
       this._items[index] = tree;
     }
 
-    return this._items[index];
+    let itemPage = this._items[index];
+
+    if (index > this.length - 1) {
+      throwBetterError(
+        itemPage,
+        null,
+        ELEMENT_NOT_FOUND,
+        { selector: itemPage.scope }
+      );
+    }
+
+    return itemPage;
   }
 
   filter(...args) {

--- a/addon/-private/properties/collection/main.js
+++ b/addon/-private/properties/collection/main.js
@@ -1,0 +1,104 @@
+/* global Symbol */
+import Ember from 'ember';
+import { buildSelector, assign } from '../../helpers';
+import { create } from '../../create';
+import { count } from '../count';
+import Ceibo from 'ceibo';
+
+export class Collection {
+  constructor(definition, parent, key) {
+    this.definition = definition;
+    this.parent = parent;
+    this.key = key;
+
+    this._itemCounter = create({
+      count: count(definition.scope, {
+        resetScope: definition.resetScope,
+        testContainer: definition.testContainer
+      })
+    }, { parent });
+
+    this._items = [];
+  }
+
+  get length() {
+    return this._itemCounter.count;
+  }
+
+  objectAt(index) {
+    if (typeof this._items[index] === 'undefined') {
+      let { definition, parent, key } = this;
+      let scope = buildSelector({}, definition.scope, { at: index });
+
+      let finalizedDefinition = assign({}, definition);
+
+      finalizedDefinition.scope = scope;
+
+      let tree = create(finalizedDefinition, { parent });
+
+      // Change the key of the root node
+      Ceibo.meta(tree).key = `${key}[${index}]`;
+
+      this._items[index] = tree;
+    }
+
+    return this._items[index];
+  }
+
+  filter(...args) {
+    return this.toArray().filter(...args);
+  }
+
+  filterBy(...args) {
+    return this.toArray().filterBy(...args);
+  }
+
+  forEach(...args) {
+    return this.toArray().forEach(...args);
+  }
+
+  map(...args) {
+    return this.toArray().map(...args);
+  }
+
+  mapBy(...args) {
+    return this.toArray().mapBy(...args);
+  }
+
+  toArray() {
+    let { length } = this;
+
+    let array = Ember.A();
+
+    for (let i = 0; i < length; i++) {
+      array.push(this.objectAt(i));
+    }
+
+    return array;
+  }
+}
+
+if (typeof (Symbol) !== 'undefined' && Symbol.iterator) {
+  Collection.prototype[Symbol.iterator] = function() {
+    let i = 0;
+    let items = this.toArray();
+    let next = () => ({ done: i >= items.length, value: items[i++] });
+
+    return { next };
+  }
+}
+
+export function collection(definition) {
+  let descriptor = {
+    isDescriptor: true,
+
+    setup(node, key) {
+      // Set the value on the descriptor so that it will be picked up and applied by Ceibo.
+      // This does mutate the descriptor, but because `setup` is always called before the
+      // value is assigned we are guaranteed to get a new, unique Collection instance each time.
+      descriptor.value = new Collection(definition, node, key);
+    }
+  };
+
+  return descriptor;
+}

--- a/addon/-private/properties/collection/main.js
+++ b/addon/-private/properties/collection/main.js
@@ -30,8 +30,10 @@ export class Collection {
   }
 
   objectAt(index) {
+    let { key } = this;
+
     if (typeof this._items[index] === 'undefined') {
-      let { definition, parent, key } = this;
+      let { definition, parent } = this;
       let scope = buildSelector({}, definition.scope, { at: index });
 
       let finalizedDefinition = assign({}, definition);
@@ -50,8 +52,8 @@ export class Collection {
 
     if (index > this.length - 1) {
       throwBetterError(
-        itemPage,
-        null,
+        this.parent,
+        `${key}.objectAt(${index})`,
         ELEMENT_NOT_FOUND,
         { selector: itemPage.scope }
       );

--- a/tests/unit/-private/properties/collection-test.js
+++ b/tests/unit/-private/properties/collection-test.js
@@ -201,7 +201,7 @@ moduleForProperty('collection', function(test) {
     assert.equal(page.foo.objectAt(0).bar.objectAt(0).text, 'Ipsum');
   });
 
-  test("returns the page object path when item's element doesn't exist", function(assert) {
+  test("throws an error when the item's element doesn't exist", function(assert) {
     let page = create({
       foo: {
         bar: collection({
@@ -214,7 +214,7 @@ moduleForProperty('collection', function(test) {
 
     this.adapter.createTemplate(this, page);
 
-    assert.throws(() => page.foo.bar.objectAt(1).baz.qux, /page\.foo\.bar\[1\]/);
+    assert.throws(() => page.foo.bar.objectAt(1).baz.qux, /page\.foo\.bar\.objectAt\(1\)/);
   });
 
   test('iterates over scoped items with a for loop', function(assert) {

--- a/tests/unit/-private/properties/collection-test.js
+++ b/tests/unit/-private/properties/collection-test.js
@@ -214,7 +214,7 @@ moduleForProperty('collection', function(test) {
 
     this.adapter.createTemplate(this, page);
 
-    assert.throws(() => page.foo.bar.objectAt(1).baz.qux, /page\.foo\.bar\[1\]\.baz\.qux/);
+    assert.throws(() => page.foo.bar.objectAt(1).baz.qux, /page\.foo\.bar\[1\]/);
   });
 
   test('iterates over scoped items with a for loop', function(assert) {

--- a/tests/unit/-private/properties/collection-test.js
+++ b/tests/unit/-private/properties/collection-test.js
@@ -3,10 +3,10 @@ import { create, collection, text, hasClass } from 'ember-cli-page-object';
 import withIteratorSymbolDefined from '../../../helpers/with-iterator-symbol-defined';
 
 moduleForProperty('collection', function(test) {
-  test('generates a count property', function(assert) {
+  test('generates a length property', function(assert) {
     let page = create({
       foo: collection({
-        itemScope: 'span'
+        scope: 'span'
       })
     });
 
@@ -15,34 +15,29 @@ moduleForProperty('collection', function(test) {
       <span>Ipsum</span>
     `);
 
-    assert.equal(page.foo().count, 2);
+    assert.equal(page.foo.length, 2);
   });
 
-  test('does not override custom count property', function(assert) {
+  test('Works with zero length', function(assert) {
     let page = create({
       foo: collection({
-        itemScope: 'span',
-
-        count: 'custom count'
+        scope: 'span'
       })
     });
 
     this.adapter.createTemplate(this, page, `
-      <span>Lorem</span>
-      <span>Ipsum</span>
+      <div>Lorem</div>
+      <div>Ipsum</div>
     `);
 
-    assert.equal(page.foo().count, 'custom count');
+    assert.equal(page.foo.length, 0);
   });
 
   test('returns an item', function(assert) {
     let page = create({
       foo: collection({
-        itemScope: 'span',
-
-        item: {
-          text: text()
-        }
+        scope: 'span',
+        text: text()
       })
     });
 
@@ -51,18 +46,15 @@ moduleForProperty('collection', function(test) {
       <span>Ipsum</span>
     `);
 
-    assert.equal(page.foo(0).text, 'Lorem');
-    assert.equal(page.foo(1).text, 'Ipsum');
+    assert.equal(page.foo.objectAt(0).text, 'Lorem');
+    assert.equal(page.foo.objectAt(1).text, 'Ipsum');
   });
 
   test('collects an array of items', function(assert) {
     let page = create({
       foo: collection({
-        itemScope: 'span',
-
-        item: {
-          text: text()
-        }
+        scope: 'span',
+        text: text()
       })
     });
 
@@ -71,49 +63,22 @@ moduleForProperty('collection', function(test) {
       <span>Ipsum</span>
     `);
 
-    let array = page.foo().toArray();
+    let array = page.foo.toArray();
     assert.equal(array.length, 2);
     assert.equal(array[0].text, 'Lorem');
     assert.equal(array[1].text, 'Ipsum');
-  });
 
-  test('delegates configured methods to `toArray()`', function(assert) {
-    let page = create({
-      foo: collection({
-        itemScope: 'span',
-
-        item: {
-          isSpecial: hasClass('special'),
-          text: text()
-        }
-      })
-    });
-
-    this.adapter.createTemplate(this, page, `
-      <span class="special">Lorem</span>
-      <span>Ipsum</span>
-    `);
-
-    assert.deepEqual(page.foo().map((i) => i.text), ['Lorem', 'Ipsum']);
-    assert.deepEqual(page.foo().mapBy('text'), ['Lorem', 'Ipsum']);
-
-    assert.deepEqual(page.foo().filter((i) => i.isSpecial).map((i) => i.text), ['Lorem']);
-    assert.deepEqual(page.foo().filterBy('isSpecial').map((i) => i.text), ['Lorem']);
-    let textArray = [];
-    page.foo().forEach((i) => {
-      textArray.push(i.text);
-    });
-    assert.deepEqual(textArray, ['Lorem', 'Ipsum']);
+    let proxyArray = page.foo.toArray();
+    assert.equal(proxyArray.length, 2);
+    assert.equal(proxyArray[0].text, 'Lorem');
+    assert.equal(proxyArray[1].text, 'Ipsum');
   });
 
   test('produces an iterator for items', function(assert) {
     let page = create({
       foo: collection({
-        itemScope: 'span',
-
-        item: {
-          text: text()
-        }
+        scope: 'span',
+        text: text()
       })
     });
 
@@ -124,7 +89,7 @@ moduleForProperty('collection', function(test) {
 
     let textContents = [];
     withIteratorSymbolDefined(() => {
-      for (let item of page.foo()) {
+      for (let item of page.foo) {
         textContents.push(item.text);
       }
     });
@@ -137,12 +102,8 @@ moduleForProperty('collection', function(test) {
       scope: '.scope',
 
       foo: collection({
-        itemScope: 'span',
-        hola: 'mundo',
-
-        item: {
-          text: text()
-        }
+        scope: 'span',
+        text: text()
       })
     });
 
@@ -155,7 +116,7 @@ moduleForProperty('collection', function(test) {
       </div>
     `);
 
-    assert.equal(page.foo(0).text, 'Ipsum');
+    assert.equal(page.foo.objectAt(0).text, 'Ipsum');
   });
 
   test('looks for elements inside multiple scopes', function(assert) {
@@ -163,14 +124,11 @@ moduleForProperty('collection', function(test) {
       scope: '.scope',
 
       foo: collection({
-        itemScope: 'li',
+        scope: 'li',
+        bar: {
+          scope: '.another-scope',
 
-        item: {
-          bar: {
-            scope: '.another-scope',
-
-            text: text('li', { at: 0 })
-          }
+          text: text('li', { at: 0 })
         }
       })
     });
@@ -198,71 +156,7 @@ moduleForProperty('collection', function(test) {
       </ul>
     `);
 
-    assert.equal(page.foo(1).bar.text, 'Sit');
-  });
-
-  test('looks for elements inside collection\'s scope', function(assert) {
-    let page = create({
-      foo: collection({
-        scope: '.scope',
-        itemScope: 'li',
-
-        item: {
-          text: text()
-        }
-      })
-    });
-
-    this.adapter.createTemplate(this, page, `
-      <ul>
-        <li>Lorem</li>
-      </ul>
-      <ul class="scope">
-        <li>Ipsum</li>
-      </ul>
-    `);
-
-    assert.equal(page.foo(0).text, 'Ipsum');
-  });
-
-  test('returns collection\'s component', function(assert) {
-    let page = create({
-      foo: collection({
-        itemScope: 'span',
-
-        text: text('button')
-      })
-    });
-
-    this.adapter.createTemplate(this, page, `
-      <span>Lorem</span>
-      <span>Second</span>
-      <button>Submit</button>
-    `);
-
-    assert.equal(page.foo().text, 'Submit');
-  });
-
-  test('looks for elements inside collection\'s scope (collection component)', function(assert) {
-    let page = create({
-      foo: collection({
-        scope: '.scope',
-        itemScope: 'li',
-
-        text: text('span')
-      })
-    });
-
-    this.adapter.createTemplate(this, page, `
-      <div>
-        <span>Lorem</span>
-      </div>
-      <div class="scope">
-        <span>Ipsum</span>
-      </div>
-    `);
-
-    assert.equal(page.foo().text, 'Ipsum');
+    assert.equal(page.foo.objectAt(1).bar.text, 'Sit');
   });
 
   test('resets scope for items', function(assert) {
@@ -271,64 +165,31 @@ moduleForProperty('collection', function(test) {
 
       foo: collection({
         resetScope: true,
-        scope: '.scope',
-        itemScope: 'span',
-
-        item: {
-          text: text()
-        }
+        scope: 'span',
+        text: text()
       })
     });
 
     this.adapter.createTemplate(this, page, `
+      <span>Lorem</span>
       <div>
-        <span>Lorem</span>
-      </div>
-      <div class="scope">
         <span>Ipsum</span>
       </div>
     `);
 
-    assert.equal(page.foo(0).text, 'Ipsum');
-  });
-
-  test('resets scope for collection\'s component', function(assert) {
-    let page = create({
-      scope: 'div',
-
-      foo: collection({
-        resetScope: true,
-        scope: '.scope',
-        text: text('span')
-      })
-    });
-
-    this.adapter.createTemplate(this, page, `
-      <div>
-        <span>Lorem</span>
-      </div>
-      <div class="scope">
-        <span>Ipsum</span>
-      </div>
-    `);
-
-    assert.equal(page.foo().text, 'Ipsum');
+    assert.equal(page.foo.objectAt(0).text, 'Lorem');
   });
 
   test('sets correct scope to child collections', function(assert) {
     let page = create({
-      foo: collection({
-        scope: '.scope',
-        itemScope: 'span',
+      scope: '.scope',
 
-        item: {
-          bar: collection({
-            itemScope: 'em',
-            item: {
-              text: text()
-            }
-          })
-        }
+      foo: collection({
+        scope: 'span',
+        bar: collection({
+          scope: 'em',
+          text: text()
+        })
       })
     });
 
@@ -337,33 +198,13 @@ moduleForProperty('collection', function(test) {
       <div class="scope"><span><em>Ipsum</em></span></div>
     `);
 
-    assert.equal(page.foo(0).bar(0).text, 'Ipsum');
+    assert.equal(page.foo.objectAt(0).bar.objectAt(0).text, 'Ipsum');
   });
 
   test("returns the page object path when item's element doesn't exist", function(assert) {
     let page = create({
       foo: {
         bar: collection({
-          item: {
-            baz: {
-              qux: text('span')
-            }
-          }
-        })
-      }
-    });
-
-    this.adapter.createTemplate(this, page);
-
-    assert.throws(() => page.foo.bar(1).baz.qux, /page\.foo\.bar\(1\)\.baz\.qux/);
-  });
-
-  test("returns the page object path when collection's element doesn't exist", function(assert) {
-    let page = create({
-      foo: {
-        bar: collection({
-          scope: 'span',
-
           baz: {
             qux: text('span')
           }
@@ -373,46 +214,29 @@ moduleForProperty('collection', function(test) {
 
     this.adapter.createTemplate(this, page);
 
-    assert.throws(() => page.foo.bar().baz.qux, /page\.foo\.bar\(\)\.baz\.qux/);
-  });
-
-  test("doesn't generate an item or itemScope property", function(assert) {
-    let page = create({
-      foo: collection({
-        itemScope: 'span',
-        item: {}
-      })
-    });
-
-    this.adapter.createTemplate(this, page);
-
-    assert.notOk(page.foo().item);
-    assert.notOk(page.foo().itemScope);
+    assert.throws(() => page.foo.bar.objectAt(1).baz.qux, /page\.foo\.bar\[1\]\.baz\.qux/);
   });
 
   test('iterates over scoped items with a for loop', function(assert) {
     let page = create({
+      scope: 'div',
       foo: collection({
-        scope: 'div',
-        itemScope: 'span',
-
-        item: {
-          text: text()
-        }
+        scope: 'span',
+        text: text()
       })
     });
 
     this.adapter.createTemplate(this, page, `
       <div>
-          <span>Lorem</span>
-          <span>Ipsum</span>
+        <span>Lorem</span>
+        <span>Ipsum</span>
       </div>
     `);
 
     let textContents = [];
 
-    for (let i = 0; i < page.foo().count; i++) {
-      let item = page.foo(i);
+    for (let i = 0; i < page.foo.length; i++) {
+      let item = page.foo.objectAt(i);
       textContents.push(item.text);
     }
 
@@ -421,27 +245,24 @@ moduleForProperty('collection', function(test) {
 
   test('iterates over scoped items with a for of loop', function(assert) {
     let page = create({
+      scope: 'div',
       foo: collection({
-        scope: 'div',
-        itemScope: 'span',
-
-        item: {
-          text: text()
-        }
+        scope: 'span',
+        text: text()
       })
     });
 
     this.adapter.createTemplate(this, page, `
       <div>
-          <span>Lorem</span>
-          <span>Ipsum</span>
+        <span>Lorem</span>
+        <span>Ipsum</span>
       </div>
     `);
 
     let textContents = [];
 
     withIteratorSymbolDefined(() => {
-      for (let item of page.foo()) {
+      for (let item of page.foo) {
         textContents.push(item.text);
       }
     });
@@ -451,26 +272,24 @@ moduleForProperty('collection', function(test) {
 
   test('iterates over scoped items with a forEach loop', function(assert) {
     let page = create({
-      foo: collection({
-        scope: 'div',
-        itemScope: 'span',
+      scope: 'div',
 
-        item: {
-          text: text()
-        }
+      foo: collection({
+        scope: 'span',
+        text: text()
       })
     });
 
     this.adapter.createTemplate(this, page, `
       <div>
-          <span>Lorem</span>
-          <span>Ipsum</span>
+        <span>Lorem</span>
+        <span>Ipsum</span>
       </div>
     `);
 
     let textContents = [];
 
-    page.foo().toArray().forEach(function(item) {
+    page.foo.forEach((item) => {
       textContents.push(item.text);
     });
 
@@ -479,23 +298,21 @@ moduleForProperty('collection', function(test) {
 
   test('does not mutate definition object', function(assert) {
     let prop = text('.baz');
+
     let expected = {
-      scope: '.a-scope',
-      itemScope: '.another-scope',
-      item: {
-        baz: prop
-      },
-
-      bar: prop
+      scope: '.another-scope',
+      bar: prop,
+      baz: {
+        qux: prop
+      }
     };
-    let actual = {
-      scope: '.a-scope',
-      itemScope: '.another-scope',
-      item: {
-        baz: prop
-      },
 
-      bar: prop
+    let actual = {
+      scope: '.another-scope',
+      bar: prop,
+      baz: {
+        qux: prop
+      }
     };
 
     let page = create({
@@ -516,7 +333,7 @@ moduleForProperty('collection', function(test) {
     page = create({
       foo: collection({
         testContainer: expectedContext,
-        itemScope: 'span'
+        scope: 'span'
       })
     });
 
@@ -527,7 +344,113 @@ moduleForProperty('collection', function(test) {
       { useAlternateContainer: true }
     );
 
-    assert.equal(page.foo().count, 2);
-    assert.equal(page.foo(0).text, 'Lorem');
+    assert.equal(page.foo.length, 2);
+    assert.equal(page.foo.objectAt(0).text, 'Lorem');
+  });
+
+  test('objectAt returns an item', function(assert) {
+    let page = create({
+      foo: collection({
+        scope: 'span',
+        text: text()
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <span>Lorem</span>
+      <span>Ipsum</span>
+    `);
+
+    assert.equal(page.foo.objectAt(0).text, 'Lorem');
+    assert.equal(page.foo.objectAt(1).text, 'Ipsum');
+  });
+
+  test('forEach works correctly', function(assert) {
+    let page = create({
+      foo: collection({
+        scope: 'span',
+        text: text()
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <span class="special">Lorem</span>
+      <span>Ipsum</span>
+    `);
+
+    let textArray = [];
+    page.foo.forEach((i) => {
+      textArray.push(i.text);
+    });
+
+    assert.deepEqual(textArray, ['Lorem', 'Ipsum']);
+  });
+
+  test('map works correctly', function(assert) {
+    let page = create({
+      foo: collection({
+        scope: 'span',
+        text: text()
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <span>Lorem</span>
+      <span>Ipsum</span>
+    `);
+
+    assert.deepEqual(page.foo.map((i) => i.text), ['Lorem', 'Ipsum']);
+  });
+
+  test('mapBy works correctly', function(assert) {
+    let page = create({
+      foo: collection({
+        scope: 'span',
+        text: text()
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <span>Lorem</span>
+      <span>Ipsum</span>
+    `);
+
+    assert.deepEqual(page.foo.mapBy('text'), ['Lorem', 'Ipsum']);
+  });
+
+  test('filter works correctly', function(assert) {
+    let page = create({
+      foo: collection({
+        scope: 'span',
+        isSpecial: hasClass('special'),
+        text: text()
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <span class="special">Lorem</span>
+      <span>Ipsum</span>
+    `);
+
+    assert.deepEqual(page.foo.filter((i) => i.isSpecial).map((i) => i.text), ['Lorem']);
+    assert.deepEqual(page.foo.filter((i) => i.isFoo).map((i) => i.text), []);
+  });
+
+  test('filterBy works correctly', function(assert) {
+    let page = create({
+      foo: collection({
+        scope: 'span',
+        isSpecial: hasClass('special'),
+        text: text()
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <span class="special">Lorem</span>
+      <span>Ipsum</span>
+    `);
+
+    assert.deepEqual(page.foo.filterBy('isSpecial').map((i) => i.text), ['Lorem']);
+    assert.deepEqual(page.foo.filterBy('isFoo').map((i) => i.text), []);
   });
 });

--- a/tests/unit/-private/properties/legacy-collection-test.js
+++ b/tests/unit/-private/properties/legacy-collection-test.js
@@ -1,0 +1,584 @@
+import { moduleForProperty } from '../../../helpers/properties';
+import { create, collection, text, hasClass } from 'ember-cli-page-object';
+import withIteratorSymbolDefined from '../../../helpers/with-iterator-symbol-defined';
+
+moduleForProperty('legacy collection', function(test) {
+  test('generates a count property', function(assert) {
+    let page = create({
+      foo: collection({
+        itemScope: 'span'
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <span>Lorem</span>
+      <span>Ipsum</span>
+    `);
+
+    assert.equal(page.foo().count, 2);
+  });
+
+  test('does not override custom count property', function(assert) {
+    let page = create({
+      foo: collection({
+        itemScope: 'span',
+
+        count: 'custom count'
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <span>Lorem</span>
+      <span>Ipsum</span>
+    `);
+
+    assert.equal(page.foo().count, 'custom count');
+  });
+
+  test('returns an item', function(assert) {
+    let page = create({
+      foo: collection({
+        itemScope: 'span',
+
+        item: {
+          text: text()
+        }
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <span>Lorem</span>
+      <span>Ipsum</span>
+    `);
+
+    assert.equal(page.foo(0).text, 'Lorem');
+    assert.equal(page.foo(1).text, 'Ipsum');
+  });
+
+  test('collects an array of items', function(assert) {
+    let page = create({
+      foo: collection({
+        itemScope: 'span',
+
+        item: {
+          text: text()
+        }
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <span>Lorem</span>
+      <span>Ipsum</span>
+    `);
+
+    let array = page.foo().toArray();
+    assert.equal(array.length, 2);
+    assert.equal(array[0].text, 'Lorem');
+    assert.equal(array[1].text, 'Ipsum');
+  });
+
+  test('delegates configured methods to `toArray()`', function(assert) {
+    let page = create({
+      foo: collection({
+        itemScope: 'span',
+
+        item: {
+          isSpecial: hasClass('special'),
+          text: text()
+        }
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <span class="special">Lorem</span>
+      <span>Ipsum</span>
+    `);
+
+    assert.deepEqual(page.foo().map((i) => i.text), ['Lorem', 'Ipsum']);
+    assert.deepEqual(page.foo().mapBy('text'), ['Lorem', 'Ipsum']);
+
+    assert.deepEqual(page.foo().filter((i) => i.isSpecial).map((i) => i.text), ['Lorem']);
+    assert.deepEqual(page.foo().filterBy('isSpecial').map((i) => i.text), ['Lorem']);
+    let textArray = [];
+    page.foo().forEach((i) => {
+      textArray.push(i.text);
+    });
+    assert.deepEqual(textArray, ['Lorem', 'Ipsum']);
+  });
+
+  test('produces an iterator for items', function(assert) {
+    let page = create({
+      foo: collection({
+        itemScope: 'span',
+
+        item: {
+          text: text()
+        }
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <span>Lorem</span>
+      <span>Ipsum</span>
+    `);
+
+    let textContents = [];
+    withIteratorSymbolDefined(() => {
+      for (let item of page.foo()) {
+        textContents.push(item.text);
+      }
+    });
+
+    assert.deepEqual(textContents, ['Lorem', 'Ipsum']);
+  });
+
+  test('looks for elements inside the scope', function(assert) {
+    let page = create({
+      scope: '.scope',
+
+      foo: collection({
+        itemScope: 'span',
+        hola: 'mundo',
+
+        item: {
+          text: text()
+        }
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <div>
+        <span>Lorem</span>
+      </div>
+      <div class="scope">
+        <span>Ipsum</span>
+      </div>
+    `);
+
+    assert.equal(page.foo(0).text, 'Ipsum');
+  });
+
+  test('looks for elements inside multiple scopes', function(assert) {
+    let page = create({
+      scope: '.scope',
+
+      foo: collection({
+        itemScope: 'li',
+
+        item: {
+          bar: {
+            scope: '.another-scope',
+
+            text: text('li', { at: 0 })
+          }
+        }
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <ul>
+        <li>Blah</li>
+        <li>
+          <ul class="another-scope">
+            <li>Lorem<li>
+          </ul>
+        </li>
+      </ul>
+      <ul class="scope">
+        <li>Ipsum</li>
+        <li>
+          <ul>
+            <li>Dolor</li>
+          </ul>
+          <ul class="another-scope">
+            <li>Sit</li>
+            <li>Amet</li>
+          </ul>
+        </li>
+      </ul>
+    `);
+
+    assert.equal(page.foo(1).bar.text, 'Sit');
+  });
+
+  test('looks for elements inside collection\'s scope', function(assert) {
+    let page = create({
+      foo: collection({
+        scope: '.scope',
+        itemScope: 'li',
+
+        item: {
+          text: text()
+        }
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <ul>
+        <li>Lorem</li>
+      </ul>
+      <ul class="scope">
+        <li>Ipsum</li>
+      </ul>
+    `);
+
+    assert.equal(page.foo(0).text, 'Ipsum');
+  });
+
+  test('returns collection\'s component', function(assert) {
+    let page = create({
+      foo: collection({
+        itemScope: 'span',
+
+        text: text('button')
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <span>Lorem</span>
+      <span>Second</span>
+      <button>Submit</button>
+    `);
+
+    assert.equal(page.foo().text, 'Submit');
+  });
+
+  test('looks for elements inside collection\'s scope (collection component)', function(assert) {
+    let page = create({
+      foo: collection({
+        scope: '.scope',
+        itemScope: 'li',
+
+        text: text('span')
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <div>
+        <span>Lorem</span>
+      </div>
+      <div class="scope">
+        <span>Ipsum</span>
+      </div>
+    `);
+
+    assert.equal(page.foo().text, 'Ipsum');
+  });
+
+  test('resets scope for items', function(assert) {
+    let page = create({
+      scope: 'div',
+
+      foo: collection({
+        resetScope: true,
+        scope: '.scope',
+        itemScope: 'span',
+
+        item: {
+          text: text()
+        }
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <div>
+        <span>Lorem</span>
+      </div>
+      <div class="scope">
+        <span>Ipsum</span>
+      </div>
+    `);
+
+    assert.equal(page.foo(0).text, 'Ipsum');
+  });
+
+  test('resets scope for collection\'s component', function(assert) {
+    let page = create({
+      scope: 'div',
+
+      foo: collection({
+        resetScope: true,
+        scope: '.scope',
+        itemScope: 'span',
+        text: text('span')
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <div>
+        <span>Lorem</span>
+      </div>
+      <div class="scope">
+        <span>Ipsum</span>
+      </div>
+    `);
+
+    assert.equal(page.foo().text, 'Ipsum');
+  });
+
+  test('sets correct scope to child collections', function(assert) {
+    let page = create({
+      foo: collection({
+        scope: '.scope',
+        itemScope: 'span',
+
+        item: {
+          bar: collection({
+            itemScope: 'em',
+            item: {
+              text: text()
+            }
+          })
+        }
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <div><span><em>Lorem</em></span></div>
+      <div class="scope"><span><em>Ipsum</em></span></div>
+    `);
+
+    assert.equal(page.foo(0).bar(0).text, 'Ipsum');
+  });
+
+  test("returns the page object path when item's element doesn't exist", function(assert) {
+    let page = create({
+      foo: {
+        bar: collection({
+          itemScope: 'span',
+          item: {
+            baz: {
+              qux: text('span')
+            }
+          }
+        })
+      }
+    });
+
+    this.adapter.createTemplate(this, page);
+
+    assert.throws(() => page.foo.bar(1).baz.qux, /page\.foo\.bar\(1\)\.baz\.qux/);
+  });
+
+  test("returns the page object path when collection's element doesn't exist", function(assert) {
+    let page = create({
+      foo: {
+        bar: collection({
+          scope: 'span',
+          itemScope: 'span',
+
+          baz: {
+            qux: text('span')
+          }
+        })
+      }
+    });
+
+    this.adapter.createTemplate(this, page);
+
+    assert.throws(() => page.foo.bar().baz.qux, /page\.foo\.bar\(\)\.baz\.qux/);
+  });
+
+  test("doesn't generate an item or itemScope property", function(assert) {
+    let page = create({
+      foo: collection({
+        itemScope: 'span',
+        item: {}
+      })
+    });
+
+    this.adapter.createTemplate(this, page);
+
+    assert.notOk(page.foo().item);
+    assert.notOk(page.foo().itemScope);
+  });
+
+  test('iterates over scoped items with a for loop', function(assert) {
+    let page = create({
+      foo: collection({
+        scope: 'div',
+        itemScope: 'span',
+
+        item: {
+          text: text()
+        }
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <div>
+          <span>Lorem</span>
+          <span>Ipsum</span>
+      </div>
+    `);
+
+    let textContents = [];
+
+    for (let i = 0; i < page.foo().count; i++) {
+      let item = page.foo(i);
+      textContents.push(item.text);
+    }
+
+    assert.deepEqual(textContents, ['Lorem', 'Ipsum']);
+  });
+
+  test('iterates over scoped items with a for of loop', function(assert) {
+    let page = create({
+      foo: collection({
+        scope: 'div',
+        itemScope: 'span',
+
+        item: {
+          text: text()
+        }
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <div>
+          <span>Lorem</span>
+          <span>Ipsum</span>
+      </div>
+    `);
+
+    let textContents = [];
+
+    withIteratorSymbolDefined(() => {
+      for (let item of page.foo()) {
+        textContents.push(item.text);
+      }
+    });
+
+    assert.deepEqual(textContents, ['Lorem', 'Ipsum']);
+  });
+
+  test('iterates over scoped items with a forEach loop', function(assert) {
+    let page = create({
+      foo: collection({
+        scope: 'div',
+        itemScope: 'span',
+
+        item: {
+          text: text()
+        }
+      })
+    });
+
+    this.adapter.createTemplate(this, page, `
+      <div>
+          <span>Lorem</span>
+          <span>Ipsum</span>
+      </div>
+    `);
+
+    let textContents = [];
+
+    page.foo().toArray().forEach(function(item) {
+      textContents.push(item.text);
+    });
+
+    assert.deepEqual(textContents, ['Lorem', 'Ipsum']);
+  });
+
+  test('does not mutate definition object', function(assert) {
+    let prop = text('.baz');
+    let expected = {
+      scope: '.a-scope',
+      itemScope: '.another-scope',
+      item: {
+        baz: prop
+      },
+
+      bar: prop
+    };
+    let actual = {
+      scope: '.a-scope',
+      itemScope: '.another-scope',
+      item: {
+        baz: prop
+      },
+
+      bar: prop
+    };
+
+    let page = create({
+      foo: collection(actual)
+    });
+
+    this.adapter.createTemplate(this, page);
+
+    assert.deepEqual(actual, expected);
+  });
+
+  test('looks for elements within test container specified', function(assert) {
+    assert.expect(2);
+
+    let expectedContext = '#alternate-ember-testing';
+    let page;
+
+    page = create({
+      foo: collection({
+        testContainer: expectedContext,
+        itemScope: 'span'
+      })
+    });
+
+    this.adapter.createTemplate(
+      this,
+      page,
+      '<span>Lorem</span><span>ipsum</span>',
+      { useAlternateContainer: true }
+    );
+
+    assert.equal(page.foo().count, 2);
+    assert.equal(page.foo(0).text, 'Lorem');
+  });
+
+  test('can provide custom array methods', function(assert) {
+    assert.expect(6);
+
+    let page = create({
+      foo: collection({
+        toArray() {
+          assert.ok(true, 'custom toArray allowed');
+        },
+
+        forEach() {
+          assert.ok(true, 'custom forEach allowed');
+        },
+
+        map() {
+          assert.ok(true, 'custom map allowed');
+        },
+
+        mapBy() {
+          assert.ok(true, 'custom mapBy allowed');
+        },
+
+        filter() {
+          assert.ok(true, 'custom filter allowed');
+        },
+
+        filterBy() {
+          assert.ok(true, 'custom filterBy allowed');
+        },
+
+        itemScope: 'span'
+      })
+    });
+
+    this.adapter.createTemplate(
+      this,
+      page,
+      '<span>Lorem</span><span>ipsum</span>',
+      { useAlternateContainer: true }
+    );
+
+    page.foo().toArray();
+    page.foo().forEach();
+    page.foo().map();
+    page.foo().mapBy();
+    page.foo().filter();
+    page.foo().filterBy();
+  });
+});


### PR DESCRIPTION
This PR implements the new Collection API RFC outlined in #352. The new API is optionally applied if users omit `itemScope` from collection definitions, allowing them to opt into the new syntax over time.

## Structure

The new collection is implemented as a class, that has a single instance per collection, rather than returning a new one each time the collection is called. Users are meant to interact with this class directly rather than calling the collection like method as before.

The class also caches individual item pages internally so they don't have to be regenerated each time the collection is accessed. This allows us to optimize for CPU over memory usage, which will (incrementally) help test speed.

## API

The new API that is exposed has the following methods:

* `objectAt`: Returns the item at the specified index, throws an error if it doesn't exist
* `length`: The current length of the collection
* `toArray`: Returns an array of all the items at that point in time. Should likely be a native array.
* `forEach`: Runs a function for every item in the collection, like native `forEach`
* `filter`: Filters the collection, like native `filter`
* `filterBy`: Filters the collection by a given key
* `map`: Maps over the collection, like native `map`
* `mapBy`: Maps over the collection by the given key

cc @magistrula @san650 @ro0gr 