### PR TITLE
Improve FastBoot compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,10 @@ module.exports = {
         return {
           enabled: this._shouldIncludeFiles(),
           vendor: ['dist/jquery.js'],
-          destDir: 'ecpo-jquery'
+          destDir: 'ecpo-jquery',
+          processTree(tree) {
+            return require('fastboot-transform')(tree);
+          }
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ember-cli-babel": "^6.12.0",
     "ember-cli-node-assets": "^0.2.2",
     "ember-native-dom-helpers": "^0.5.3",
+    "fastboot-transform": "^0.1.3",
     "jquery": "^3.2.1",
     "rsvp": "^4.7.0"
   },

--- a/vendor/shims/ecpo-jquery.js
+++ b/vendor/shims/ecpo-jquery.js
@@ -1,23 +1,27 @@
-// Define an amd module called "-jquery".
-// It expects that we have already imported our own version of jQuery
-// which is going to be used in ember-cli-page-oject internally.
-//
-// This mode is used when we deal with `jquery`-less apps.
-(function() {
-  // prevent jquery provided by ember-cli-page-object
-  // to be set to `Ember.$` by Ember. 
-  var jq = self['$'].noConflict();
-  delete self['jQuery'];
+if (typeof FastBoot === 'undefined') {
+  // Define an amd module called "-jquery".
+  // It expects that we have already imported our own version of jQuery
+  // which is going to be used in ember-cli-page-oject internally.
+  //
+  // This mode is used when we deal with `jquery`-less apps.
+  (function() {
+    // prevent jquery provided by ember-cli-page-object
+    // to be set to `Ember.$` by Ember.
+    var jq = self['$'].noConflict();
+    delete self['jQuery'];
 
-  function vendorModule() {
-    'use strict';
+    function vendorModule() {
+      'use strict';
 
-    if (!jq) {
-      throw new Error('Unable to find jQuery');
+      if (!jq) {
+        throw new Error('Unable to find jQuery');
+      }
+
+      return { 'default': jq };
     }
 
-    return { 'default': jq };
-  }
-
-  define('-jquery', [], vendorModule);
-})();
+    define('-jquery', [], vendorModule);
+  })();
+} else {
+  define('-jquery', [], function() {});
+}


### PR DESCRIPTION
This should fix #397. Newer versions of FastBoot don't set `process.env.EMBER_CLI_FASTBOOT`—instead there's only a single build step, and the runtime code is expected to be guarded by a `typeof FastBoot` check if it's not FastBoot-compatible.

I do think the change proposed in #399 is a good idea independent of this, but it looks like it got held up because of code coverage issues, and this solves the more immediate problem.