### PR TITLE
Update documentation command

### DIFF
--- a/docs.js
+++ b/docs.js
@@ -41,7 +41,7 @@ function execCmd(command) {
  * @returns {Promise} (resolves {string}) A promise that resolves with the Markdown text representation
  */
 function parseSourceFile(filePath) {
-  return execCmd('node ./node_modules/documentation/bin/documentation "' + filePath + '" --format "md" --github --shallow');
+  return execCmd('node ./node_modules/documentation/bin/documentation build "' + filePath + '" -f md --shallow');
 }
 
 /* Takes Markdown and adds yml frontmatter and a table of contents, and adds 1 to


### PR DESCRIPTION
### Purpose
We updated the `documentation` module to `v5.3.3`, and now we need to update the command that builds the docs. 

### Open Questions
- [ ] What did the `--github` argument do? It does not seem to be supported in `5.3.3`.

**Sanity Check**:
After making these updates, I was able to successfully generate the docs that we will publish for `v1.13.0`.