### PR TITLE
Change collection signature

### DIFF
--- a/addon/-private/properties/collection.js
+++ b/addon/-private/properties/collection.js
@@ -1,4 +1,5 @@
 import { deprecate } from '@ember/application/deprecations';
+import { warn } from '@ember/debug';
 
 import { collection as mainCollection } from './collection/main';
 import { collection as legacyCollection } from './collection/legacy';
@@ -122,6 +123,14 @@ export function collection(scopeOrDefinition, definitionOrNothing) {
     until: '2.0.0',
     url: 'https://gist.github.com/san650/17174e4b7b1fd80b049a47eb456a7cdc#file-old-collection-api-js',
   });
+
+  warn(
+    'Legacy page object collection definition is invalid. Please, make sure you include a `itemScope` selector.',
+    scopeOrDefinition.itemScope,
+    {
+      id: 'ember-cli-page-object.legacy-collection-missing-item-scope'
+    }
+  );
 
   return legacyCollection(scopeOrDefinition);
 }

--- a/addon/-private/properties/collection.js
+++ b/addon/-private/properties/collection.js
@@ -114,14 +114,40 @@ import { collection as legacyCollection } from './collection/legacy';
  * @return {Descriptor}
  */
 export function collection(definition) {
-  if ('itemScope' in definition) {
+  if (useLegacyAPI(definition)) {
     deprecate('You are currently using the legacy collection API, check the documentation to see how to upgrade to the new API.', false, {
       id: 'ember-cli-page-object.old-collection-api',
-      until: '2.0.0'
+      until: '2.0.0',
+      url: 'https://gist.github.com/san650/17174e4b7b1fd80b049a47eb456a7cdc#file-old-collection-api-js',
     });
 
     return legacyCollection(definition);
   } else {
     return mainCollection(definition);
   }
+}
+
+function useLegacyAPI(definition) {
+  // We test the use of `itemScope` attribute to guess that the users are using
+  // the legacy API.
+  //
+  // Also, there's a common mistake in page objects created in the wild that
+  // don't define the `itemScope` attribute but they do implement the `items`
+  // object.
+  //
+  //     var page = create({
+  //       foo: collection({
+  //         scope: '.foo',
+  //         item: {
+  //           text: text('p')
+  //         }
+  //       })
+  //     });
+  //
+  // Although this doesn't make any sense and doesn't work in legacy
+  // collections definitions, using the new collection API in this cases break
+  // tests suites. For that reason we use the legacy definition and print a
+  // deprecation warning.
+  return ('itemScope' in definition) ||
+    ('scope' in definition && 'item' in definition);
 }

--- a/addon/-private/properties/collection.js
+++ b/addon/-private/properties/collection.js
@@ -36,8 +36,7 @@ import { collection as legacyCollection } from './collection/legacy';
  * // </table>
  *
  * const page = PageObject.create({
- *   users: collection({
- *     scope: 'table tr',
+ *   users: collection('table tr', {
  *     firstName: text('td', { at: 0 }),
  *     lastName: text('td', { at: 1 })
  *   })
@@ -72,8 +71,7 @@ import { collection as legacyCollection } from './collection/legacy';
  * const page = PageObject.create({
  *   scope: '.admins',
  *
- *   users: collection({
- *     scope: 'table tr',
+ *   users: collection('table tr', {
  *     firstName: text('td', { at: 0 }),
  *     lastName: text('td', { at: 1 })
  *   })
@@ -100,8 +98,7 @@ import { collection as legacyCollection } from './collection/legacy';
  * const page = PageObject.create({
  *   scope: 'table',
  *
- *   users: PageObject.collection({
- *     scope: 'tr',
+ *   users: PageObject.collection('tr', {
  *     firstName: text('td', { at: 0 }),
  *     lastName: text('td', { at: 1 }),
  *   })
@@ -110,44 +107,21 @@ import { collection as legacyCollection } from './collection/legacy';
  * let john = page.users.filter((item) => item.firstName === 'John' )[0];
  * assert.equal(john.lastName, 'Doe');
  *
- * @param {Object} definition - Collection definition
+ * @param {String} scopeOrDefinition - Selector to define the items of the collection
+ * @param {Object} [definitionOrNothing] - Object with the definition of item properties
  * @return {Descriptor}
  */
-export function collection(definition) {
-  if (useLegacyAPI(definition)) {
-    deprecate('You are currently using the legacy collection API, check the documentation to see how to upgrade to the new API.', false, {
-      id: 'ember-cli-page-object.old-collection-api',
-      until: '2.0.0',
-      url: 'https://gist.github.com/san650/17174e4b7b1fd80b049a47eb456a7cdc#file-old-collection-api-js',
-    });
+export function collection(scopeOrDefinition, definitionOrNothing) {
 
-    return legacyCollection(definition);
-  } else {
-    return mainCollection(definition);
+  if (typeof scopeOrDefinition === 'string') {
+    return mainCollection(scopeOrDefinition, definitionOrNothing);
   }
-}
 
-function useLegacyAPI(definition) {
-  // We test the use of `itemScope` attribute to guess that the users are using
-  // the legacy API.
-  //
-  // Also, there's a common mistake in page objects created in the wild that
-  // don't define the `itemScope` attribute but they do implement the `items`
-  // object.
-  //
-  //     var page = create({
-  //       foo: collection({
-  //         scope: '.foo',
-  //         item: {
-  //           text: text('p')
-  //         }
-  //       })
-  //     });
-  //
-  // Although this doesn't make any sense and doesn't work in legacy
-  // collections definitions, using the new collection API in this cases break
-  // tests suites. For that reason we use the legacy definition and print a
-  // deprecation warning.
-  return ('itemScope' in definition) ||
-    ('scope' in definition && 'item' in definition);
+  deprecate('You are currently using the legacy collection API, check the documentation to see how to upgrade to the new API.', false, {
+    id: 'ember-cli-page-object.old-collection-api',
+    until: '2.0.0',
+    url: 'https://gist.github.com/san650/17174e4b7b1fd80b049a47eb456a7cdc#file-old-collection-api-js',
+  });
+
+  return legacyCollection(scopeOrDefinition);
 }

--- a/addon/-private/properties/collection/main.js
+++ b/addon/-private/properties/collection/main.js
@@ -10,15 +10,16 @@ import { count } from '../count';
 import Ceibo from 'ceibo';
 
 export class Collection {
-  constructor(definition, parent, key) {
-    this.definition = definition;
+  constructor(scope, definition, parent, key) {
+    this.scope = scope;
+    this.definition = definition || {};
     this.parent = parent;
     this.key = key;
 
     this._itemCounter = create({
-      count: count(definition.scope, {
-        resetScope: definition.resetScope,
-        testContainer: definition.testContainer
+      count: count(scope, {
+        resetScope: this.definition.resetScope,
+        testContainer: this.definition.testContainer
       })
     }, { parent });
 
@@ -33,12 +34,12 @@ export class Collection {
     let { key } = this;
 
     if (typeof this._items[index] === 'undefined') {
-      let { definition, parent } = this;
-      let scope = buildSelector({}, definition.scope, { at: index });
+      let { scope, definition, parent } = this;
+      let itemScope = buildSelector({}, scope, { at: index });
 
       let finalizedDefinition = assign({}, definition);
 
-      finalizedDefinition.scope = scope;
+      finalizedDefinition.scope = itemScope;
 
       let tree = create(finalizedDefinition, { parent });
 
@@ -105,7 +106,7 @@ if (typeof (Symbol) !== 'undefined' && Symbol.iterator) {
   }
 }
 
-export function collection(definition) {
+export function collection(scope, definition) {
   let descriptor = {
     isDescriptor: true,
 
@@ -113,7 +114,7 @@ export function collection(definition) {
       // Set the value on the descriptor so that it will be picked up and applied by Ceibo.
       // This does mutate the descriptor, but because `setup` is always called before the
       // value is assigned we are guaranteed to get a new, unique Collection instance each time.
-      descriptor.value = new Collection(definition, node, key);
+      descriptor.value = new Collection(scope, definition, node, key);
     }
   };
 

--- a/tests/integration/actions-test.js
+++ b/tests/integration/actions-test.js
@@ -36,17 +36,12 @@ const button = function(scope) {
 };
 
 const page = PageObject.create({
-  numbers: collection({
-    scope: '.numbers',
-    itemScope: 'button',
-
-    item: {
-      click: clickable(),
-      text: text()
-    },
-
-    clickOn: clickOnText()
+  numbers: collection('.numbers button', {
+    click: clickable(),
+    text: text()
   }),
+
+  clickOnNumber: clickOnText('.numbers'),
 
   operators: {
     scope: '.operators',
@@ -112,22 +107,22 @@ test('Actions work when defined inside collections', function(assert) {
   this.render(template);
 
   page
-    .numbers(0)
+    .numbers
+    .objectAt(0)
     .click();
 
   assert.equal(page.screen.text, '1');
 });
 
-test('Chaining of actions inside a collection works', function(assert) {
+test('Chaining of custom actions works', function(assert) {
   let template = createCalculatorTemplate();
 
   this.render(template);
 
   page
-    .numbers()
-    .clickOn('1')
-    .clickOn('2')
-    .clickOn('3');
+    .clickOnNumber('1')
+    .clickOnNumber('2')
+    .clickOnNumber('3');
 
   assert.equal(page.screen.text, '123');
 });

--- a/tests/integration/deprecations/comma-separated-selector-test.js
+++ b/tests/integration/deprecations/comma-separated-selector-test.js
@@ -7,7 +7,7 @@ import PageObject from 'dummy/tests/page-object';
 // only in the `moduleForComponent` test helper. Unfortunatelly it requires
 // some component name to be passed as a first argument. That's why we pass
 // a `calculating-device` here despite the fact that we don't actually need it.
-moduleForComponent('calculating-device', 'Integration | comma separated selectors', {
+moduleForComponent('calculating-device', 'Deprecation | comma separated selectors', {
   integration: true
 });
 

--- a/tests/integration/deprecations/legacy-collection-test.js
+++ b/tests/integration/deprecations/legacy-collection-test.js
@@ -6,7 +6,7 @@ moduleForComponent('calculating-device', 'Deprecation | legacy collection', {
   integration: true
 });
 
-test('usage of itemScope in definition leads to the deprecation', function(assert) {
+test('shows deprecation warning when first parameter is not a string', function(assert) {
   let page = create({
     foo: collection({
       itemScope: 'li'
@@ -18,25 +18,9 @@ test('usage of itemScope in definition leads to the deprecation', function(asser
   assert.expectDeprecation('You are currently using the legacy collection API, check the documentation to see how to upgrade to the new API.');
 });
 
-test('usage of scope plus item leads to the deprecation', function(assert) {
+test("doesn't show a deprecation warning when first parameter is a string", function(assert) {
   let page = create({
-    foo: collection({
-      scope: 'foo',
-      item: {}
-    })
-  });
-
-  page.foo();
-
-  assert.expectDeprecation('You are currently using the legacy collection API, check the documentation to see how to upgrade to the new API.');
-});
-
-test('usage of scope without item does not lead to the deprecation', function(assert) {
-  let page = create({
-    foo: collection({
-      scope: 'foo',
-      bar: {}
-    })
+    foo: collection('foo')
   });
 
   page.foo;

--- a/tests/integration/deprecations/legacy-collection-test.js
+++ b/tests/integration/deprecations/legacy-collection-test.js
@@ -27,3 +27,12 @@ test("doesn't show a deprecation warning when first parameter is a string", func
 
   assert.expectNoDeprecation();
 });
+
+test('shows a warning on invalid legacy collection definitions', function(assert) {
+  assert.expectWarning(function() {
+    create({
+      foo: collection({
+      })
+    });
+  }, 'Legacy page object collection definition is invalid. Please, make sure you include a `itemScope` selector.');
+});

--- a/tests/integration/deprecations/legacy-collection-test.js
+++ b/tests/integration/deprecations/legacy-collection-test.js
@@ -1,0 +1,45 @@
+import { moduleForComponent, test } from 'ember-qunit';
+
+import { create, collection } from 'ember-cli-page-object';
+
+moduleForComponent('calculating-device', 'Deprecation | legacy collection', {
+  integration: true
+});
+
+test('usage of itemScope in definition leads to the deprecation', function(assert) {
+  let page = create({
+    foo: collection({
+      itemScope: 'li'
+    })
+  });
+
+  page.foo();
+
+  assert.expectDeprecation('You are currently using the legacy collection API, check the documentation to see how to upgrade to the new API.');
+});
+
+test('usage of scope plus item leads to the deprecation', function(assert) {
+  let page = create({
+    foo: collection({
+      scope: 'foo',
+      item: {}
+    })
+  });
+
+  page.foo();
+
+  assert.expectDeprecation('You are currently using the legacy collection API, check the documentation to see how to upgrade to the new API.');
+});
+
+test('usage of scope without item does not lead to the deprecation', function(assert) {
+  let page = create({
+    foo: collection({
+      scope: 'foo',
+      bar: {}
+    })
+  });
+
+  page.foo;
+
+  assert.expectNoDeprecation();
+});

--- a/tests/unit/-private/properties/collection-test.js
+++ b/tests/unit/-private/properties/collection-test.js
@@ -5,9 +5,7 @@ import withIteratorSymbolDefined from '../../../helpers/with-iterator-symbol-def
 moduleForProperty('collection', function(test) {
   test('generates a length property', function(assert) {
     let page = create({
-      foo: collection({
-        scope: 'span'
-      })
+      foo: collection('span')
     });
 
     this.adapter.createTemplate(this, page, `
@@ -20,9 +18,7 @@ moduleForProperty('collection', function(test) {
 
   test('Works with zero length', function(assert) {
     let page = create({
-      foo: collection({
-        scope: 'span'
-      })
+      foo: collection('span')
     });
 
     this.adapter.createTemplate(this, page, `
@@ -35,8 +31,7 @@ moduleForProperty('collection', function(test) {
 
   test('returns an item', function(assert) {
     let page = create({
-      foo: collection({
-        scope: 'span',
+      foo: collection('span', {
         text: text()
       })
     });
@@ -52,8 +47,7 @@ moduleForProperty('collection', function(test) {
 
   test('collects an array of items', function(assert) {
     let page = create({
-      foo: collection({
-        scope: 'span',
+      foo: collection('span', {
         text: text()
       })
     });
@@ -76,8 +70,7 @@ moduleForProperty('collection', function(test) {
 
   test('produces an iterator for items', function(assert) {
     let page = create({
-      foo: collection({
-        scope: 'span',
+      foo: collection('span', {
         text: text()
       })
     });
@@ -101,8 +94,7 @@ moduleForProperty('collection', function(test) {
     let page = create({
       scope: '.scope',
 
-      foo: collection({
-        scope: 'span',
+      foo: collection('span', {
         text: text()
       })
     });
@@ -123,8 +115,7 @@ moduleForProperty('collection', function(test) {
     let page = create({
       scope: '.scope',
 
-      foo: collection({
-        scope: 'li',
+      foo: collection('li', {
         bar: {
           scope: '.another-scope',
 
@@ -163,9 +154,8 @@ moduleForProperty('collection', function(test) {
     let page = create({
       scope: 'div',
 
-      foo: collection({
+      foo: collection('span', {
         resetScope: true,
-        scope: 'span',
         text: text()
       })
     });
@@ -184,10 +174,8 @@ moduleForProperty('collection', function(test) {
     let page = create({
       scope: '.scope',
 
-      foo: collection({
-        scope: 'span',
-        bar: collection({
-          scope: 'em',
+      foo: collection('span', {
+        bar: collection('em', {
           text: text()
         })
       })
@@ -204,7 +192,7 @@ moduleForProperty('collection', function(test) {
   test("throws an error when the item's element doesn't exist", function(assert) {
     let page = create({
       foo: {
-        bar: collection({
+        bar: collection('span', {
           baz: {
             qux: text('span')
           }
@@ -220,8 +208,7 @@ moduleForProperty('collection', function(test) {
   test('iterates over scoped items with a for loop', function(assert) {
     let page = create({
       scope: 'div',
-      foo: collection({
-        scope: 'span',
+      foo: collection('span', {
         text: text()
       })
     });
@@ -246,8 +233,7 @@ moduleForProperty('collection', function(test) {
   test('iterates over scoped items with a for of loop', function(assert) {
     let page = create({
       scope: 'div',
-      foo: collection({
-        scope: 'span',
+      foo: collection('span', {
         text: text()
       })
     });
@@ -274,8 +260,7 @@ moduleForProperty('collection', function(test) {
     let page = create({
       scope: 'div',
 
-      foo: collection({
-        scope: 'span',
+      foo: collection('span', {
         text: text()
       })
     });
@@ -300,7 +285,6 @@ moduleForProperty('collection', function(test) {
     let prop = text('.baz');
 
     let expected = {
-      scope: '.another-scope',
       bar: prop,
       baz: {
         qux: prop
@@ -308,7 +292,6 @@ moduleForProperty('collection', function(test) {
     };
 
     let actual = {
-      scope: '.another-scope',
       bar: prop,
       baz: {
         qux: prop
@@ -316,7 +299,7 @@ moduleForProperty('collection', function(test) {
     };
 
     let page = create({
-      foo: collection(actual)
+      foo: collection('.another-scope', actual)
     });
 
     this.adapter.createTemplate(this, page);
@@ -331,9 +314,8 @@ moduleForProperty('collection', function(test) {
     let page;
 
     page = create({
-      foo: collection({
+      foo: collection('span', {
         testContainer: expectedContext,
-        scope: 'span'
       })
     });
 
@@ -350,8 +332,7 @@ moduleForProperty('collection', function(test) {
 
   test('objectAt returns an item', function(assert) {
     let page = create({
-      foo: collection({
-        scope: 'span',
+      foo: collection('span', {
         text: text()
       })
     });
@@ -367,8 +348,7 @@ moduleForProperty('collection', function(test) {
 
   test('forEach works correctly', function(assert) {
     let page = create({
-      foo: collection({
-        scope: 'span',
+      foo: collection('span', {
         text: text()
       })
     });
@@ -388,8 +368,7 @@ moduleForProperty('collection', function(test) {
 
   test('map works correctly', function(assert) {
     let page = create({
-      foo: collection({
-        scope: 'span',
+      foo: collection('span', {
         text: text()
       })
     });
@@ -404,8 +383,7 @@ moduleForProperty('collection', function(test) {
 
   test('mapBy works correctly', function(assert) {
     let page = create({
-      foo: collection({
-        scope: 'span',
+      foo: collection('span', {
         text: text()
       })
     });
@@ -420,8 +398,7 @@ moduleForProperty('collection', function(test) {
 
   test('filter works correctly', function(assert) {
     let page = create({
-      foo: collection({
-        scope: 'span',
+      foo: collection('span', {
         isSpecial: hasClass('special'),
         text: text()
       })
@@ -438,8 +415,7 @@ moduleForProperty('collection', function(test) {
 
   test('filterBy works correctly', function(assert) {
     let page = create({
-      foo: collection({
-        scope: 'span',
+      foo: collection('span', {
         isSpecial: hasClass('special'),
         text: text()
       })


### PR DESCRIPTION
This PR changes the new collection's function signature:

before

```js
var page = create({
  users: collection({
    scope: 'table tr'
  })
});
```

after

```js
var page = create({
  users1: collection('table tr'),

  users2: collection('table tr', {
    text: text()
  })
});
```

The main reason for this is that we don't have an easy way to distinguish uses of the legacy collection API from the new collection API.

This PR also renders a warning for missing `itemScope` property in legacy collection API.