### PR TITLE
Remove Ember.Logger usage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,8 @@ module.exports = {
     browser: true
   },
   rules: {
-    'ember/no-global-jquery': 0
+    'ember/no-global-jquery': 0,
+    'no-console': [ "error", { allow: [ "warn", "error" ] } ]
   },
   overrides: [
     // node files

--- a/addon-test-support/-private/better-errors.js
+++ b/addon-test-support/-private/better-errors.js
@@ -1,8 +1,5 @@
-import Ember from 'ember';
 import EmberError from '@ember/error';
 import Ceibo from 'ceibo';
-
-const { Logger } = Ember;
 
 export const ELEMENT_NOT_FOUND = 'Element not found.';
 
@@ -32,6 +29,6 @@ export function throwBetterError(node, key, msg, { selector } = {}) {
     fullErrorMessage = `${fullErrorMessage}\n  Selector: '${selector}'`;
   }
 
-  Logger.error(fullErrorMessage);
+  console.error(fullErrorMessage);
   throw new EmberError(fullErrorMessage);
 }

--- a/tests/helpers/properties/acceptance-adapter.js
+++ b/tests/helpers/properties/acceptance-adapter.js
@@ -22,7 +22,6 @@ AcceptanceAdapter.prototype = {
     template = template || '';
 
     if (!(test && page)) {
-      // eslint-disable-next-line no-console
       console.error('Missing parameters in adapter.createTemplate(testContext, pageObject, templateString)');
     }
 

--- a/tests/helpers/properties/application-adapter.js
+++ b/tests/helpers/properties/application-adapter.js
@@ -32,7 +32,6 @@ Object.assign(ApplicationAdapter.prototype, {
 
   async createTemplate(test, page, template = '', { useAlternateContainer } = {}) {
     if (!(test && page)) {
-      // eslint-disable-next-line no-console
       console.error('Missing parameters in adapter.createTemplate(testContext, pageObject, templateString)');
     }
 

--- a/tests/helpers/properties/integration-adapter.js
+++ b/tests/helpers/properties/integration-adapter.js
@@ -19,7 +19,6 @@ IntegrationAdapter.prototype = {
     template = template || '';
 
     if (!(test && page)) {
-      // eslint-disable-next-line no-console
       console.error('Missing parameters in adapter.createTemplate(testContext, pageObject, templateString)');
     }
 

--- a/tests/helpers/properties/rendering-adapter.js
+++ b/tests/helpers/properties/rendering-adapter.js
@@ -18,7 +18,6 @@ Object.assign(RenderingAdapter.prototype, {
 
   async createTemplate(test, page, template = '', { useAlternateContainer } = {}) {
     if (!(test && page)) {
-      // eslint-disable-next-line no-console
       console.error('Missing parameters in adapter.createTemplate(testContext, pageObject, templateString)');
     }
 

--- a/tests/unit/-private/better-errors-test.js
+++ b/tests/unit/-private/better-errors-test.js
@@ -1,12 +1,9 @@
-import Ember from 'ember';
 import EmberError from '@ember/error';
 import { test, module } from 'qunit';
 import { create } from 'ember-cli-page-object';
 import {
   throwBetterError
 } from 'ember-cli-page-object/test-support/-private/better-errors';
-
-const { Logger } = Ember;
 
 const page = create({
   foo: {
@@ -49,15 +46,15 @@ test('shows the expected error message when `selector` is passed in', function(a
 test('logs the error to the console', function(assert) {
   assert.expect(2);
 
-  const origEmberLoggerError = Logger.error;
+  const origConsoleError = console.error;
 
   try {
-    Logger.error = (msg) => {
+    console.error = (msg) => {
       assert.equal(msg, "Oops!\n\nPageObject: 'page.foo.bar.focus'");
     };
 
     assert.throws(() => throwBetterError(page.foo.bar, 'focus', 'Oops!'));
   } finally {
-    Logger.error = origEmberLoggerError;
+    console.error = origConsoleError;
   }
 });


### PR DESCRIPTION
It's deprecated in favor of the now-reliable console.* methods.