### PR TITLE
Add named collection items support

### DIFF
--- a/addon-test-support/properties/collection/main.js
+++ b/addon-test-support/properties/collection/main.js
@@ -48,6 +48,10 @@ export class Collection {
     return this._items[index];
   }
 
+  getById(id) {
+    return this.toArray().find(o => o.id === id);
+  }
+
   filter(...args) {
     return this.toArray().filter(...args);
   }
@@ -100,6 +104,10 @@ function proxyIt(instance) {
         if (!isNaN(index)) {
           return target.objectAt(index);
         }
+      }
+
+      if (typeof target[name] === 'undefined') {
+        return target.getById(name);
       }
 
       return target[name];

--- a/tests/integration/collection-id-test.js
+++ b/tests/integration/collection-id-test.js
@@ -1,37 +1,41 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { create, collection, attribute } from 'ember-cli-page-object';
+import require from 'require';
 
-const page = create({
-  items: collection('ul>li', {
-    id: attribute('data-test-uuid')
-  })
-});
+if (require.has('@ember/test-helpers')) {
+  const { render } = require('@ember/test-helpers')
 
-const { items } = page;
-
-module('Integration | collection id', function(hooks) {
-  setupRenderingTest(hooks);
-
-  test('getById works', async function(assert) {
-    await render(hbs`<ul>
-      <li data-test-uuid="uuid1">UUID1</li>
-      <li data-test-uuid="uuid2">UUID2</li>
-    </ul>`);
-
-    const first = items.getById('uuid1');
-    assert.equal(first.text, 'UUID1');
+  const page = create({
+    items: collection('ul>li', {
+      id: attribute('data-test-uuid')
+    })
   });
 
-  test('enumerating by id works', async function(assert) {
-    await render(hbs`<ul>
-      <li data-test-uuid="uuid1">UUID1</li>
-      <li data-test-uuid="uuid2">UUID2</li>
-    </ul>`);
+  const { items } = page;
 
-    const { uuid1 } = items;
-    assert.equal(uuid1.text, 'UUID1');
+  module('Integration | collection id', function(hooks) {
+    setupRenderingTest(hooks);
+
+    test('getById works', async function(assert) {
+      await render(hbs`<ul>
+        <li data-test-uuid="uuid1">UUID1</li>
+        <li data-test-uuid="uuid2">UUID2</li>
+      </ul>`);
+
+      const first = items.getById('uuid1');
+      assert.equal(first.text, 'UUID1');
+    });
+
+    test('enumerating by id works', async function(assert) {
+      await render(hbs`<ul>
+        <li data-test-uuid="uuid1">UUID1</li>
+        <li data-test-uuid="uuid2">UUID2</li>
+      </ul>`);
+
+      const { uuid1 } = items;
+      assert.equal(uuid1.text, 'UUID1');
+    });
   });
-});
+}

--- a/tests/integration/collection-id-test.js
+++ b/tests/integration/collection-id-test.js
@@ -1,0 +1,37 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { create, collection, attribute } from 'ember-cli-page-object';
+
+const page = create({
+  items: collection('ul>li', {
+    id: attribute('data-test-uuid')
+  })
+});
+
+const { items } = page;
+
+module('Integration | collection id', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('getById works', async function(assert) {
+    await render(hbs`<ul>
+      <li data-test-uuid="uuid1">UUID1</li>
+      <li data-test-uuid="uuid2">UUID2</li>
+    </ul>`);
+
+    const first = items.getById('uuid1');
+    assert.equal(first.text, 'UUID1');
+  });
+
+  test('enumerating by id works', async function(assert) {
+    await render(hbs`<ul>
+      <li data-test-uuid="uuid1">UUID1</li>
+      <li data-test-uuid="uuid2">UUID2</li>
+    </ul>`);
+
+    const { uuid1 } = items;
+    assert.equal(uuid1.text, 'UUID1');
+  });
+});


### PR DESCRIPTION
Closes: #198, #288 

Also I think it should address most of use cases of the `findOne()` originally [proposed](https://github.com/san650/ember-cli-page-object/issues/352) by @pzuraq.

--------

This is a quick try to implement named collection items support described in https://github.com/san650/ember-cli-page-object/issues/288#issuecomment-407566187

There are two new pieces added to the public API:

- `id` is a component definition attribute which gives collections a hint how to identify items in the DOM.
We can use any getter attribute(`attribute`, `property`, `text`,...) provided by page object. It's also possible to use `alias` to find an `id` in the child components ~~or even custom functions to define more complex id rules~~(currently collection expects `id` to be a getter).

- `getById()` allows to find collection element by id. It's similar to an `objectAt`, but it works with a string name rather than position.

### Example
```html
<!-- Some dynamic fields form -->
<form>
  <div>
    <label for="id1">label 1</label>
    <input id="id1" name="field1" />
  </div>
  <div>
    <label for="id2">label 2</label>
    <input id="id2" name="field2" />
  </div>
</form>
```
```js
const p = create({
  scope: 'form',
  fields: collection('>div', {
    id: alias('input.name'),

    label: {
      scope: 'label'
    },

    input: {
      scope: 'input',
      name: attribute('name')
    }
  })
})

await p.fields['field1'].input.fillIn('value1');
await p.fields['field2'].input.fillIn('value2');

// we can even destruct fields by names
const { field1, field2 } = p.fields;

assert.equal(field1.label.label, 'label 1');
assert.equal(field2.label.text, 'label 2');
```

### Questions

#### Naming

tbh I'm not very excited about `id` name. It can be confused with a DOM `id` attribute. Maybe `key` is a better name?

-----

**TODO**: 
 - [ ] update docs
 - [ ] handle cases when `id` is not defined 
 - [ ] decide on naming
 - [ ] more tests/edge cases