### PR TITLE
[refactor] Cleanup readonly properties

### DIFF
--- a/addon-test-support/-private/execution_context/acceptance.js
+++ b/addon-test-support/-private/execution_context/acceptance.js
@@ -17,10 +17,6 @@ export default function AcceptanceExecutionContext(pageObjectNode) {
 }
 
 AcceptanceExecutionContext.prototype = {
-  run(cb) {
-    return cb(this);
-  },
-
   runAsync(cb) {
     window.wait().then(() => {
       cb(this);

--- a/addon-test-support/-private/execution_context/integration.js
+++ b/addon-test-support/-private/execution_context/integration.js
@@ -20,10 +20,6 @@ export default function IntegrationExecutionContext(pageObjectNode, testContext)
 }
 
 IntegrationExecutionContext.prototype = {
-  run(cb) {
-    return cb(this);
-  },
-
   runAsync(cb) {
     run(() => {
       cb(this);

--- a/addon-test-support/-private/execution_context/native-events-context.js
+++ b/addon-test-support/-private/execution_context/native-events-context.js
@@ -30,10 +30,6 @@ export default function ExecutionContext(pageObjectNode, testContext) {
 }
 
 ExecutionContext.prototype = {
-  run(cb) {
-    return cb(this);
-  },
-
   runAsync() {
     throw new Error('not implemented');
   },

--- a/addon-test-support/-private/execution_context/rfc268.js
+++ b/addon-test-support/-private/execution_context/rfc268.js
@@ -27,10 +27,6 @@ export default function ExecutionContext(pageObjectNode) {
 }
 
 ExecutionContext.prototype = {
-  run(cb) {
-    return cb(this);
-  },
-
   runAsync(cb) {
     let root = getRoot(this.pageObjectNode);
     let isChained = !root._chainedTree;

--- a/addon-test-support/-private/helpers.js
+++ b/addon-test-support/-private/helpers.js
@@ -162,17 +162,15 @@ export function normalizeText(text) {
 export function every(jqArray, cb) {
   let arr = jqArray.get();
 
-  return A(arr).every(function(element) {
-    return cb($(element));
-  });
+  return A(arr).every((element) => cb($(element)));
 }
 
-export function map(jqArray, cb) {
+export function map(jqArray, cb, options = {}) {
   let arr = jqArray.get();
 
-  return A(arr).map(function(element) {
-    return cb($(element));
-  });
+  const values =  A(arr).map(element => cb($(element)));
+
+  return options.multiple ? values : values[0];
 }
 
 /**
@@ -235,7 +233,7 @@ function getAllValuesForProperty(node, property) {
  * Return full scope of node (includes all ancestors scopes)
  *
  * @param {Ceibo} node - Node of the tree
- * @return {?Object} Full scope of node
+ * @return {string} Full scope of node
  */
 export function fullScope(node) {
   let scopes = getAllValuesForProperty(node, 'scope');

--- a/addon-test-support/extend/find-element-with-assert.js
+++ b/addon-test-support/extend/find-element-with-assert.js
@@ -36,9 +36,5 @@ import { getExecutionContext } from '../-private/execution_context';
  * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function findElementWithAssert(pageObjectNode, targetSelector, options = {}) {
-  let executionContext = getExecutionContext(pageObjectNode);
-
-  return executionContext.run((context) => {
-    return context.findWithAssert(targetSelector, options);
-  });
+  return getExecutionContext(pageObjectNode).findWithAssert(targetSelector, options);
 }

--- a/addon-test-support/extend/find-element.js
+++ b/addon-test-support/extend/find-element.js
@@ -34,9 +34,5 @@ import { getExecutionContext } from '../-private/execution_context';
  * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function findElement(pageObjectNode, targetSelector, options = {}) {
-  let executionContext = getExecutionContext(pageObjectNode);
-
-  return executionContext.run((context) => {
-    return context.find(targetSelector, options);
-  });
+  return getExecutionContext(pageObjectNode).find(targetSelector, options);
 }

--- a/addon-test-support/properties/attribute.js
+++ b/addon-test-support/properties/attribute.js
@@ -1,5 +1,5 @@
 import { assign, map } from '../-private/helpers';
-import { getExecutionContext } from '../-private/execution_context';
+import { findElementWithAssert } from '../extend';
 
 /**
  * @public
@@ -80,19 +80,11 @@ export function attribute(attributeName, selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let executionContext = getExecutionContext(this);
       let options = assign({ pageObjectKey: key }, userOptions);
 
-      return executionContext.run((context) => {
-        let elements = context.findWithAssert(selector, options);
-        let result;
+      let elements = findElementWithAssert(this, selector, options);
 
-        result = map(elements, function(element) {
-          return element.attr(attributeName);
-        });
-
-        return options.multiple ? result : result[0];
-      });
+      return map(elements, element => element.attr(attributeName), options);
     }
   };
 }

--- a/addon-test-support/properties/contains.js
+++ b/addon-test-support/properties/contains.js
@@ -1,5 +1,5 @@
 import { assign, every } from '../-private/helpers';
-import { getExecutionContext } from '../-private/execution_context';
+import { findElementWithAssert } from '../extend';
 
 /**
  * Returns a boolean representing whether an element or a set of elements contains the specified text.
@@ -95,15 +95,12 @@ export function contains(selector, userOptions = {}) {
 
     get(key) {
       return function(textToSearch) {
-        let executionContext = getExecutionContext(this);
         let options = assign({ pageObjectKey: `${key}("${textToSearch}")` }, userOptions);
 
-        return executionContext.run((context) => {
-          let elements = context.findWithAssert(selector, options);
+        let elements = findElementWithAssert(this, selector, options);
 
-          return every(elements, function(element) {
-            return element.text().indexOf(textToSearch) >= 0;
-          });
+        return every(elements, function(element) {
+          return element.text().indexOf(textToSearch) >= 0;
         });
       };
     }

--- a/addon-test-support/properties/count.js
+++ b/addon-test-support/properties/count.js
@@ -1,5 +1,5 @@
 import { assign } from '../-private/helpers';
-import { getExecutionContext } from '../-private/execution_context';
+import { findElement } from '../extend';
 
 /**
  * @public
@@ -86,14 +86,11 @@ export function count(selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let executionContext = getExecutionContext(this);
       let options = assign({ pageObjectKey: key }, userOptions);
 
       options = assign(options, { multiple: true });
 
-      return executionContext.run((context) => {
-        return context.find(selector, options).length;
-      });
+      return findElement(this, selector, options).length;
     }
   };
 }

--- a/addon-test-support/properties/has-class.js
+++ b/addon-test-support/properties/has-class.js
@@ -1,5 +1,5 @@
 import { assign, every } from '../-private/helpers';
-import { getExecutionContext } from '../-private/execution_context';
+import { findElementWithAssert } from '../extend'
 
 /**
  * Validates if an element or a set of elements have a given CSS class.
@@ -97,15 +97,12 @@ export function hasClass(cssClass, selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let executionContext = getExecutionContext(this);
       let options = assign({ pageObjectKey: key }, userOptions);
 
-      return executionContext.run((context) => {
-        let elements = context.findWithAssert(selector, options);
+      let elements = findElementWithAssert(this, selector, options);
 
-        return every(elements, function(element) {
-          return element.hasClass(cssClass);
-        });
+      return every(elements, function(element) {
+        return element.hasClass(cssClass);
       });
     }
   };

--- a/addon-test-support/properties/is-hidden.js
+++ b/addon-test-support/properties/is-hidden.js
@@ -1,5 +1,5 @@
 import { assign, every } from '../-private/helpers';
-import { getExecutionContext } from '../-private/execution_context';
+import { findElement } from '../extend';
 
 /**
  * Validates if an element or set of elements is hidden or does not exist in the DOM.
@@ -104,16 +104,11 @@ export function isHidden(selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let executionContext = getExecutionContext(this);
       let options = assign({ pageObjectKey: key }, userOptions);
 
-      return executionContext.run((context) => {
-        let elements = context.find(selector, options);
+      let elements = findElement(this, selector, options);
 
-        return every(elements, function(element) {
-          return element.is(':hidden');
-        });
-      });
+      return every(elements, element => element.is(':hidden'));
     }
   };
 }

--- a/addon-test-support/properties/is-visible.js
+++ b/addon-test-support/properties/is-visible.js
@@ -1,5 +1,5 @@
 import { assign, every } from '../-private/helpers';
-import { getExecutionContext } from '../-private/execution_context';
+import { findElement } from '../extend';
 
 /**
  * Validates if an element or set of elements are visible.
@@ -110,19 +110,16 @@ export function isVisible(selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let executionContext = getExecutionContext(this);
       let options = assign({ pageObjectKey: key }, userOptions);
 
-      return executionContext.run((context) => {
-        let elements = context.find(selector, options);
+      let elements = findElement(this, selector, options);
 
-        if (elements.length === 0) {
-          return false;
-        }
+      if (elements.length === 0) {
+        return false;
+      }
 
-        return every(elements, function(element) {
-          return element.is(':visible');
-        });
+      return every(elements, function(element) {
+        return element.is(':visible');
       });
     }
   };

--- a/addon-test-support/properties/is.js
+++ b/addon-test-support/properties/is.js
@@ -1,5 +1,5 @@
 import { assign, every } from '../-private/helpers';
-import { getExecutionContext } from '../-private/execution_context';
+import { findElementWithAssert } from '../extend';
 
 /**
  * @public
@@ -51,16 +51,11 @@ export function is(testSelector, targetSelector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let executionContext = getExecutionContext(this);
       let options = assign({ pageObjectKey: key }, userOptions);
 
-      return executionContext.run((context) => {
-        let elements = context.findWithAssert(targetSelector, options);
+      let elements = findElementWithAssert(this, targetSelector, options);
 
-        return every(elements, function(element) {
-          return element.is(testSelector);
-        });
-      });
+      return every(elements, (element) => element.is(testSelector));
     }
   };
 }

--- a/addon-test-support/properties/not-has-class.js
+++ b/addon-test-support/properties/not-has-class.js
@@ -1,5 +1,5 @@
 import { assign, every } from '../-private/helpers';
-import { getExecutionContext } from '../-private/execution_context';
+import { findElementWithAssert } from '../extend';
 
 /**
  * @public
@@ -101,15 +101,12 @@ export function notHasClass(cssClass, selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let executionContext = getExecutionContext(this);
       let options = assign({ pageObjectKey: key }, userOptions);
 
-      return executionContext.run((context) => {
-        let elements = context.findWithAssert(selector, options);
+      let elements = findElementWithAssert(this, selector, options);
 
-        return every(elements, function(element) {
-          return !element.hasClass(cssClass);
-        });
+      return every(elements, function(element) {
+        return !element.hasClass(cssClass);
       });
     }
   };

--- a/addon-test-support/properties/property.js
+++ b/addon-test-support/properties/property.js
@@ -1,5 +1,5 @@
 import { assign, map } from '../-private/helpers';
-import { getExecutionContext } from '../-private/execution_context';
+import { findElementWithAssert } from '../extend';
 
 /**
  * @public
@@ -64,19 +64,11 @@ export function property(propertyName, selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let executionContext = getExecutionContext(this);
       let options = assign({ pageObjectKey: key }, userOptions);
 
-      return executionContext.run((context) => {
-        let elements = context.findWithAssert(selector, options);
-        let result;
+      let elements = findElementWithAssert(this, selector, options);
 
-        result = map(elements, function(element) {
-          return element.prop(propertyName);
-        });
-
-        return options.multiple ? result : result[0];
-      });
+      return map(elements, element => element.prop(propertyName), options);
     }
   };
 }

--- a/addon-test-support/properties/text.js
+++ b/addon-test-support/properties/text.js
@@ -1,5 +1,5 @@
 import { assign, map, normalizeText } from '../-private/helpers';
-import { getExecutionContext } from '../-private/execution_context';
+import { findElementWithAssert } from '../extend';
 
 function identity(v) {
   return v;
@@ -104,19 +104,13 @@ export function text(selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let executionContext = getExecutionContext(this);
       let options = assign({ pageObjectKey: key }, userOptions);
 
-      return executionContext.run((context) => {
-        let elements = context.findWithAssert(selector, options);
-        let f = options.normalize === false ? identity : normalizeText;
+      let elements = findElementWithAssert(this, selector, options);
 
-        let result = map(elements, function(element) {
-          return f(element.text());
-        });
+      let f = options.normalize === false ? identity : normalizeText;
 
-        return options.multiple ? result : result[0];
-      });
+      return map(elements, element => f(element.text()), options);
     }
   };
 }

--- a/addon-test-support/properties/value.js
+++ b/addon-test-support/properties/value.js
@@ -1,5 +1,5 @@
 import { assign, map } from '../-private/helpers';
-import { getExecutionContext } from '../-private/execution_context';
+import { findElementWithAssert } from '../extend';
 
 /**
  * @public
@@ -91,23 +91,17 @@ export function value(selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let executionContext = getExecutionContext(this);
       let options = assign({ pageObjectKey: key }, userOptions);
 
-      return executionContext.run((context) => {
-        let elements = context.findWithAssert(selector, options);
-        let result;
+      let elements = findElementWithAssert(this, selector, options);
 
-        result = map(elements, function(element) {
-          if (element.is('[contenteditable]')) {
-            return element.html();
-          } else {
-            return element.val();
-          }
-        });
-
-        return options.multiple ? result : result[0];
-      });
+      return map(elements, function(element) {
+        if (element.is('[contenteditable]')) {
+          return element.html();
+        } else {
+          return element.val();
+        }
+      }, options);
     }
   };
 }


### PR DESCRIPTION
This PR avoids direct usages of `execution-context` in the "readonly" properties. Also `ExecutionContext.run` was completely removed cause it's a no-op method now. 