### PR TITLE
[feat] Allow native getter syntax

### DIFF
--- a/guides/components.md
+++ b/guides/components.md
@@ -120,19 +120,24 @@ You can use native syntax for functions and getters on pages as well to create
 methods and properties with custom functionality:
 
 ```js
-import { click } from 'ember-test-helpers';
-import { findElement } from 'ember-cli-page-object';
+import { find, click } from 'ember-test-helpers';
 
 const page = create({
-  button: {
-    scope: 'button',
+  form: {
+    scope: '.awesome-form',
 
-    clickWith(options) {
-      click(findElement(this), options);
-    },
+    firstName: fillable('#firstName'),
+    lastName: fillable('#lastName'),
+    submit: clickable('button')
+
+    login(data) {
+      return this.username(data.username)
+        .password(data.password)
+        .submit();
+    }
 
     get role() {
-      return findElement(this).getAttribute('aria-role');
+      return find(this.scope).getAttribute('aria-role');
     }
   }
 });

--- a/guides/components.md
+++ b/guides/components.md
@@ -8,6 +8,7 @@ Group attributes and create new ones
 * [Components](#components)
 * [Default attributes](#default-attributes)
 * [Custom helper](#custom-helper)
+* [Functions and Getters](#scopes)
 * [Scopes](#scopes)
 
 ## Components
@@ -111,6 +112,30 @@ andThen(function() {
 });
 
 page.modal.clickOn("I'm sure");
+```
+
+## Functions and Getters
+
+You can use native syntax for functions and getters on pages as well to create
+methods and properties with custom functionality:
+
+```js
+import { click } from 'ember-test-helpers';
+import { findElement } from 'ember-cli-page-object';
+
+const page = create({
+  button: {
+    scope: 'button',
+
+    clickWith(options) {
+      click(findElement(this), options);
+    },
+
+    get role() {
+      return findElement(this).getAttribute('aria-role');
+    }
+  }
+});
 ```
 
 ## Scopes

--- a/tests/unit/-private/properties/native-getter-test.js
+++ b/tests/unit/-private/properties/native-getter-test.js
@@ -1,0 +1,43 @@
+import { moduleForProperty } from '../../../helpers/properties';
+import {
+  create,
+  property,
+  value
+} from 'ember-cli-page-object';
+
+moduleForProperty('native getter', function(test) {
+  test('returns the result of the passed-in function', function(assert) {
+    assert.expect(2);
+
+    const page = create({
+      get foo() {
+        return 'lorem';
+      },
+      get bar() {
+        return 'ipsum';
+      }
+    });
+
+    assert.equal(page.foo, 'lorem');
+    assert.equal(page.bar, 'ipsum');
+  });
+
+  test('executes the passed-in function with the correct context for `this`', async function (assert) {
+    assert.expect(1);
+
+    const page = create({
+      inputValue: value('input'),
+      isSubmitButtonDisabled: property('disabled', 'button'),
+      get isFormEmpty() {
+        return !this.inputValue && this.isSubmitButtonDisabled;
+      }
+    });
+
+    await this.adapter.createTemplate(this, page, `
+      <input value="">
+      <button disabled="true">Submit</button>
+    `);
+
+    assert.ok(page.isFormEmpty);
+  });
+});


### PR DESCRIPTION
This PR allows users to use native `get` syntax directly on page
objects, as opposed to the `getter` macro. This syntax is much less
verbose and easier to read overall.

The implementation first ensures that all property descriptors are
correctly copied to the final definition, then updates objects in the
Ceibo builder to use the equivalent of the getter macro. This could also
be added directly to Ceibo, but would likely still require some changes
to ember-cli-page-object to ensure that descriptors are copied via
`getOwnPropertyDescriptor` and `defineProperty` and not via simple
assignment (which will activate the getter when attempting to assign
it).

I'm also unsure where the best place to document this feature would be.
Should it just be a part of the API docs for `getter`?