### PR TITLE
Prepare docs 1.14

### DIFF
--- a/addon/-private/properties/attribute.js
+++ b/addon/-private/properties/attribute.js
@@ -9,9 +9,11 @@ import { getExecutionContext } from '../execution_context';
  *
  * @example
  * // <input placeholder="a value">
+ * 
+ * import { create, attribute } from 'ember-cli-page-object';
  *
- * const page = PageObject.create({
- *   inputPlaceholder: PageObject.attribute('placeholder', 'input')
+ * const page = create({
+ *   inputPlaceholder: attribute('placeholder', 'input')
  * });
  *
  * assert.equal(page.inputPlaceholder, 'a value');
@@ -21,8 +23,10 @@ import { getExecutionContext } from '../execution_context';
  * // <input placeholder="a value">
  * // <input placeholder="other value">
  *
- * const page = PageObject.create({
- *   inputPlaceholders: PageObject.attribute('placeholder', ':input', { multiple: true })
+ * import { create, attribute } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   inputPlaceholders: attribute('placeholder', ':input', { multiple: true })
  * });
  *
  * assert.deepEqual(page.inputPlaceholders, ['a value', 'other value']);
@@ -33,8 +37,10 @@ import { getExecutionContext } from '../execution_context';
  * // <div class="scope"><input placeholder="a value"></div>
  * // <div><input></div>
  *
- * const page = PageObject.create({
- *   inputPlaceholder: PageObject.attribute('placeholder', ':input', { scope: '.scope' })
+ * import { create, attribute } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   inputPlaceholder: attribute('placeholder', ':input', { scope: '.scope' })
  * });
  *
  * assert.equal(page.inputPlaceholder, 'a value');
@@ -45,9 +51,11 @@ import { getExecutionContext } from '../execution_context';
  * // <div class="scope"><input placeholder="a value"></div>
  * // <div><input></div>
  *
- * const page = PageObject.create({
+ * import { create, attribute } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   scope: 'scope',
- *   inputPlaceholder: PageObject.attribute('placeholder', ':input')
+ *   inputPlaceholder: attribute('placeholder', ':input')
  * });
  *
  * assert.equal(page.inputPlaceholder, 'a value');

--- a/addon/-private/properties/blurrable.js
+++ b/addon/-private/properties/blurrable.js
@@ -10,7 +10,9 @@ import { getExecutionContext } from '../execution_context';
  * // <input class="name">
  * // <input class="email">
  *
- * const page = PageObject.create({
+ * import { create, blurrable } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   blur: blurrable('.name')
  * });
  *
@@ -24,7 +26,9 @@ import { getExecutionContext } from '../execution_context';
  * // </div>
  * // <input class="email">
  *
- * const page = PageObject.create({
+ * import { create, blurrable } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   blur: blurrable('.name', { scope: '.scope' })
  * });
  *
@@ -38,7 +42,9 @@ import { getExecutionContext } from '../execution_context';
  * // </div>
  * // <input class="email">
  *
- * const page = PageObject.create({
+ * import { create, blurrable } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   scope: '.scope',
  *   blur: blurrable('.name')
  * });

--- a/addon/-private/properties/click-on-text.js
+++ b/addon/-private/properties/click-on-text.js
@@ -15,9 +15,11 @@ import { buildSelector } from './click-on-text/helpers';
  * //  <button>Ipsum</button>
  * // </fieldset>
  *
- * const page = PageObject.create({
- *   clickOnFieldset: PageObject.clickOnText('fieldset'),
- *   clickOnButton: PageObject.clickOnText('button')
+ * import { create, clickOnText } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   clickOnFieldset: clickOnText('fieldset'),
+ *   clickOnButton: clickOnText('button')
  * });
  *
  * // queries the DOM with selector 'fieldset :contains("Lorem"):last'
@@ -35,9 +37,11 @@ import { buildSelector } from './click-on-text/helpers';
  * //   </fieldset>
  * // </div>
  *
- * const page = PageObject.create({
- *   clickOnFieldset: PageObject.clickOnText('fieldset', { scope: '.scope' }),
- *   clickOnButton: PageObject.clickOnText('button', { scope: '.scope' })
+ * import { create, clickOnText } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   clickOnFieldset: clickOnText('fieldset', { scope: '.scope' }),
+ *   clickOnButton: clickOnText('button', { scope: '.scope' })
  * });
  *
  * // queries the DOM with selector '.scope fieldset :contains("Lorem"):last'
@@ -55,10 +59,12 @@ import { buildSelector } from './click-on-text/helpers';
  * //   </fieldset>
  * // </div>
  *
- * const page = PageObject.create({
+ * import { create, clickOnText } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   scope: '.scope',
- *   clickOnFieldset: PageObject.clickOnText('fieldset'),
- *   clickOnButton: PageObject.clickOnText('button')
+ *   clickOnFieldset: clickOnText('fieldset'),
+ *   clickOnButton: clickOnText('button')
  * });
  *
  * // queries the DOM with selector '.scope fieldset :contains("Lorem"):last'

--- a/addon/-private/properties/clickable.js
+++ b/addon/-private/properties/clickable.js
@@ -9,7 +9,9 @@ import { getExecutionContext } from '../execution_context';
  * // <button class="continue">Continue<button>
  * // <button>Cancel</button>
  *
- * const page = PageObject.create({
+ * import { create, clickable } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   continue: clickable('button.continue')
  * });
  *
@@ -23,7 +25,9 @@ import { getExecutionContext } from '../execution_context';
  * // </div>
  * // <button>Cancel</button>
  *
- * const page = PageObject.create({
+ * import { create, clickable } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   continue: clickable('button.continue', { scope: '.scope' })
  * });
  *
@@ -37,7 +41,9 @@ import { getExecutionContext } from '../execution_context';
  * // </div>
  * // <button>Cancel</button>
  *
- * const page = PageObject.create({
+ * import { create, clickable } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   scope: '.scope',
  *   continue: clickable('button.continue')
  * });

--- a/addon/-private/properties/collection.js
+++ b/addon/-private/properties/collection.js
@@ -5,18 +5,13 @@ import { collection as mainCollection } from './collection/main';
 import { collection as legacyCollection } from './collection/legacy';
 
 /**
- * @public
- *
- * <div class="alert alert-warning" role="alert">
+ *  <div class="alert alert-warning" role="alert">
  *   <strong>Note:</strong> v1.14.x introduces the new collection API.
- *   You can see the legacy collection API in the [v1.13.x docs](/docs/v1.13.x/api/collection).
+ *   You can see the legacy collection API in the <a href="/docs/v1.13.x/api/collection">v1.13.x docs</a>
  * </div>
  *
  * Creates a enumerable that represents a collection of items. The collection is zero-indexed
  * and has the following public methods and properties:
- *
- * IMPORTANT: You can use Array accessors only on browsers that support Proxy.
- *            See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#Browser_compatibility
  *
  * - `length` - The number of items in the collection.
  * - `objectAt()` - Returns the page for the item at the specified index.
@@ -31,7 +26,6 @@ import { collection as legacyCollection } from './collection/legacy';
  * @example
  *
  * // <table>
- * //   <caption>List of users</caption>
  * //   <tbody>
  * //     <tr>
  * //       <td>Mary<td>
@@ -45,7 +39,7 @@ import { collection as legacyCollection } from './collection/legacy';
  * // </table>
  *
  * import { create, collection, text } from 'ember-cli-page-object';
- * 
+ *
  * const page = create({
  *   users: collection('table tr', {
  *     firstName: text('td', { at: 0 }),
@@ -80,7 +74,7 @@ import { collection as legacyCollection } from './collection/legacy';
  * // </div>
  *
  * import { create, collection, text } from 'ember-cli-page-object';
- * 
+ *
  * const page = create({
  *   scope: '.admins',
  *
@@ -109,7 +103,7 @@ import { collection as legacyCollection } from './collection/legacy';
  * // </table>
  *
  * import { create, collection, text } from 'ember-cli-page-object';
- * 
+ *
  * const page = create({
  *   scope: 'table',
  *
@@ -122,7 +116,8 @@ import { collection as legacyCollection } from './collection/legacy';
  * let john = page.users.filter((item) => item.firstName === 'John' )[0];
  * assert.equal(john.lastName, 'Doe');
  *
- * @example if the browser you run tests supports Proxy, you can use array accessors to access elements by index
+ * @example
+ * <caption>If the browser you run tests [supports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#Browser_compatibility) Proxy, you can use array accessors to access elements by index</caption>
  *
  * // <table>
  * //   <tr>
@@ -134,7 +129,7 @@ import { collection as legacyCollection } from './collection/legacy';
  * // </table>
  *
  * import { create, collection } from 'ember-cli-page-object';
- * 
+ *
  * const page = create({
  *   users: collection('tr')
  * });

--- a/addon/-private/properties/collection.js
+++ b/addon/-private/properties/collection.js
@@ -7,6 +7,11 @@ import { collection as legacyCollection } from './collection/legacy';
 /**
  * @public
  *
+ * <div class="alert alert-warning" role="alert">
+ *   <strong>Note:</strong> v1.14.x introduces the new collection API.
+ *   You can see the legacy collection API in the [v1.13.x docs](/docs/v1.13.x/api/collection).
+ * </div>
+ *
  * Creates a enumerable that represents a collection of items. The collection is zero-indexed
  * and has the following public methods and properties:
  *

--- a/addon/-private/properties/collection.js
+++ b/addon/-private/properties/collection.js
@@ -39,7 +39,9 @@ import { collection as legacyCollection } from './collection/legacy';
  * //   </tbody>
  * // </table>
  *
- * const page = PageObject.create({
+ * import { create, collection, text } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   users: collection('table tr', {
  *     firstName: text('td', { at: 0 }),
  *     lastName: text('td', { at: 1 })
@@ -72,7 +74,9 @@ import { collection as legacyCollection } from './collection/legacy';
  * //   </table>
  * // </div>
  *
- * const page = PageObject.create({
+ * import { create, collection, text } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   scope: '.admins',
  *
  *   users: collection('table tr', {
@@ -99,10 +103,12 @@ import { collection as legacyCollection } from './collection/legacy';
  * //   </tbody>
  * // </table>
  *
- * const page = PageObject.create({
+ * import { create, collection, text } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   scope: 'table',
  *
- *   users: PageObject.collection('tr', {
+ *   users: collection('tr', {
  *     firstName: text('td', { at: 0 }),
  *     lastName: text('td', { at: 1 }),
  *   })
@@ -122,8 +128,10 @@ import { collection as legacyCollection } from './collection/legacy';
  * //   </tr>
  * // </table>
  *
- * const page = PageObject.create({
- *   users: PageObject.collection('tr')
+ * import { create, collection } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   users: collection('tr')
  * });
  *
  * // This only works on browsers that support `Proxy`

--- a/addon/-private/properties/contains.js
+++ b/addon/-private/properties/contains.js
@@ -8,8 +8,10 @@ import { getExecutionContext } from '../execution_context';
  *
  * // Lorem <span>ipsum</span>
  *
- * const page = PageObject.create({
- *   spanContains: PageObject.contains('span')
+ * import { create, contains } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   spanContains: contains('span')
  * });
  *
  * assert.ok(page.spanContains('ipsum'));
@@ -32,8 +34,10 @@ import { getExecutionContext } from '../execution_context';
  * // <span>super text</span>
  * // <span>regular text</span>
  *
- * const page = PageObject.create({
- *   spansContain: PageObject.contains('span', { multiple: true })
+ * import { create, contains } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   spansContain: contains('span', { multiple: true })
  * });
  *
  * // all spans contain 'text'
@@ -45,8 +49,10 @@ import { getExecutionContext } from '../execution_context';
  * // <div class="scope"><span>ipsum</span></div>
  * // <div><span>dolor</span></div>
  *
- * const page = PageObject.create({
- *   spanContains: PageObject.contains('span', { scope: '.scope' })
+ * import { create, contains } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   spanContains: contains('span', { scope: '.scope' })
  * });
  *
  * assert.notOk(page.spanContains('lorem'));
@@ -58,10 +64,12 @@ import { getExecutionContext } from '../execution_context';
  * // <div class="scope"><span>ipsum</span></div>
  * // <div><span>dolor</span></div>
  *
- * const page = PageObject.create({
+ * import { create, contains } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   scope: '.scope',
 
- *   spanContains: PageObject.contains('span')
+ *   spanContains: contains('span')
  * });
  *
  * assert.notOk(page.spanContains('lorem'));

--- a/addon/-private/properties/count.js
+++ b/addon/-private/properties/count.js
@@ -11,8 +11,10 @@ import { getExecutionContext } from '../execution_context';
  * // <span>1</span>
  * // <span>2</span>
  *
- * const page = PageObject.create({
- *   spanCount: PageObject.count('span')
+ * import { create, count } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   spanCount: count('span')
  * });
  *
  * assert.equal(page.spanCount, 2);
@@ -21,8 +23,10 @@ import { getExecutionContext } from '../execution_context';
  *
  * // <div>Text</div>
  *
- * const page = PageObject.create({
- *   spanCount: PageObject.count('span')
+ * import { create, count } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   spanCount: count('span')
  * });
  *
  * assert.equal(page.spanCount, 0);
@@ -32,8 +36,10 @@ import { getExecutionContext } from '../execution_context';
  * // <div><span></span></div>
  * // <div class="scope"><span></span><span></span></div>
  *
- * const page = PageObject.create({
- *   spanCount: PageObject.count('span', { scope: '.scope' })
+ * import { create, count } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   spanCount: count('span', { scope: '.scope' })
  * });
  *
  * assert.equal(page.spanCount, 2)
@@ -43,9 +49,11 @@ import { getExecutionContext } from '../execution_context';
  * // <div><span></span></div>
  * // <div class="scope"><span></span><span></span></div>
  *
- * const page = PageObject.create({
+ * import { create, count } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   scope: '.scope',
- *   spanCount: PageObject.count('span')
+ *   spanCount: count('span')
  * });
  *
  * assert.equal(page.spanCount, 2)
@@ -55,9 +63,11 @@ import { getExecutionContext } from '../execution_context';
  * // <div><span></span></div>
  * // <div class="scope"><span></span><span></span></div>
  *
- * const page = PageObject.create({
+ * import { create, count } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   scope: '.scope',
- *   spanCount: PageObject.count('span', { resetScope: true })
+ *   spanCount: count('span', { resetScope: true })
  * });
  *
  * assert.equal(page.spanCount, 1);

--- a/addon/-private/properties/fillable.js
+++ b/addon/-private/properties/fillable.js
@@ -28,8 +28,10 @@ import { getExecutionContext } from '../execution_context';
  *
  * // <input value="">
  *
- * const page = PageObject.create({
- *   fillIn: PageObject.fillable('input')
+ * import { create, fillable } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   fillIn: fillable('input')
  * });
  *
  * // result: <input value="John Doe">
@@ -44,8 +46,10 @@ import { getExecutionContext } from '../execution_context';
  * //   <input value= "">
  * // </div>
  *
- * const page = PageObject.create({
- *   fillInName: PageObject.fillable('input', { scope: '.name' })
+ * import { create, fillable } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   fillInName: fillable('input', { scope: '.name' })
  * });
  *
  * page.fillInName('John Doe');
@@ -64,9 +68,11 @@ import { getExecutionContext } from '../execution_context';
  * //   <input value= "">
  * // </div>
  *
- * const page = PageObject.create({
+ * import { create, fillable } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   scope: 'name',
- *   fillInName: PageObject.fillable('input')
+ *   fillInName: fillable('input')
  * });
  *
  * page.fillInName('John Doe');

--- a/addon/-private/properties/focusable.js
+++ b/addon/-private/properties/focusable.js
@@ -10,7 +10,9 @@ import { getExecutionContext } from '../execution_context';
  * // <input class="name">
  * // <input class="email">
  *
- * const page = PageObject.create({
+ * import { create, focusable } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   focus: focusable('.name')
  * });
  *
@@ -24,7 +26,9 @@ import { getExecutionContext } from '../execution_context';
  * // </div>
  * // <input class="email">
  *
- * const page = PageObject.create({
+ * import { create, focusable } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   focus: focusable('.name', { scope: '.scope' })
  * });
  *
@@ -38,7 +42,9 @@ import { getExecutionContext } from '../execution_context';
  * // </div>
  * // <input class="email">
  *
- * const page = PageObject.create({
+ * import { create, focusable } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   scope: '.scope',
  *   focus: focusable('.name')
  * });

--- a/addon/-private/properties/getter.js
+++ b/addon/-private/properties/getter.js
@@ -12,7 +12,7 @@ const NOT_A_FUNCTION_ERROR = 'Argument passed to `getter` must be a function.';
  * // <input type="text">
  * // <button disabled>Submit</button>
  *
- * import { create } from 'ember-cli-page-object';
+ * import { create, value, property } from 'ember-cli-page-object';
  * import { getter } from 'ember-cli-page-object/macros';
  *
  * const page = create({

--- a/addon/-private/properties/has-class.js
+++ b/addon/-private/properties/has-class.js
@@ -8,8 +8,10 @@ import { getExecutionContext } from '../execution_context';
  *
  * // <em class="lorem"></em><span class="success">Message!</span>
  *
- * const page = PageObject.create({
- *   messageIsSuccess: PageObject.hasClass('success', 'span')
+ * import { create, hasClass } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   messageIsSuccess: hasClass('success', 'span')
  * });
  *
  * assert.ok(page.messageIsSuccess);
@@ -19,8 +21,10 @@ import { getExecutionContext } from '../execution_context';
  * // <span class="success"></span>
  * // <span class="error"></span>
  *
- * const page = PageObject.create({
- *   messagesAreSuccessful: PageObject.hasClass('success', 'span', { multiple: true })
+ * import { create, hasClass } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   messagesAreSuccessful: hasClass('success', 'span', { multiple: true })
  * });
  *
  * assert.notOk(page.messagesAreSuccessful);
@@ -30,8 +34,10 @@ import { getExecutionContext } from '../execution_context';
  * // <span class="success"></span>
  * // <span class="success"></span>
  *
- * const page = PageObject.create({
- *   messagesAreSuccessful: PageObject.hasClass('success', 'span', { multiple: true })
+ * import { create, hasClass } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   messagesAreSuccessful: hasClass('success', 'span', { multiple: true })
  * });
  *
  * assert.ok(page.messagesAreSuccessful);
@@ -45,8 +51,10 @@ import { getExecutionContext } from '../execution_context';
  * //   <span class="ipsum"></span>
  * // </div>
  *
- * const page = PageObject.create({
- *   spanHasClass: PageObject.hasClass('ipsum', 'span', { scope: '.scope' })
+ * import { create, hasClass } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   spanHasClass: hasClass('ipsum', 'span', { scope: '.scope' })
  * });
  *
  * assert.ok(page.spanHasClass);
@@ -60,9 +68,11 @@ import { getExecutionContext } from '../execution_context';
  * //   <span class="ipsum"></span>
  * // </div>
  *
- * const page = PageObject.create({
+ * import { create, hasClass } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   scope: '.scope',
- *   spanHasClass: PageObject.hasClass('ipsum', 'span')
+ *   spanHasClass: hasClass('ipsum', 'span')
  * });
  *
  * assert.ok(page.spanHasClass);

--- a/addon/-private/properties/is-hidden.js
+++ b/addon/-private/properties/is-hidden.js
@@ -8,8 +8,10 @@ import { getExecutionContext } from '../execution_context';
  *
  * // Lorem <span style="display:none">ipsum</span>
  *
- * const page = PageObject.create({
- *   spanIsHidden: PageObject.isHidden('span')
+ * import { create, isHidden } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   spanIsHidden: isHidden('span')
  * });
  *
  * assert.ok(page.spanIsHidden);
@@ -19,8 +21,10 @@ import { getExecutionContext } from '../execution_context';
  * // <span>ipsum</span>
  * // <span style="display:none">dolor</span>
  *
+ * import { create, isHidden } from 'ember-cli-page-object';
+ * 
  * const page = create({
- *   spansAreHidden: PageObject.isHidden('span', { multiple: true })
+ *   spansAreHidden: isHidden('span', { multiple: true })
  * });
  *
  * // not all spans are hidden
@@ -31,8 +35,10 @@ import { getExecutionContext } from '../execution_context';
  * // <span style="display:none">dolor</span>
  * // <span style="display:none">dolor</span>
  *
+ * import { create, isHidden } from 'ember-cli-page-object';
+ * 
  * const page = create({
- *   spansAreHidden: PageObject.isHidden('span', { multiple: true })
+ *   spansAreHidden: isHidden('span', { multiple: true })
  * });
  *
  * // all spans are hidden
@@ -42,8 +48,10 @@ import { getExecutionContext } from '../execution_context';
  *
  * // Lorem <strong>ipsum</strong>
  *
- * const page = PageObject.create({
- *   spanIsHidden: PageObject.isHidden('span')
+ * import { create, isHidden } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   spanIsHidden: isHidden('span')
  * });
  *
  * // returns true when element doesn't exist in DOM
@@ -55,8 +63,10 @@ import { getExecutionContext } from '../execution_context';
  * // <div class="scope"><span style="display:none">ipsum</span></div>
  * // <div><span>dolor</span></div>
  *
- * const page = PageObject.create({
- *   scopedSpanIsHidden: PageObject.isHidden('span', { scope: '.scope' })
+ * import { create, isHidden } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   scopedSpanIsHidden: isHidden('span', { scope: '.scope' })
  * });
  *
  * assert.ok(page.scopedSpanIsHidden);
@@ -67,9 +77,11 @@ import { getExecutionContext } from '../execution_context';
  * // <div class="scope"><span style="display:none">ipsum</span></div>
  * // <div><span>dolor</span></div>
  *
- * const page = PageObject.create({
+ * import { create, isHidden } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   scope: '.scope',
- *   scopedSpanIsHidden: PageObject.isHidden('span')
+ *   scopedSpanIsHidden: isHidden('span')
  * });
  *
  * assert.ok(page.scopedSpanIsHidden);

--- a/addon/-private/properties/is-present.js
+++ b/addon/-private/properties/is-present.js
@@ -16,8 +16,10 @@ import { findElement } from 'ember-cli-page-object';
  *
  * // Lorem <span>ipsum</span>
  *
- * const page = PageObject.create({
- *   spanIsPresent: PageObject.isPresent('span')
+ * import { create, isPresent } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   spanIsPresent: isPresent('span')
  * });
  *
  * assert.ok(page.spanIsPresent);
@@ -27,8 +29,10 @@ import { findElement } from 'ember-cli-page-object';
  * // <span>ipsum</span>
  * // <span style="display:none">dolor</span>
  *
- * const page = PageObject.create({
- *   spanIsPresent: PageObject.isPresent('span', { multiple: true })
+ * import { create, isPresent } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   spanIsPresent: isPresent('span', { multiple: true })
  * });
  *
  * assert.ok(page.spanIsPresent);
@@ -39,8 +43,10 @@ import { findElement } from 'ember-cli-page-object';
  * //   <meta name='robots' content='noindex'>
  * // </head>
  *
- * const page = PageObject.create({
- *   notIndexed: PageObject.isPresent(`meta[name='robots'][content='noindex']`, {
+ * import { create, isPresent } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   notIndexed: isPresent(`meta[name='robots'][content='noindex']`, {
  *     testContainer: 'head'
  *   })
  * });
@@ -51,8 +57,10 @@ import { findElement } from 'ember-cli-page-object';
  *
  * // Lorem <strong>ipsum</strong>
  *
- * const page = PageObject.create({
- *   spanIsPresent: PageObject.isPresent('span')
+ * import { create, isPresent } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   spanIsPresent: isPresent('span')
  * });
  *
  * // returns false when element doesn't exist in DOM

--- a/addon/-private/properties/is-visible.js
+++ b/addon/-private/properties/is-visible.js
@@ -8,8 +8,10 @@ import { getExecutionContext } from '../execution_context';
  *
  * // Lorem <span>ipsum</span>
  *
- * const page = PageObject.create({
- *   spanIsVisible: PageObject.isVisible('span')
+ * import { create, isVisible } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   spanIsVisible: isVisible('span')
  * });
  *
  * assert.ok(page.spanIsVisible);
@@ -19,8 +21,10 @@ import { getExecutionContext } from '../execution_context';
  * // <span>ipsum</span>
  * // <span style="display:none">dolor</span>
  *
- * const page = PageObject.create({
- *   spansAreVisible: PageObject.isVisible('span', { multiple: true })
+ * import { create, isVisible } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   spansAreVisible: isVisible('span', { multiple: true })
  * });
  *
  * // not all spans are visible
@@ -31,8 +35,10 @@ import { getExecutionContext } from '../execution_context';
  * // <span>ipsum</span>
  * // <span>dolor</span>
  *
- * const page = PageObject.create({
- *   spansAreVisible: PageObject.isVisible('span', { multiple: true })
+ * import { create, isVisible } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   spansAreVisible: isVisible('span', { multiple: true })
  * });
  *
  * // all spans are visible
@@ -42,8 +48,10 @@ import { getExecutionContext } from '../execution_context';
  *
  * // Lorem <strong>ipsum</strong>
  *
- * const page = PageObject.create({
- *   spanIsVisible: PageObject.isVisible('span')
+ * import { create, isVisible } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   spanIsVisible: isVisible('span')
  * });
  *
  * // returns false when element doesn't exist in DOM
@@ -58,8 +66,10 @@ import { getExecutionContext } from '../execution_context';
  * //   <span>ipsum</span>
  * // </div>
  *
- * const page = PageObject.create({
- *   spanIsVisible: PageObject.isVisible('span', { scope: '.scope' })
+ * import { create, isVisible } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   spanIsVisible: isVisible('span', { scope: '.scope' })
  * });
  *
  * assert.ok(page.spanIsVisible);
@@ -73,9 +83,11 @@ import { getExecutionContext } from '../execution_context';
  * //   <span>ipsum</span>
  * // </div>
  *
- * const page = PageObject.create({
+ * import { create, isVisible } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   scope: '.scope',
- *   spanIsVisible: PageObject.isVisible('span')
+ *   spanIsVisible: isVisible('span')
  * });
  *
  * assert.ok(page.spanIsVisible);

--- a/addon/-private/properties/is.js
+++ b/addon/-private/properties/is.js
@@ -14,7 +14,9 @@ import { getExecutionContext } from '../execution_context';
  * // <input type="checkbox" checked="checked">
  * // <input type="checkbox" checked>
  *
- * const page = PageObject.create({
+ * import { create, is } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   areInputsChecked: is(':checked', 'input', { multiple: true })
  * });
  *
@@ -23,7 +25,9 @@ import { getExecutionContext } from '../execution_context';
  * @example
  * // <button class="toggle-button active" disabled>Toggle something</button>
  *
- * const page = PageObject.create({
+ * import { create, is } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   isToggleButtonActive: is('.active:disabled', '.toggle-button')
  * });
  *

--- a/addon/-private/properties/not-has-class.js
+++ b/addon/-private/properties/not-has-class.js
@@ -10,8 +10,10 @@ import { getExecutionContext } from '../execution_context';
  *
  * // <em class="lorem"></em><span class="success">Message!</span>
  *
- * const page = PageObject.create({
- *   messageIsSuccess: PageObject.notHasClass('error', 'span')
+ * import { create, notHasClass } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   messageIsSuccess: notHasClass('error', 'span')
  * });
  *
  * assert.ok(page.messageIsSuccess);
@@ -21,8 +23,10 @@ import { getExecutionContext } from '../execution_context';
  * // <span class="success"></span>
  * // <span class="error"></span>
  *
- * const page = PageObject.create({
- *   messagesAreSuccessful: PageObject.notHasClass('error', 'span', { multiple: true })
+ * import { create, notHasClass } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   messagesAreSuccessful: notHasClass('error', 'span', { multiple: true })
  * });
  *
  * // one span has error class
@@ -33,8 +37,10 @@ import { getExecutionContext } from '../execution_context';
  * // <span class="success"></span>
  * // <span class="success"></span>
  *
- * const page = PageObject.create({
- *   messagesAreSuccessful: PageObject.notHasClass('error', 'span', { multiple: true })
+ * import { create, notHasClass } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   messagesAreSuccessful: notHasClass('error', 'span', { multiple: true })
  * });
  *
  * // no spans have error class
@@ -49,8 +55,10 @@ import { getExecutionContext } from '../execution_context';
  * //   <span class="ipsum"></span>
  * // </div>
  *
- * const page = PageObject.create({
- *   spanNotHasClass: PageObject.notHasClass('lorem', 'span', { scope: '.scope' })
+ * import { create, notHasClass } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   spanNotHasClass: notHasClass('lorem', 'span', { scope: '.scope' })
  * });
  *
  * assert.ok(page.spanNotHasClass);
@@ -64,9 +72,11 @@ import { getExecutionContext } from '../execution_context';
  * //   <span class="ipsum"></span>
  * // </div>
  *
- * const page = PageObject.create({
+ * import { create, notHasClass } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   scope: '.scope',
- *   spanNotHasClass: PageObject.notHasClass('lorem', 'span')
+ *   spanNotHasClass: notHasClass('lorem', 'span')
  * });
  *
  * assert.ok(page.spanNotHasClass);

--- a/addon/-private/properties/property.js
+++ b/addon/-private/properties/property.js
@@ -10,8 +10,10 @@ import { getExecutionContext } from '../execution_context';
  * @example
  * // <input type="checkbox" checked="checked">
  *
- * const page = PageObject.create({
- *   isChecked: PageObject.property('checked', 'input')
+ * import { create, property } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   isChecked: property('checked', 'input')
  * });
  *
  * assert.ok(page.isChecked);
@@ -21,8 +23,10 @@ import { getExecutionContext } from '../execution_context';
  * // <input type="checkbox" checked="checked">
  * // <input type="checkbox" checked="">
  *
- * const page = PageObject.create({
- *   inputsChecked: PageObject.property('checked', 'input', { multiple: true })
+ * import { create, property } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   inputsChecked: property('checked', 'input', { multiple: true })
  * });
  *
  * assert.deepEqual(page.inputsChecked, [true, false]);
@@ -33,8 +37,10 @@ import { getExecutionContext } from '../execution_context';
  * // <div class="scope"><input type="checkbox" checked="checked"></div>
  * // <div><input></div>
  *
- * const page = PageObject.create({
- *   isChecked: PageObject.property('checked', 'input', { scope: '.scope' })
+ * import { create, property } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   isChecked: property('checked', 'input', { scope: '.scope' })
  * });
  *
  * assert.ok(page.isChecked);

--- a/addon/-private/properties/text.js
+++ b/addon/-private/properties/text.js
@@ -14,8 +14,10 @@ function identity(v) {
  *
  * // Hello <span>world!</span>
  *
- * const page = PageObject.create({
- *   text: PageObject.text('span')
+ * import { create, text } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   text: text('span')
  * });
  *
  * assert.equal(page.text, 'world!');
@@ -26,8 +28,10 @@ function identity(v) {
  * // <span> ipsum </span>
  * // <span>dolor</span>
  *
- * const page = PageObject.create({
- *   texts: PageObject.text('span', { multiple: true })
+ * import { create, text } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   texts: text('span', { multiple: true })
  * });
  *
  * assert.deepEqual(page.texts, ['lorem', 'ipsum', 'dolor']);
@@ -38,8 +42,10 @@ function identity(v) {
  * // <div class="scope"><span>ipsum</span></div>
  * // <div><span>dolor</span></div>
  *
- * const page = PageObject.create({
- *   text: PageObject.text('span', { scope: '.scope' })
+ * import { create, text } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   text: text('span', { scope: '.scope' })
  * });
  *
  * assert.equal(page.text, 'ipsum');
@@ -50,9 +56,11 @@ function identity(v) {
  * // <div class="scope"><span>ipsum</span></div>
  * // <div><span>dolor</span></div>
  *
- * const page = PageObject.create({
+ * import { create, text } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   scope: '.scope',
- *   text: PageObject.text('span')
+ *   text: text('span')
  * });
  *
  * // returns 'ipsum'
@@ -66,9 +74,11 @@ function identity(v) {
  * // </div>
  * // <div><span>dolor</span></div>
  *
- * const page = PageObject.create({
+ * import { create, text } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   scope: '.scope',
- *   text: PageObject.text('span', { normalize: false })
+ *   text: text('span', { normalize: false })
  * });
  *
  * // returns 'ipsum'

--- a/addon/-private/properties/triggerable.js
+++ b/addon/-private/properties/triggerable.js
@@ -10,7 +10,9 @@ import { getExecutionContext } from '../execution_context';
  * // <input class="name">
  * // <input class="email">
  *
- * const page = PageObject.create({
+ * import { create, triggerable } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   enter: triggerable('keypress', '.name', { eventProperties: { keyCode: 13 } })
  * });
  *
@@ -22,7 +24,9 @@ import { getExecutionContext } from '../execution_context';
  * // <input class="name">
  * // <input class="email">
  *
- * const page = PageObject.create({
+ * import { create, triggerable } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   keydown: triggerable('keypress', '.name')
  * });
  *
@@ -36,7 +40,9 @@ import { getExecutionContext } from '../execution_context';
  * // </div>
  * // <input class="email">
  *
- * const page = PageObject.create({
+ * import { create, triggerable } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   keydown: triggerable('keypress', '.name', { scope: '.scope' })
  * });
  *
@@ -50,7 +56,9 @@ import { getExecutionContext } from '../execution_context';
  * // </div>
  * // <input class="email">
  *
- * const page = PageObject.create({
+ * import { create, triggerable } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   scope: '.scope',
  *   keydown: triggerable('keypress', '.name')
  * });

--- a/addon/-private/properties/value.js
+++ b/addon/-private/properties/value.js
@@ -12,8 +12,10 @@ import { getExecutionContext } from '../execution_context';
  *
  * // <input value="Lorem ipsum">
  *
- * const page = PageObject.create({
- *   value: PageObject.value('input')
+ * import { create, value } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   value: value('input')
  * });
  *
  * assert.equal(page.value, 'Lorem ipsum');
@@ -22,8 +24,10 @@ import { getExecutionContext } from '../execution_context';
  *
  * // <div contenteditable="true"><b>Lorem ipsum</b></div>
  *
- * const page = PageObject.create({
- *   value: PageObject.value('[contenteditable]')
+ * import { create, value } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   value: value('[contenteditable]')
  * });
  *
  * assert.equal(page.value, '<b>Lorem ipsum</b>');
@@ -33,8 +37,10 @@ import { getExecutionContext } from '../execution_context';
  * // <input value="lorem">
  * // <input value="ipsum">
  *
- * const page = PageObject.create({
- *   value: PageObject.value('input', { multiple: true })
+ * import { create, value } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   value: value('input', { multiple: true })
  * });
  *
  * assert.deepEqual(page.value, ['lorem', 'ipsum']);
@@ -44,8 +50,10 @@ import { getExecutionContext } from '../execution_context';
  * // <div><input value="lorem"></div>
  * // <div class="scope"><input value="ipsum"></div>
  *
- * const page = PageObject.create({
- *   value: PageObject.value('input', { scope: '.scope' })
+ * import { create, value } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   value: value('input', { scope: '.scope' })
  * });
  *
  * assert.equal(page.value, 'ipsum');
@@ -55,9 +63,11 @@ import { getExecutionContext } from '../execution_context';
  * // <div><input value="lorem"></div>
  * // <div class="scope"><input value="ipsum"></div>
  *
- * const page = PageObject.create({
+ * import { create, value } from 'ember-cli-page-object';
+ * 
+ * const page = create({
  *   scope: '.scope',
- *   value: PageObject.value('input')
+ *   value: value('input')
  * });
  *
  * assert.equal(page.value, 'ipsum');

--- a/addon/-private/properties/visitable.js
+++ b/addon/-private/properties/visitable.js
@@ -42,8 +42,10 @@ function appendQueryParams(path, queryParams) {
  *
  * @example
  *
- * const page = PageObject.create({
- *   visit: PageObject.visitable('/users')
+ * import { create, visitable } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   visit: visitable('/users')
  * });
  *
  * // visits '/users'
@@ -51,8 +53,10 @@ function appendQueryParams(path, queryParams) {
  *
  * @example
  *
- * const page = PageObject.create({
- *   visit: PageObject.visitable('/users/:user_id')
+ * import { create, visitable } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   visit: visitable('/users/:user_id')
  * });
  *
  * // visits '/users/10'
@@ -60,8 +64,10 @@ function appendQueryParams(path, queryParams) {
  *
  * @example
  *
- * const page = PageObject.create({
- *   visit: PageObject.visitable('/users')
+ * import { create, visitable } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   visit: visitable('/users')
  * });
  *
  * // visits '/users?name=john'
@@ -69,8 +75,10 @@ function appendQueryParams(path, queryParams) {
  *
  * @example
  *
- * const page = PageObject.create({
- *   visit: PageObject.visitable('/users/:user_id')
+ * import { create, visitable } from 'ember-cli-page-object';
+ * 
+ * const page = create({
+ *   visit: visitable('/users/:user_id')
  * });
  *
  * // visits '/users/1?name=john'

--- a/guides/components.md
+++ b/guides/components.md
@@ -1,0 +1,250 @@
+---
+layout: page
+title: Components
+---
+
+Group attributes and create new ones
+
+* [Components](#components)
+* [Default attributes](#default-attributes)
+* [Custom helper](#custom-helper)
+* [Scopes](#scopes)
+
+## Components
+
+Components let you group attributes together, they are just plain objects with attributes on it. You can even define these objects in different files and reuse them in multiple places. Components can define a scope.
+
+__Example__
+
+```html
+<h1>New user</h1>
+<form class="awesome-form">
+  <input id="firstName" placeholder="First name">
+  <input id="lastName" placeholder="Last name">
+  <button>Create</button>
+</form>
+```
+
+```js
+const { visitable, text, fillable, clickable } = PageObject;
+
+var page = PageObject.create({
+  visit: visitable('/user/create'),
+  title: text('h1'),
+
+  form: {
+    scope: '.awesome-form',
+
+    firstName: fillable('#firstName'),
+    lastName: fillable('#lastName'),
+    submit: clickable('button')
+  }
+});
+
+page
+  .visit()
+  .form
+  .firstName('John')
+  .lastName('Doe')
+  .submit();
+
+andThen(function() {
+  // assert something
+});
+```
+
+## Default attributes
+
+By default, all components define some handy attributes and methods without being explicitly declared.
+
+* [click](/docs/v1.8.x/api/clickable)
+* [clickOn](/docs/v1.8.x/api/click-on-text)
+* [contains](/docs/v1.8.x/api/contains)
+* [fillIn](/docs/v1.8.x/api/fillable)
+* [isVisible](/docs/v1.8.x/api/is-visible)
+* [isHidden](/docs/v1.8.x/api/is-hidden)
+* [select](/docs/v1.8.x/api/selectable)
+* [text](/docs/v1.8.x/api/text)
+* [value](/docs/v1.8.x/api/value)
+
+<div class="alert alert-warning" role="alert">
+  <strong>Note</strong> that these attributes will use the component scope as their selector.
+</div>
+
+__Example__
+
+Suppose you have a modal dialog
+
+```html
+<div class="modal">
+  Are you sure you want to exit the page?
+  <button>I'm sure</button>
+  <button>No</button>
+</form>
+```
+
+```js
+const { visitable } = PageObject;
+
+var page = PageObject.create({
+  visit: visitable('/'),
+
+  modal: {
+    scope: '.modal'
+  }
+});
+
+page.visit();
+
+andThen(function() {
+  assert.ok(page.modal.contains('Are you sure you want to exit the page?'));
+});
+
+page.modal.clickOn("I'm sure");
+```
+
+## Custom helper
+
+You can create custom helpers by creating `Ceibo` descriptors. (`Ceibo` is a small library for parsing trees. You can check it out [here](http://github.com/san650/ceibo).)
+
+```js
+import { findElement } from './page-object';
+
+export default function disabled(selector, options = {}) {
+  return {
+    isDescriptor: true,
+
+    get() {
+      return findElement(this, selector, options).is(':disabled');
+    }
+  }
+}
+```
+
+Example usage:
+
+```js
+let page = PageObject.create({
+  scope: '.page',
+
+  isAdmin: disabled('#override-name')
+});
+```
+
+`page.isAdmin` will look for elements in the DOM that match ".page
+\#override-name" and check if they are disabled.
+
+## Scopes
+
+The `scope` attribute can be used to reduce the set of matched elements to the ones enclosed by the given selector.
+
+Given the following HTML
+
+```html
+<div class="article">
+  <p>Lorem ipsum dolor</p>
+</div>
+<div class="footer">
+  <p>Copyright Acme Inc.</p>
+</div>
+```
+
+the following configuration will match the article paragraph element
+
+```js
+var page = PageObject.create({
+  scope: '.article',
+
+  textBody: PageObject.text('p'),
+});
+
+andThen(function() {
+  assert.equal(page.textBody, 'Lorem ipsum dolor.');
+});
+```
+
+The attribute's selector can be omited when the scope matches the element we want to use.
+
+Given the following HTML
+
+```html
+<form>
+  <input id="userName" value="a value" />
+  <button>Submit</button>
+</form>
+```
+
+We can define several attributes on the same `input` element as follows
+
+```js
+var page = PageObject.create({
+  input: {
+    scope: '#userName',
+
+    hasError: hasClass('has-error'),
+    value: value(),
+    fillIn: fillable()
+  },
+
+  submit: clickable('button')
+});
+
+page
+  .input
+  .fillIn('an invalid value');
+
+page.submit();
+
+andThen(function() {
+  assert.ok(page.input.hasError, 'Input has an error');
+});
+```
+
+### A `component` inherits parent scope by default
+
+```html
+<div class="search">
+  <input placeholder="Search...">
+  <button>Search</button>
+</div>
+```
+
+```js
+var page = PageObject.create({
+  search: {
+    scope: '.search',
+
+    input: {
+      fillIn: fillable('input'),
+      value: value('input')
+    }
+  }
+});
+```
+
+| call                      | translates to                 |
+|:--------------------------|:------------------------------|
+| `page.search.input.value` | `find('.search input').val()` |
+{: .table}
+
+You can reset parent scope by setting the `scope` and `resetScope` attribute on the component declaration.
+
+```js
+var page = PageObject.create({
+  search: {
+    scope: '.search',
+
+    input: {
+      scope: 'input',
+      resetScope: true,
+
+      fillIn: fillable()
+    }
+  }
+});
+```
+
+| call                      | translates to         |
+|:--------------------------|:----------------------|
+| `page.search.input.value` | `find('input').val()` |
+{: .table}

--- a/guides/components.md
+++ b/guides/components.md
@@ -26,9 +26,15 @@ __Example__
 ```
 
 ```js
-const { visitable, text, fillable, clickable } = PageObject;
+import {
+  create,
+  visitable,
+  text,
+  fillable,
+  clickable
+} from 'ember-cli-page-object';
 
-var page = PageObject.create({
+const page = create({
   visit: visitable('/user/create'),
   title: text('h1'),
 
@@ -84,9 +90,9 @@ Suppose you have a modal dialog
 ```
 
 ```js
-const { visitable } = PageObject;
+import { create, visitable } from 'ember-cli-page-object';
 
-var page = PageObject.create({
+const page = create({
   visit: visitable('/'),
 
   modal: {
@@ -105,10 +111,10 @@ page.modal.clickOn("I'm sure");
 
 ## Custom helper
 
-You can create custom helpers by creating `Ceibo` descriptors. (`Ceibo` is a small library for parsing trees. You can check it out [here](http://github.com/san650/ceibo).)
+You can create custom helpers by creating `Ceibo` descriptors. (`Ceibo` is a small library for parsing trees. You can check it out [here](http://github.com/san650/ceibo)).
 
 ```js
-import { findElement } from './page-object';
+import { findElement } from 'ember-cli-page-object';
 
 export default function disabled(selector, options = {}) {
   return {
@@ -124,7 +130,7 @@ export default function disabled(selector, options = {}) {
 Example usage:
 
 ```js
-let page = PageObject.create({
+const page = create({
   scope: '.page',
 
   isAdmin: disabled('#override-name')
@@ -152,10 +158,10 @@ Given the following HTML
 the following configuration will match the article paragraph element
 
 ```js
-var page = PageObject.create({
+const page = create({
   scope: '.article',
 
-  textBody: PageObject.text('p'),
+  textBody: text('p'),
 });
 
 andThen(function() {
@@ -177,7 +183,7 @@ Given the following HTML
 We can define several attributes on the same `input` element as follows
 
 ```js
-var page = PageObject.create({
+const page = create({
   input: {
     scope: '#userName',
 
@@ -210,7 +216,7 @@ andThen(function() {
 ```
 
 ```js
-var page = PageObject.create({
+const page = create({
   search: {
     scope: '.search',
 
@@ -230,7 +236,7 @@ var page = PageObject.create({
 You can reset parent scope by setting the `scope` and `resetScope` attribute on the component declaration.
 
 ```js
-var page = PageObject.create({
+const page = create({
   search: {
     scope: '.search',
 

--- a/guides/components.md
+++ b/guides/components.md
@@ -113,37 +113,6 @@ andThen(function() {
 page.modal.clickOn("I'm sure");
 ```
 
-## Custom helper
-
-You can create custom helpers by creating `Ceibo` descriptors. (`Ceibo` is a small library for parsing trees. You can check it out [here](http://github.com/san650/ceibo)).
-
-```js
-import { findElement } from 'ember-cli-page-object';
-
-export default function disabled(selector, options = {}) {
-  return {
-    isDescriptor: true,
-
-    get() {
-      return findElement(this, selector, options).is(':disabled');
-    }
-  }
-}
-```
-
-Example usage:
-
-```js
-const page = create({
-  scope: '.page',
-
-  isAdmin: disabled('#override-name')
-});
-```
-
-`page.isAdmin` will look for elements in the DOM that match ".page
-\#override-name" and check if they are disabled.
-
 ## Scopes
 
 The `scope` attribute can be used to reduce the set of matched elements to the ones enclosed by the given selector.

--- a/guides/components.md
+++ b/guides/components.md
@@ -63,15 +63,19 @@ andThen(function() {
 
 By default, all components define some handy attributes and methods without being explicitly declared.
 
-* [click](/docs/v1.8.x/api/clickable)
-* [clickOn](/docs/v1.8.x/api/click-on-text)
-* [contains](/docs/v1.8.x/api/contains)
-* [fillIn](/docs/v1.8.x/api/fillable)
-* [isVisible](/docs/v1.8.x/api/is-visible)
-* [isHidden](/docs/v1.8.x/api/is-hidden)
-* [select](/docs/v1.8.x/api/selectable)
-* [text](/docs/v1.8.x/api/text)
-* [value](/docs/v1.8.x/api/value)
+* [as](/docs/v1.14.x/api/as)
+* [blur](/docs/v1.14.x/api/blur)
+* [click](/docs/v1.14.x/api/clickable)
+* [clickOn](/docs/v1.14.x/api/click-on-text)
+* [contains](/docs/v1.14.x/api/contains)
+* [fillIn](/docs/v1.14.x/api/fillable)
+* [focus](/docs/v1.14.x/api/focus)
+* [isHidden](/docs/v1.14.x/api/is-hidden)
+* [isPresent](/docs/v1.14.x/api/is-present)
+* [isVisible](/docs/v1.14.x/api/is-visible)
+* [select](/docs/v1.14.x/api/selectable)
+* [text](/docs/v1.14.x/api/text)
+* [value](/docs/v1.14.x/api/value)
 
 <div class="alert alert-warning" role="alert">
   <strong>Note</strong> that these attributes will use the component scope as their selector.

--- a/guides/extend.md
+++ b/guides/extend.md
@@ -6,6 +6,8 @@ title: Extend
 {% raw %}
 ### Methods
 
+You can create custom helpers by creating `Ceibo` descriptors. (`Ceibo` is a small library for parsing trees. You can check it out [here](http://github.com/san650/ceibo)).
+
 - [findElementWithAssert](#findelementwithassert)
 - [findElement](#findelement)
 
@@ -43,8 +45,6 @@ export default function isDisabled(selector, options = {}) {
 }
 ```
 
-Returns **Object** jQuery object
-
 ## findElement
 
 [addon/-private/extend/find-element.js:36-42](https://github.com/san650/ember-cli-page-object/blob/c521335ffba9955a6acaf1006ed503cbb61ba72d/addon/-private/extend/find-element.js#L36-L42 "Source code on GitHub")
@@ -78,5 +78,17 @@ export default function isDisabled(selector, options = {}) {
 }
 ```
 
-Returns **Object** jQuery object
+Usage Example:
+
+```js
+const page = create({
+  scope: '.page',
+
+  isAdmin: disabled('#override-name')
+});
+```
+
+`page.isAdmin` will look for elements in the DOM that match ".page
+\#override-name" and check if they are disabled.
+
 {% endraw %}

--- a/guides/extend.md
+++ b/guides/extend.md
@@ -1,0 +1,82 @@
+---
+layout: page
+title: Extend
+---
+
+{% raw %}
+### Methods
+
+- [findElementWithAssert](#findelementwithassert)
+- [findElement](#findelement)
+
+## findElementWithAssert
+
+[addon/-private/extend/find-element-with-assert.js:38-44](https://github.com/san650/ember-cli-page-object/blob/c521335ffba9955a6acaf1006ed503cbb61ba72d/addon/-private/extend/find-element-with-assert.js#L38-L44 "Source code on GitHub")
+
+**Parameters**
+
+-   `pageObjectNode` **Ceibo** Node of the tree
+-   `targetSelector` **string** Specific CSS selector
+-   `options` **Object** Additional options
+    -   `options.resetScope` **boolean** Do not use inherited scope
+    -   `options.contains` **string** Filter by using :contains('foo') pseudo-class
+    -   `options.last` **boolean** Filter by using :last pseudo-class
+    -   `options.visible` **boolean** Filter by using :visible pseudo-class
+    -   `options.multiple` **boolean** Specify if built selector can match multiple elements.
+    -   `options.testContainer` **String** Context where to search elements in the DOM
+    -   `options.at` **number** Filter by index using :eq(x) pseudo-class
+    -   `options.pageObjectKey` **String** Used in the error message when the element is not found
+
+**Examples**
+
+```javascript
+import { findElementWithAssert } from 'ember-cli-page-object/extend';
+
+export default function isDisabled(selector, options = {}) {
+  return {
+    isDescriptor: true,
+
+    get() {
+      return findElementWithAssert(this, selector, options).is(':disabled');
+    }
+  };
+}
+```
+
+Returns **Object** jQuery object
+
+## findElement
+
+[addon/-private/extend/find-element.js:36-42](https://github.com/san650/ember-cli-page-object/blob/c521335ffba9955a6acaf1006ed503cbb61ba72d/addon/-private/extend/find-element.js#L36-L42 "Source code on GitHub")
+
+**Parameters**
+
+-   `pageObjectNode` **Ceibo** Node of the tree
+-   `targetSelector` **string** Specific CSS selector
+-   `options` **Object** Additional options
+    -   `options.resetScope` **boolean** Do not use inherited scope
+    -   `options.contains` **string** Filter by using :contains('foo') pseudo-class
+    -   `options.at` **number** Filter by index using :eq(x) pseudo-class
+    -   `options.last` **boolean** Filter by using :last pseudo-class
+    -   `options.visible` **boolean** Filter by using :visible pseudo-class
+    -   `options.multiple` **boolean** Specify if built selector can match multiple elements.
+    -   `options.testContainer` **String** Context where to search elements in the DOM
+
+**Examples**
+
+```javascript
+import { findElement } from 'ember-cli-page-object/extend';
+
+export default function isDisabled(selector, options = {}) {
+  return {
+    isDescriptor: true,
+
+    get() {
+      return findElement(this, selector, options).is(':disabled');
+    }
+  };
+}
+```
+
+Returns **Object** jQuery object
+{% endraw %}

--- a/guides/index.md
+++ b/guides/index.md
@@ -1,0 +1,55 @@
+---
+layout: page
+title: Overview
+---
+
+The ember-cli-page-object addon makes it easy to create page objects for your acceptance and integration tests.
+
+The addon is:
+
+- Mostly declarative
+- Quick to set up and uses convention over configuration
+- Extremely easy to extend
+- Unobtrusive
+- Agnostic to the testing framework (but really hooked on Ember!)
+
+```javascript
+const page = PageObject.create({
+  visit: visitable('/'),
+
+  username: fillable('#username'),
+  password: fillable('#password'),
+  submit: clickable('button'),
+  error: text('.errors')
+});
+
+test('my awesome test', function(assert) {
+  page
+    .visit()
+    .username('admin')
+    .password('invalid')
+    .submit();
+
+  andThen(() => {
+    assert.equal(page.error, 'Invalid credentials');
+  });
+});
+```
+
+## So, What Is a Page Object?
+
+Ember, and more specifically `ember-testing`, provides a DSL that simplifies the creation and validation of conditions on our tests.
+
+One of the problems with acceptance and integration testing is that many of the CSS selectors used to look up elements are repeated across tests. In some cases, this repetition seems like a smell.
+
+In some cases the complexity of selectors makes it hard to remember what we were actually trying to test. This confusion can lead to difficulties updating tests and collaborating with others.
+
+A widely used design pattern comes to the rescue: page objects. The main idea behind this pattern is to encapsulate in an object the page or component structure being tested, hiding the details of its HTML structure and exposing only the semantic structure of the page.
+
+This addon allows you to define page objects in a declarative fashion, making it simple to model complex pages and components.
+
+### Resources
+
+- [Using the page object pattern with ember-cli](https://wyeworks.com/blog/2015/5/13/using-the-page-object-pattern-with-ember-cli/)
+- [Martin Fowler's original description](http://martinfowler.com/bliki/PageObject.html)
+- [Selenium's wiki page](https://seleniumhq.github.io/docs/best.html#page_object_models)

--- a/guides/index.md
+++ b/guides/index.md
@@ -14,7 +14,7 @@ The addon is:
 - Agnostic to the testing framework (but really hooked on Ember!)
 
 ```javascript
-const page = PageObject.create({
+const page = create({
   visit: visitable('/'),
 
   username: fillable('#username'),
@@ -52,4 +52,4 @@ This addon allows you to define page objects in a declarative fashion, making it
 
 - [Using the page object pattern with ember-cli](https://wyeworks.com/blog/2015/5/13/using-the-page-object-pattern-with-ember-cli/)
 - [Martin Fowler's original description](http://martinfowler.com/bliki/PageObject.html)
-- [Selenium's wiki page](https://seleniumhq.github.io/docs/best.html#page_object_models)
+- [Selenium's wiki page](https://github.com/SeleniumHQ/selenium/wiki/PageObjects)

--- a/guides/index.md
+++ b/guides/index.md
@@ -14,6 +14,14 @@ The addon is:
 - Agnostic to the testing framework (but really hooked on Ember!)
 
 ```javascript
+import {
+  create,
+  visitable,
+  fillable,
+  clickable,
+  text
+} from 'ember-cli-page-object';
+
 const page = create({
   visit: visitable('/'),
 

--- a/guides/installation.md
+++ b/guides/installation.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Installation
+---
+
+```bash
+$ ember install ember-cli-page-object
+```
+
+That's it!

--- a/guides/migrating.md
+++ b/guides/migrating.md
@@ -1,0 +1,340 @@
+---
+layout: page
+title: Migration Guide
+---
+{% raw %}
+In the update to ember-cli-page-object v1.x, we've defined more intuitive behavior and moved to a more polished and mature API.
+
+This sounds great, but it also comes with a cost: you need to migrate your test suite. This page includes a list of breaking changes and API enhancements to help you upgrade as quickly and painlessly as possible.
+
+- [Change `build()` calls to `create()` calls](#change-build-calls-to-create-calls)
+- [Components are now just plain objects](#components-are-now-just-plain-objects)
+- [`.customHelper` is deprecated](#customhelper)
+- [Collections are now 0-based](#collections-are-now-0-based)
+- [`index` option renamed to `at` and is 0-based](#index-option-renamed-to-at-and-is-0-based)
+- [Remove parentheses when getting a value for a query or predicate](#remove-parentheses-when-getting-a-value-for-a-query-or-predicate)
+- [Scope and `resetScope`](#scope-and-resetscope)
+- [The `multiple` option](#the-multiple-optionm)
+- [`.visitable()`](#visitable)
+- [`.clickOnText()`](#clickontext)
+
+## Change `build()` calls to `create()` calls
+
+This is very simple:
+
+```js
+const page = PageObject.build({
+  // ...
+});
+```
+
+Should be changed to:
+
+```js
+const page = PageObject.create({
+  // ...
+});
+```
+
+## Components are now just plain objects
+
+In `v0.x` we deprecated the `component` function. In `v1.0` we
+removed it completely in favor of using plain JS objects.
+
+```js
+const page = PageObject.create({
+  // ...
+  modal: component({
+    // modal component definition
+  }),
+  // ...
+});
+```
+
+Should be changed to:
+
+```js
+const page = PageObject.create({
+  // ...
+  modal: {
+    // modal component definition
+  },
+  // ...
+});
+```
+
+## .customHelper
+
+`.customHelper` is now deprecated. Use `Ceibo` descriptors instead. (`Ceibo` is a small library for parsing trees. You can check it out [here](http://github.com/san650/ceibo).)
+
+With the old `v0.x` syntax, you would define a custom helper like:
+
+```js
+var disabled = customHelper(function(selector, options) {
+  return $(selector).prop('disabled');
+});
+```
+
+On version `1.x` this can be represented as:
+
+```js
+import { findElement } from './page-object';
+
+export default function disabled(selector, options = {}) {
+  return {
+    isDescriptor: true,
+
+    get() {
+      return findElement(this, selector, options).is(':disabled');
+    }
+  }
+}
+```
+
+Example usage:
+
+```js
+let page = PageObject.create({
+  scope: '.page',
+
+  isAdmin: disabled('#override-name')
+});
+```
+
+`page.isAdmin` will look for elements in the DOM that match ".page #override-name" and check if they are disabled.
+
+## Collections are now 0-based
+
+When we first implemented the `collection` function, we were using the
+`nth-of-type` CSS pseudo-class which is 1-based, so we though it would
+be clearer to also make collections 1-based. Later we decided to
+change to an implementation to use `:eq`, which is `0-based`. We decided `v1.0`
+was the moment to break compatibility and switch to 0-based collections.
+
+```hbs
+<table>
+  <tbody>
+    <tr>
+      <td>Jane</td>
+    </tr>
+    <tr>
+      <td>John</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+Example from the old `v0.x` syntax:
+
+```js
+const page = create({
+  users: collection({
+    itemScope: 'table tr',
+    item: {
+      name: text('td')
+    }
+  })
+});
+
+page.users(1).name(); //  returns 'Jane'
+page.users(2).name(); //  returns 'John'
+```
+
+Example in `v1.x` syntax:
+
+```js
+const page = create({
+  users: collection({
+    itemScope: 'table tr',
+    item: {
+      name: text('td')
+    }
+  })
+});
+
+page.users(0).name; //  returns 'Jane'
+page.users(1).name; //  returns 'John'
+```
+
+## `index` option renamed to `at` and is 0-based
+
+In `v0.x`, the `index` option was used to reduce the set of matched elements to the
+one at the specified index which was 1-based. A small example from `v0.x`:
+
+```js
+const page = create({
+  secondTitle: text('h1', { index: 2 })
+});
+
+page.secondTitle(); // translates into $('h1:eq(1)').text()
+```
+
+In `v1.x` this should be changed to:
+
+```js
+const page = create({
+  secondTitle: text('h1', { at: 1 })
+});
+
+page.secondTitle; // translates into $('h1:eq(1)').text()
+```
+
+## Remove parentheses when getting a value for a query or predicate 
+
+In `v1` we decided to go a step further on improving the code and
+polished the tree structure we already used when defining page objects.
+The `Ceibo` project was born (you can see it over
+[here](http://github.com/san650/ceibo)) which defines a simple way to
+create complex properties within an object. So for most cases
+properties used only to get a value will no longer need parentheses
+when accessed.
+
+```js
+const page = create({
+  scope: '#my-page',
+
+  title: text('h1'),
+  fillInName: fillable('#name')
+});
+```
+
+In `v0.x` the following code was used within tests:
+
+```js
+assert.equal(page.title(), 'My page title');
+page.fillInName('Juan'); // fill #name with 'Juan'
+```
+
+In `v1.x` this should be changed to:
+
+```js
+assert.equal(page.title, 'My page title');
+page.fillInName('Juan'); // Doesn't change
+```
+
+## Scope and `resetScope`
+
+In `v0.x` defining the `scope` attribute on a page object used to override how the element was looked up in the DOM. Example:
+
+```js
+const page = create({
+  scope: '#my-page',
+
+  title: text('h1'),
+  fillInName: fillable('#name')
+
+  modal: {
+    scope: '#my-modal',
+    title: PageObject.text('h3')
+  }
+});
+```
+
+When running tests in `v0.x`:
+
+```js
+page.title(); // translates to `find('#my-page h1').text()`
+page.modal().title() //  transaltes to `find('#my-modal h3').text()`
+```
+
+In `v1.0` we decided to implement scope inheritance, this means that if a
+component defines a scope and has a child component, the latter will
+inherit its parent scope.
+
+```js
+page.title; // translates into find('#my-page h1').text()
+page.modal.title //  transaltes into find('#my-page #my-modalh3').text()
+```
+
+In some scenarios, this change of behavior will not affect test
+assertions but in some cases, it will. If you want to make sure lookups
+work as in `v0.x` you can use the `resetScope` option (you can see more
+options on the documentation [site](/docs/v1.1.x/options)).
+
+Changed definition to keep lookups the same:
+
+```js
+const page = create({
+  scope: '#my-page',
+
+  title: text('h1'),
+  fillInName: fillable('#name')
+
+  modal: {
+    scope: '#my-modal',
+    resetScope: true,
+
+    title: text('h3')
+  }
+});
+```
+
+## The `multiple` option
+
+Another cause of failure when upgrading to `v1.x` is that, by default, an error will be thrown if multiple elements match a query or predicate.
+
+For example, if the previous page object definition is used with the following template:
+
+```hbs
+<div class="#my-page">
+  <h1>My title</h1>
+  <h1>My other title</h1>
+</div>
+```
+
+This call will throw an error:
+
+```js
+page.title; // Kaboom!
+```
+
+This behavior applies to every DOM lookup except `count`.
+
+If you need to match multiple elements you can use the `multiple` option on
+your properties. The resulting behavior will vary depending on the
+property. As an example, you can check how the `multiple` option behaves on the `text`
+property [here](/docs/v1.1.x/api/queries#text).
+
+## .visitable()
+
+The signature for `.visitable()` has changed. Instead of receiving two distinct object parameters (dynamic segments and query params) now it receives only one.
+
+The idea is to fill the dynamic segments first, using the values from the param object and then use the rest of the keys and values as query params.
+
+```js
+var page = create({
+  visit: visitable('/users/:user_id')
+
+});
+
+page.visit({ user_id: 1, expanded: true  });
+
+// is equivalent to
+
+visit("/users/1?expanded=true");
+```
+
+## .clickOnText()
+
+The behaviour of `.clickOnText()` has improved. When looking for elements to click (based on text), the property now considers the parent element as a valid element to click. This allows to do things like
+
+```html
+<div class="modal">
+...
+<button>Save</button><button>Cancel</button>
+```
+
+```js
+var page = PageObject.create({
+  clickButton: clickOnText('button'),
+  clickOn: clickOnText('.modal')
+});
+
+// ...
+
+page.clickButton('Save');
+page.clickOn('Save');
+```
+
+Before, the first action (`clickButton`) would not have worked, only the second action would have found the element. Now, both actions work and both actions do click the same button.
+{% endraw %}

--- a/guides/migrating.md
+++ b/guides/migrating.md
@@ -78,7 +78,7 @@ var disabled = customHelper(function(selector, options) {
 On version `1.x` this can be represented as:
 
 ```js
-import { findElement } from './page-object';
+import { findElement } from 'ember-cli-page-object/extend';
 
 export default function disabled(selector, options = {}) {
   return {

--- a/guides/native-events.md
+++ b/guides/native-events.md
@@ -1,0 +1,51 @@
+---
+layout: page
+title: Native Events Mode
+---
+
+{% raw %}
+By default, `ember-cli-page-object` uses global ember test helpers such as `click`, `fillIn`, `find`, etc.
+While it works great, this approach has one downside: global ember test helpers require `jQuery` to be bundled within your `Ember` global.
+
+As a result, if you want to drop a dependency on `jQuery` in your app or addon, you won't be able to use the standard `Ember` test helpers.
+
+In order to solve this problem, `ember-cli-page-object` provides an integration with [`ember-native-dom-helpers`](https://github.com/cibernox/ember-native-dom-helpers).
+
+In general, `native-events` mode doesn't require you to rewrite your existing page object declarations. However, you should take into account that with `native-events` mode enabled, your test suite triggers real DOM events instead of `jQuery` alternatives.
+
+## Usage
+
+You can enable `native-events` mode by simply adding this snippet into your `test-helper.js`:
+
+```js
+// tests/test-helper.js
+import { useNativeEvents } from 'ember-cli-page-object/extend';
+...
+
+useNativeEvents();
+```
+
+## Migration from jQuery events to native DOM events
+
+If you want to use `native-events` mode in your test suite, you have to ensure that your app is ready to handle native DOM events rather than jQuery events.
+
+Consider a component event handler like this:
+
+```js
+export default Component.extend({
+  doubleClick() {
+    set(this, "doubleClicked", true);
+    return true;
+  }
+})
+```
+
+`native-events` mode won't work out of the box with a handler like this. The native double-click won't have any effect on the component because Ember's event dispatcher handles events via jQuery.
+
+In order to fix this, you should replace the default event dispatcher with `ember-native-dom-event-dispatcher`:
+
+```sh
+npm i --save-dev ember-native-dom-event-dispatcher
+```
+
+{% endraw %}

--- a/guides/options.md
+++ b/guides/options.md
@@ -31,9 +31,9 @@ Given the following HTML
 the following configuration will match the footer element
 
 ```js
-const { text } = PageObject;
+const { create, text } from 'ember-cli-page-object';
 
-var page = PageObject.create({
+const page = create({
   scope: '.page',
 
   copyrightNotice: text('p', { scope: '.footer' })
@@ -57,9 +57,9 @@ The `at` option can be used to reduce the set of matched elements to the one at 
 the following configuration will match the second `span` element
 
 ```js
-const { text } = PageObject;
+import { create, text } from 'ember-cli-page-object';
 
-var page = PageObject.create({
+const page = create({
   word: text('span', { at: 1 })
 });
 
@@ -85,9 +85,9 @@ value defined on the `scope` property.
 ```
 
 ```js
-const { text } = PageObject;
+import { create, text } from 'ember-cli-page-object';
 
-var page = PageObject.create({
+const page = create({
   scope: '.scope',
   outsideWord: text('span', { scope: 'outside-scope', resetScope: true })
 });
@@ -108,9 +108,9 @@ is matched. Setting the `multiple` option will override this behavior:
 ```
 
 ```js
-const { text } = PageObject;
+import { create, text } from 'ember-cli-page-object';
 
-var page = PageObject.create({
+const page = create({
   words: text('span', { multiple: true })
 });
 

--- a/guides/options.md
+++ b/guides/options.md
@@ -1,0 +1,123 @@
+---
+layout: page
+title: Options
+---
+
+A set of options can be passed as parameters when defining attributes.
+
+* [scope](#scope)
+* [at](#at)
+* [resetScope](#resetScope)
+* [multiple](#multiple)
+
+## scope
+
+The `scope` option can be used to do nesting of the provided selector
+within the inherited scope.
+
+Given the following HTML
+
+```html
+<div class="page">
+  <div class="article">
+    <p>Lorem ipsum dolor</p>
+  </div>
+  <div class="footer">
+    <p>Copyright 2016 - Acme Inc.</p>
+  </div>
+</div>
+```
+
+the following configuration will match the footer element
+
+```js
+const { text } = PageObject;
+
+var page = PageObject.create({
+  scope: '.page',
+
+  copyrightNotice: text('p', { scope: '.footer' })
+});
+
+andThen(function() {
+  assert.equal(page.copyrightNotice, 'Copyright 2015 - Acme Inc.');
+});
+```
+
+## at
+
+The `at` option can be used to reduce the set of matched elements to the one at the specified index (starting from zero).
+
+```html
+<span>Lorem</span>
+<span>ipsum</span>
+<span>dolor</span>
+```
+
+the following configuration will match the second `span` element
+
+```js
+const { text } = PageObject;
+
+var page = PageObject.create({
+  word: text('span', { at: 1 })
+});
+
+andThen(function() {
+  assert.equal(page.word, 'ipsum'); // => ok
+});
+```
+
+## resetScope
+
+Used with the `scope` options, the 'resetScope' option is meant to
+override the inherited scope of a component or property with the
+value defined on the `scope` property.
+
+```html
+<div class="scope">
+  <span>ipsum</span>
+  <span>dolor</span>
+</div>
+<div class="outside-scope">
+  <span>Lorem</span>
+</div>
+```
+
+```js
+const { text } = PageObject;
+
+var page = PageObject.create({
+  scope: '.scope',
+  outsideWord: text('span', { scope: 'outside-scope', resetScope: true })
+});
+
+andThen(function() {
+  assert.equal(page.outsideWord, 'Lorem'); // => ok
+});
+```
+
+## multiple
+
+By default, element lookup will throw an error if more than on element
+is matched. Setting the `multiple` option will override this behavior:
+
+```html
+<span>Lorem</span>
+<span>ipsum</span>
+```
+
+```js
+const { text } = PageObject;
+
+var page = PageObject.create({
+  words: text('span', { multiple: true })
+});
+
+andThen(function() {
+  assert.deepEqual(page.word, ['Lorem', 'ipsum']); // => ok
+});
+```
+
+The return value of each property using the `multiple` option can be
+found in the API documentation.

--- a/guides/quickstart.md
+++ b/guides/quickstart.md
@@ -1,0 +1,424 @@
+---
+layout: page
+title: Quickstart
+---
+
+{% raw %}
+This is a short guide to get you started writing page objects and using them in your acceptance and integration tests.
+
+- [Acceptance tests](#acceptance-tests)
+- [Integration tests](#integration-tests)
+
+## Acceptance Tests
+
+Suppose we have a couple of acceptance tests to test the login page of our site.
+
+```js
+test('logs in sucessfully', function(assert) {
+  visit('/login');
+  fillIn('#username', 'admin');
+  fillIn('#password', 'secret');
+  click('button');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/private-page');
+  });
+});
+
+test('shows an error when password is wrong', function(assert) {
+  visit('/login');
+  fillIn('#username', 'admin');
+  fillIn('#password', 'invalid');
+  click('button');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/login');
+    assert.equal($.trim(find('.errors').text()), 'Invalid credentials');
+  });
+});
+```
+
+We want to convert these tests to use a page object.
+
+First, we need to create a new page object. For this we'll use one of the generators that comes with the addon.
+
+```bash
+$ ember generate page-object login
+
+installing
+  create tests/pages/login.js
+```
+
+The generator created a file inside the directory `/tests/pages`. Let's describe the login page structure on our new page object.
+
+```js
+import PageObject, {
+  clickable,
+  fillable,
+  text,
+  visitable
+} from 'frontend/tests/page-object';
+
+export default PageObject.create({
+  visit: visitable('/'),
+
+  username: fillable('#username'),
+  password: fillable('#password'),
+  submit: clickable('button'),
+  error: text('.errors')
+});
+```
+
+Now we include the page object in the test and replace the existing test helpers with the page object's methods and properties.
+
+```js
+import page from 'frontend/tests/pages/login';
+
+// ...
+
+test('logs in sucessfully', function(assert) {
+  page
+    .visit()
+    .username('admin')
+    .password('secret')
+    .submit();
+
+  andThen(function() {
+    assert.equal(currentURL(), '/private-page');
+  });
+});
+
+test('shows an error when password is wrong', function(assert) {
+  page
+    .visit()
+    .username('admin')
+    .password('invalid')
+    .submit();
+
+  andThen(function() {
+    assert.equal(page.error, 'Invalid credentials');
+  });
+});
+```
+
+We can go a step further and describe the steps of the test using a higher level of abstraction.
+
+```js
+import PageObject, {
+  clickable,
+  fillable,
+  text,
+  visitable
+} from 'frontend/tests/page-object';
+
+export default PageObject.create({
+  visit: visitable('/'),
+
+  username: fillable('#username'),
+  password: fillable('#password'),
+  submit: clickable('button'),
+  error: text('.errors'),
+
+  loginSuccessfully() {
+    return this.username('admin')
+      .password('secret')
+      .submit();
+  },
+
+  loginFailed() {
+    return this.username('admin')
+      .password('invalid')
+      .submit();
+  }
+});
+```
+
+Let's update the test accordingly.
+
+```js
+test('logs in sucessfully', function(assert) {
+  page.visit()
+    .loginSuccessfully();
+
+  andThen(function() {
+    assert.equal(currentURL(), '/private-page');
+  });
+});
+
+test('shows an error when password is wrong', function(assert) {
+  page.visit()
+    .loginFailed();
+
+  andThen(function() {
+    assert.equal(page.error, 'Invalid credentials');
+  });
+});
+```
+
+## Integration Tests
+
+We've made a page object for our login page. Now let's use the same page object to write integration tests for our login form component.
+
+Here are our integration tests before using a page object.
+
+```js
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('login-form', 'Integration | login form', {
+  integration: true
+});
+
+test('calls submit action with correct username and password', function(assert) {
+  assert.expect(2);
+
+  function submit(username, password) {
+    assert.equal(username, 'admin');
+    assert.equal(password, 'secret');
+  }
+
+  this.set('submit', submit);
+
+  this.render(hbs`
+    {{login-form
+      submit=(action submit)
+    }}
+  `);
+
+  $username = this.$('#username');
+  $password = this.$('#password');
+
+  $username.val('admin');
+  $username.trigger('input');
+  $username.change();
+
+  $password.val('secret');
+  $password.trigger('input');
+  $password.change();
+
+  this.$('button').click();
+});
+
+test('shows errors', function(assert) {
+  assert.expect(2);
+
+  this.set('errors', []);
+
+  this.render(hbs`
+    {{login-form
+      errors=errors
+    }}
+  `);
+
+  assert.equal(this.$('.errors').trim().text()), '');
+
+  Ember.run(() => {
+    this.set('errors', ['Invalid credentials']);
+  });
+
+  assert.equal(this.$('.errors').trim().text()), 'Invalid credentials');
+});
+```
+
+Let's use our existing page object to refactor these integration tests. As a reminder, here is our page object. (We don't need to change anything to use it in our integration tests!)
+
+```js
+import PageObject, {
+  clickable,
+  fillable,
+  text,
+  visitable
+} from 'frontend/tests/page-object';
+
+export default PageObject.create({
+  visit: visitable('/'),
+
+  username: fillable('#username'),
+  password: fillable('#password'),
+  submit: clickable('button'),
+  error: text('.errors'),
+
+  loginSuccessfully() {
+    return this.username('admin')
+      .password('secret')
+      .submit();
+  },
+
+  loginFailed() {
+    return this.username('admin')
+      .password('invalid')
+      .submit();
+  }
+});
+```
+
+Let's set up our test to use the page object we created.
+
+```js
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+import page from 'frontend/tests/pages/login';
+
+moduleForComponent('login-form', 'Integration | login form', {
+  integration: true,
+
+  beforeEach() {
+    page.setContext(this);
+  },
+
+  afterEach() {
+    page.removeContext();
+  }
+});
+
+test('calls submit action with correct username and password', function(assert) {
+  assert.expect(2);
+
+  function submit(username, password) {
+    assert.equal(username, 'admin');
+    assert.equal(password, 'secret');
+  }
+
+  this.set('submit', submit);
+
+  page.render(hbs`
+      {{login-form
+        submit=(action submit)
+      }}
+    `)
+    .username('admin')
+    .password('secret')
+    .submit();
+});
+
+test('shows errors', function(assert) {
+  assert.expect(2);
+
+  this.set('error', '');
+
+  page.render(hbs`
+    {{login-form
+      error=error
+    }}
+  `);
+
+  assert.equal(page.error, '');
+
+  Ember.run(() => {
+    this.set('error', 'Invalid credentials');
+  });
+
+  assert.equal(page.error, 'Invalid credentials');
+});
+```
+
+Let's take a look at the changes:
+
+- In the test's `beforeEach()` hook we set the page's test context with `page.setContext(this)`. That tells the page object to use the test's `this.$()` to find elements, instead of Ember's global acceptance test helpers.
+- In the `afterEach()` hook, we call `page.removeContext()` to clear the test context from the page object.
+- We change `this.render()` to `page.render()`. `page.render()` delegates to the test's `this.render()`, but it returns the page object so you can chain other page object methods onto it.
+- The rest of the changes are the same as in our acceptance tests: After you set the test's `this` context on the page object, you can use the page object as before. (The one exception is `page.visit()`, which doesn't work in component tests since we don't have access to a router.)
+
+As in our acceptance tests, we can DRY things up a bit more by grouping actions together into methods that describe specific user flows. For example, in the first test we can use our `page.loginSuccessfully()` method to eliminate a few lines of code:
+
+```js
+test('calls submit action with correct username and password', function(assert) {
+  assert.expect(2);
+
+  function submit(username, password) {
+    assert.equal(username, 'admin');
+    assert.equal(password, 'secret');
+  }
+
+  this.set('submit', submit);
+
+  page.render(hbs`
+      {{login-form
+        submit=(action submit)
+      }}
+    `)
+    .loginSuccessfully();
+});
+```
+
+And that's it! Our integration and acceptance tests are cleaner, more maintainable and easier to read.
+
+## Appendix
+
+A helpful tip is to separate the exports in component page objects. This will allow you to compose larger page objects using the same definitions. For example say we have an integration test of a `my-fanfare` component:
+
+```js
+import PageObject from 'ember-cli-page-object';
+
+const { clickable, isVisible } = PageObject;
+
+export const MyFanfare = {
+  scope: '.ui-my-fanfare',
+  playFanfare: clickable('button'),
+  isCelebrating: isVisible('.fireworks')
+};
+
+export default PageObject.create(MyFanfare);
+```
+
+This separation gives us two `import`-able signatures. In the case of the component's integration test importing the `default` will work as expected:
+
+```js
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import page from 'my-app/tests/pages/components/my-fanfare';
+
+moduleForComponent('my-fanfare', 'Integration | Components | my fanfare', {
+  integration: true,
+  beforeEach() {
+    page.setContext(this);
+  },
+  afterEach() {
+    page.removeContext();
+  }
+});
+
+test('it show fireworks when user clicks fanfare button', function (assert) {
+  page.render(hbs`{{my-fanfaire}}`);
+  page.playFanfare();
+  assert.ok(page.isCelebrating, 'expected fireworks to have happened');
+});
+```
+
+Then in the case of an acceptance test where the page object happens to include a `my-fanfare` component we can add that definition to the page object we are using in the acceptance test(s):
+
+```js
+import PageObject from 'ember-cli-page-object';
+import { MyFanfare } from 'frontend/tests/pages/components/my-fanfare';
+
+const { visitable, fillable, clickable } = PageObject;
+
+export default PageObject.create({
+  visit('/');
+  enterName: fillable('input.username'),
+  register: clickable('button.register'),
+  myFanfare: MyFanfare
+});
+```
+
+Which will allow us to reference the `MyFanfare` component from the acceptance test.
+
+```js
+assert.ok(page.myFanfare.isCelebrating, 'expected fireworks to have happened');
+```
+
+Some manipulation could be added (for example picking the first instance only):
+
+```js
+import Ember from 'ember';
+import PageObject from 'ember-cli-page-object';
+import { MyFanfare } from 'frontend/tests/pages/components/my-fanfare';
+
+const { assign } = Ember;
+
+export default PageObject.create({
+  myFanfare: assign({eq: 0}, MyFanfare)
+});
+```
+{% endraw %}


### PR DESCRIPTION
In this PR I've copied existing v1.13 docs from "gh-pages" to development branch and put it under the "guides/" directory.

The idea is to keep the freshest docs in the main branch and copy it to the gh-pages with a existing docs script as it currently happens for generated API docs. I believe locating of the guides alongside the code/API docs should improve a contributor experience. 

Also this PR contains refreshing of existing examples with a new syntax and some fixes. I hope commit messages are explanatory enough to follow what has happened.

todo:
 - [x] make legacy collection [link](https://github.com/san650/ember-cli-page-object/pull/389/files#diff-3b664b1551d5c88bf2d403b24a164761R13) be included to the generated markdown