### PR TITLE
Focusable/Blurrable tweaks

### DIFF
--- a/addon/-private/execution_context/helpers.js
+++ b/addon/-private/execution_context/helpers.js
@@ -55,7 +55,7 @@ export function assertFocusable(element, { selector, pageObjectNode, pageObjectK
     error = 'disabled';
   } else if ($element.is('[contenteditable="false"]')) {
     error = 'contenteditable="false"';
-  } else if (!$element.is(':input, select, a[href], area[href], iframe, [contenteditable], [tabindex]')) {
+  } else if (!$element.is(':input, a[href], area[href], iframe, [contenteditable], [tabindex]')) {
     error = 'not a link, input, form element, contenteditable, iframe, or an element with tabindex';
   }
 

--- a/tests/unit/-private/properties/blurrable-test.js
+++ b/tests/unit/-private/properties/blurrable-test.js
@@ -204,7 +204,7 @@ moduleForProperty('blurrable', function(test) {
       <iframe></iframe>
       <select></select>
       <button></button>
-      <div contenteditable=true></div>
+      <div contenteditable></div>
       <div tabindex=-1></div>
     `);
 
@@ -220,19 +220,25 @@ moduleForProperty('blurrable', function(test) {
   });
 
   test('raises an error when the element is not focusable', function(assert) {
-    assert.expect(3);
+    assert.expect(4);
 
     let page = create({
       foo: {
         bar: {
           baz: blurrable('span'),
           qux: blurrable('input'),
-          quux: blurrable('button')
+          quux: blurrable('button'),
+          quuz: blurrable('[contenteditable]')
         }
       }
     });
 
-    this.adapter.createTemplate(this, page, '<span></span><input disabled=true/><button style="display: none;"></button>');
+    this.adapter.createTemplate(this, page, `
+      <span></span>
+      <input disabled=true/>
+      <button style="display: none;"></button>
+      <div contenteditable="false"></div>
+    `);
 
     this.adapter.throws(assert, function() {
       return page.foo.bar.baz();
@@ -245,5 +251,9 @@ moduleForProperty('blurrable', function(test) {
     this.adapter.throws(assert, function() {
       return page.foo.bar.quux();
     }, /page\.foo\.bar\.quux/, 'Element is not focusable because it is hidden');
+
+    this.adapter.throws(assert, function() {
+      return page.foo.bar.quuz();
+    }, /page\.foo\.bar\.quuz/, 'Element is not focusable because it is contenteditable="false"');
   });
 });

--- a/tests/unit/-private/properties/focusable-test.js
+++ b/tests/unit/-private/properties/focusable-test.js
@@ -206,7 +206,7 @@ moduleForProperty('focusable', function(test) {
       <iframe></iframe>
       <select></select>
       <button></button>
-      <div contenteditable=true></div>
+      <div contenteditable></div>
       <div tabindex=-1></div>
     `);
 
@@ -221,14 +221,15 @@ moduleForProperty('focusable', function(test) {
   });
 
   test('raises an error when the element is not focusable', function(assert) {
-    assert.expect(3);
+    assert.expect(4);
 
     let page = create({
       foo: {
         bar: {
           baz: focusable('span'),
           qux: focusable('input'),
-          quux: focusable('button')
+          quux: focusable('button'),
+          quuz: focusable('[contenteditable]')
         }
       }
     });
@@ -237,6 +238,7 @@ moduleForProperty('focusable', function(test) {
       <span></span>
       <input disabled=true/>
       <button style="display: none;"></button>
+      <div contenteditable="false"></div>
     `);
 
     this.adapter.throws(assert, function() {
@@ -250,5 +252,9 @@ moduleForProperty('focusable', function(test) {
     this.adapter.throws(assert, function() {
       return page.foo.bar.quux();
     }, /page\.foo\.bar\.quux/, 'Element is not focusable because it is hidden');
+
+    this.adapter.throws(assert, function() {
+      return page.foo.bar.quuz();
+    }, /page\.foo\.bar\.quuz/, 'Element is not focusable because it is contenteditable="false"');
   });
 });


### PR DESCRIPTION
### Purpose
- Remove unneeded check for `select` elements in `assertFocusable`. `select` elements are handled by the `:input` check.
- Add assertions for the focusability  of `contenteditable="false"` divs.