### PR TITLE
Fix link to Page Objects article by Selenium

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The pattern was first introduced by the Selenium
 
 You can find more information about this design pattern here:
 
-* [Page Objects - Selenium wiki](https://seleniumhq.github.io/docs/best.html#page_object_models)
+* [Page Objects - Selenium wiki](https://github.com/SeleniumHQ/selenium/wiki/PageObjects)
 * [PageObject - Martin Fowler](http://martinfowler.com/bliki/PageObject.html)
 
 ## Community


### PR DESCRIPTION
The current link is broken. There is an alternative link to official Selenium site https://www.seleniumhq.org/docs/06_test_design_considerations.jsp#page-object-design-pattern, but I like github wiki version more