### PR TITLE
deprecate page.render()

### DIFF
--- a/addon/-private/context.js
+++ b/addon/-private/context.js
@@ -1,3 +1,5 @@
+import { deprecate } from '@ember/application/deprecations';
+
 /**
  * @public
  *
@@ -17,6 +19,11 @@
  * @return {PageObject} - the page object
  */
 export function render(template) {
+  deprecate('PageObject.render() is deprecated. Please use "htmlbars-inline-precompile" instead.', false, {
+    id: 'ember-cli-page-object.page-render',
+    until: '2.0.0'
+  });
+
   if (!this.context) {
     let message = 'You must set a context on the page object before calling calling `render()`';
     let error = new Error(message);

--- a/addon/-private/context.js
+++ b/addon/-private/context.js
@@ -21,7 +21,8 @@ import { deprecate } from '@ember/application/deprecations';
 export function render(template) {
   deprecate('PageObject.render() is deprecated. Please use "htmlbars-inline-precompile" instead.', false, {
     id: 'ember-cli-page-object.page-render',
-    until: '2.0.0'
+    until: '2.0.0',
+    url: 'https://gist.github.com/san650/17174e4b7b1fd80b049a47eb456a7cdc#file-page-render-js',
   });
 
   if (!this.context) {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
+    "ember-qunit-assert-helpers": "^0.2.1",
     "ember-qunit-nice-errors": "^1.1.2",
     "ember-qunit-source-map": "1.1.0",
     "ember-resolver": "^4.0.0",

--- a/tests/integration/deprecations/page-render-test.js
+++ b/tests/integration/deprecations/page-render-test.js
@@ -1,0 +1,20 @@
+import { moduleForComponent, test } from 'ember-qunit';
+
+import hbs from 'htmlbars-inline-precompile';
+import { create } from 'ember-cli-page-object';
+
+moduleForComponent('calculating-device', 'Deprecation | page.render()', {
+  integration: true,
+
+  beforeEach() {
+    this.page = create({
+      context: this
+    });
+  }
+});
+
+test('page.render() leads to the deprecation', function(assert) {
+  this.page.render(hbs``);
+
+  assert.expectDeprecation('PageObject.render() is deprecated. Please use "htmlbars-inline-precompile" instead.')
+});


### PR DESCRIPTION
part of [1.x deprecations](https://github.com/san650/ember-cli-page-object/issues/359)

TODO:
 - [x] need to find and fix all the `page.render()` usages internally. 
I haven't found any usages.