### PR TITLE
include ember-test-helper specific configurations to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ env:
   - EMBER_TRY_SCENARIO=ember-release COVERAGE=true # Only log coverage from release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
+  - EMBER_TRY_SCENARIO=with-ember-test-helpers
+  - EMBER_TRY_SCENARIO=with-@ember/test-helpers
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
We've just added [2 new](https://github.com/san650/ember-cli-page-object/pull/366/files#diff-d20f4baf61c4397c467d6218d0ba6a04R95) ember-try build configurations. I think this should be reflected in the travis config as well