### PR TITLE
Fix eslint Ember.VERSION error

### DIFF
--- a/tests/expect-ember-error.js
+++ b/tests/expect-ember-error.js
@@ -1,5 +1,6 @@
 
 import { run } from '@ember/runloop';
+import { VERSION as EmberVersion } from '@ember/version';
 import Ember from 'ember';
 
 // ember@2.11.3 introduces a breaking change in how the errors are propagated
@@ -11,7 +12,7 @@ import Ember from 'ember';
 //
 // See https://github.com/emberjs/ember.js/pull/15871
 function useHack() {
-  var [major, minor] = Ember.VERSION.split('.');
+  var [major, minor] = EmberVersion.split('.');
   major = Number(major);
   minor = Number(minor);
 


### PR DESCRIPTION
https://travis-ci.org/san650/ember-cli-page-object/jobs/380784622#L499:

> /home/travis/build/san650/ember-cli-page-object/tests/expect-ember-error.js
>  14:24  error  Use import { VERSION } from '@ember/version'; instead of using Ember.VERSION  ember/new-module-imports