### PR TITLE
[doc]: use async/await in the components.md

### DIFF
--- a/guides/components.md
+++ b/guides/components.md
@@ -47,16 +47,12 @@ const page = create({
   }
 });
 
-page
+await page
   .visit()
   .form
   .firstName('John')
   .lastName('Doe')
   .submit();
-
-andThen(function() {
-  // assert something
-});
 ```
 
 ## Default attributes
@@ -104,13 +100,11 @@ const page = create({
   }
 });
 
-page.visit();
+await page.visit();
 
-andThen(function() {
-  assert.ok(page.modal.contains('Are you sure you want to exit the page?'));
-});
+assert.ok(page.modal.contains('Are you sure you want to exit the page?'));
 
-page.modal.clickOn("I'm sure");
+await page.modal.clickOn("I'm sure");
 ```
 
 ## Scopes
@@ -137,9 +131,7 @@ const page = create({
   textBody: text('p'),
 });
 
-andThen(function() {
-  assert.equal(page.textBody, 'Lorem ipsum dolor.');
-});
+assert.equal(page.textBody, 'Lorem ipsum dolor.');
 ```
 
 The attribute's selector can be omited when the scope matches the element we want to use.
@@ -168,15 +160,13 @@ const page = create({
   submit: clickable('button')
 });
 
-page
+await page
   .input
   .fillIn('an invalid value');
 
-page.submit();
+await page.submit();
 
-andThen(function() {
-  assert.ok(page.input.hasError, 'Input has an error');
-});
+assert.ok(page.input.hasError, 'Input has an error');
 ```
 
 ### A `component` inherits parent scope by default


### PR DESCRIPTION
as a part of updating the docs to the new testing API

Background: Recently I've incidentally [updated](https://github.com/san650/ember-cli-page-object/commit/e268ef0fa625401a5accbc03ea0b01f3083f1d3f) an "Overview" page with a direct commit 
 to use `async`/`await`. It happened because of some confusion with GH interface. Now we basically can revert it or keep updating the docs. Personally I'd prefer the second option.