### PR TITLE
Correct example typo

### DIFF
--- a/addon-test-support/properties/contains.js
+++ b/addon-test-support/properties/contains.js
@@ -41,7 +41,7 @@ import { getExecutionContext } from '../-private/execution_context';
  * });
  *
  * // all spans contain 'text'
- * assert.ok(page.spanContains('text'));
+ * assert.ok(page.spansContain('text'));
  *
  * @example
  *


### PR DESCRIPTION
Example full text:

```js
// <span>super text</span>
// <span>regular text</span>

const page = PageObject.create({
  spansContain: PageObject.contains('span', { multiple: true })
});

// all spans contain 'text'
assert.ok(page.spanContains('text'));

```

Link: http://ember-cli-page-object.js.org/docs/v1.4.x/api/predicates#contains