### PR TITLE
Fastboot Safe

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = {
     // https://github.com/joostdevries/twiddle-backend/pull/28 is merged.
     // return !!this.app.tests;
 
-    if('EMBER_CLI_FASTBOOT' in process.env) {
+    if(process.env && process.env.EMBER_CLI_FASTBOOT) {
       return false;
     } else {
       return this.app.env !== 'production';

--- a/index.js
+++ b/index.js
@@ -49,7 +49,12 @@ module.exports = {
     // TODO: In order to make the addon work in EmberTwiddle, we cannot use // the `tests` prop til
     // https://github.com/joostdevries/twiddle-backend/pull/28 is merged.
     // return !!this.app.tests;
-    return this.app.env !== 'production';
+
+    if('EMBER_CLI_FASTBOOT' in process.env) {
+      return false;
+    } else {
+      return this.app.env !== 'production';
+    }
   },
 
   _findHost() {


### PR DESCRIPTION
Our fastboot builds were failing for local development.  This prevents the addon from enabling itself in the fastboot build. (Addon depends on jquery)