### PR TITLE
Upgrade `ember-cli-babel` version to use new modules syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "ceibo": "~2.0.0",
-    "ember-cli-babel": "^6.6.0",
+    "ember-cli-babel": "6.12.0",
     "ember-cli-node-assets": "^0.2.2",
     "ember-native-dom-helpers": "^0.5.3",
     "jquery": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "ceibo": "~2.0.0",
-    "ember-cli-babel": "6.12.0",
+    "ember-cli-babel": "^6.12.0",
     "ember-cli-node-assets": "^0.2.2",
     "ember-native-dom-helpers": "^0.5.3",
     "jquery": "^3.2.1",


### PR DESCRIPTION
The current `ember-cli-babel` version `6.6.0` doesn't support the new modules syntax:

![image 2018-04-07 at 12 56 08 am](https://user-images.githubusercontent.com/1156865/38451921-c2ad188c-39fe-11e8-8af6-157a95fe435a.png)
