### PR TITLE
Use Ceibo descriptor `get` for visitable

### DIFF
--- a/addon-test-support/properties/visitable.js
+++ b/addon-test-support/properties/visitable.js
@@ -93,17 +93,19 @@ export function visitable(path) {
   return {
     isDescriptor: true,
 
-    value(dynamicSegmentsAndQueryParams = {}) {
-      let executionContext = getExecutionContext(this);
+    get() {
+      return function(dynamicSegmentsAndQueryParams = {}) {
+        let executionContext = getExecutionContext(this);
 
-      return executionContext.runAsync((context) => {
-        let params = assign({}, dynamicSegmentsAndQueryParams);
-        let fullPath = fillInDynamicSegments(path, params);
+        return executionContext.runAsync((context) => {
+          let params = assign({}, dynamicSegmentsAndQueryParams);
+          let fullPath = fillInDynamicSegments(path, params);
 
-        fullPath = appendQueryParams(fullPath, params);
+          fullPath = appendQueryParams(fullPath, params);
 
-        return context.visit(fullPath);
-      });
+          return context.visit(fullPath);
+        });
+      }
     }
   };
 }


### PR DESCRIPTION
~There is a single usage of Ceibo's `value` for only a `visitable` property.~ This is not true. the `value` is still [used](https://github.com/san650/ember-cli-page-object/blob/master/addon-test-support/properties/collection/main.js#L118) in the new Collection. But seems like it's for a reason.

The only difference between `value` and `get` is that `value` creates a [`writable` descriptor](https://github.com/san650/ceibo/blob/master/index.js#L46-L51) while `get` doesn't. I think `visitable` should be changed to leverage Ceibo's `get` since I can see a reason to use writable descriptor for it.

