### PR TITLE
Remove ember-test-helpers from dependencies

### DIFF
--- a/addon/-private/compatibility.js
+++ b/addon/-private/compatibility.js
@@ -1,0 +1,12 @@
+export const wait = (function() {
+  const hasLegacyEmberTestHelpers = window.require.has('ember-test-helpers');
+  const hasLatestEmberTestHelpers = window.require.has('@ember/test-helpers');
+
+  if (!hasLegacyEmberTestHelpers && !hasLatestEmberTestHelpers) {
+    return function() {
+      throw new Error('ember-test-helpers or @ember/test-helpers must be installed');
+    }
+  }
+
+  return window.require('ember-test-helpers/wait')['default'];
+})();

--- a/addon/-private/dsl.js
+++ b/addon/-private/dsl.js
@@ -10,7 +10,7 @@ import { isPresent } from './properties/is-present';
 import { isVisible } from './properties/is-visible';
 import { text } from './properties/text';
 import { value } from './properties/value';
-import wait from 'ember-test-helpers/wait';
+import { wait } from './compatibility';
 
 const thenDescriptor = {
   isDescriptor: true,

--- a/addon/-private/execution_context/acceptance-native-events.js
+++ b/addon/-private/execution_context/acceptance-native-events.js
@@ -1,5 +1,5 @@
 import ExecutionContext from './native-events-context';
-import wait from 'ember-test-helpers/wait';
+import { wait } from '../compatibility';
 
 import {
   visit

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -92,6 +92,38 @@ module.exports = {
       }
     },
     {
+      name: 'with-ember-test-helpers',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#release'
+        },
+        resolutions: {
+          'ember': 'release'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-cli-qunit': '4.0.0'
+        }
+      }
+    },
+    {
+      name: 'with-@ember/test-helpers',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#release'
+        },
+        resolutions: {
+          'ember': 'release'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-cli-qunit': '4.3.0'
+        }
+      }
+    },
+    {
       name: 'node-tests',
       command: 'npm run nodetest',
       bower: {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "ember-cli-babel": "^6.6.0",
     "ember-cli-node-assets": "^0.2.2",
     "ember-native-dom-helpers": "^0.5.3",
-    "ember-test-helpers": "^0.6.3",
     "jquery": "^3.2.1",
     "rsvp": "^4.7.0"
   },

--- a/tests/unit/-private/compatibility-test.js
+++ b/tests/unit/-private/compatibility-test.js
@@ -1,0 +1,21 @@
+import { test, module } from 'qunit';
+import { wait } from 'ember-cli-page-object/-private/compatibility';
+
+module('Unit | compatibility | wait');
+
+// Under normal circumstances, `wait` is expected not to throw an error, since
+// the necessary Ember test helpers are included by ember-qunit & ember-mocha.
+test('does not throw', function(assert) {
+  assert.expect(0);
+  wait();
+});
+
+test('throws an error if test helpers are not available', function(assert) {
+  const originalHasFn = window.require.has;
+  window.require.has = () => false;
+  window.require.unsee('ember-cli-page-object/-private/compatibility');
+  const wait = window.require('ember-cli-page-object/-private/compatibility').wait;
+
+  assert.throws(wait);
+  window.require.has = originalHasFn;
+});


### PR DESCRIPTION
### Purpose
- Remove `ember-test-helpers` from `dependencies` and rely on the host app to supply the test helpers, either via `ember-mocha` or `ember-qunit`. This will prevent `ember-cli-page-object` from clobbering the host app's version of the helpers. 
- Addresses https://github.com/san650/ember-cli-page-object/issues/361

### Approach
- Remove `ember-test-helpers` from the list of `dependencies`
- Instead of importing `ember-test-helpers/wait`, create a new `wait` helper that throws an error if `ember-test-helpers` or `@ember-test-helpers` is not available.