### PR TITLE
[DOC] Document 'resetScope' for the Collection API

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ installing
 $ git clone https://github.com/san650/ember-cli-page-object.git
 $ cd $_
 $ yarn install # or npm install
-$ bower install
 ```
 
 ### Running Tests

--- a/addon-test-support/properties/collection.js
+++ b/addon-test-support/properties/collection.js
@@ -141,6 +141,7 @@ import { collection as legacyCollection } from './collection/legacy';
  *
  * @param {String} scopeOrDefinition - Selector to define the items of the collection
  * @param {Object} [definitionOrNothing] - Object with the definition of item properties
+ * @param {boolean} definition.resetScope - Override parent's scope
  * @return {Descriptor}
  */
 export function collection(scopeOrDefinition, definitionOrNothing) {


### PR DESCRIPTION
1. Documents 'resetScope' for the Collection API. The property still works in the new API when defined on the item definition but wasn't documented anywhere.
2. Remove `bower install` step in the README. There's no `bower.json` file anymore!