### PR TITLE
Fix jQuery detection for ember-cli@3.4

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
 
     this.import('vendor/ceibo/index.js', { type: 'test' });
 
-    if (!this.app.vendorFiles['jquery.js']) {
+    if (!this.project.findAddonByName('@ember/jquery') && !this.app.vendorFiles['jquery.js']) {
       this.import('vendor/ecpo-jquery/dist/jquery.js', { type: 'test' });
       this.import('vendor/shims/ecpo-jquery.js', { type: 'test' });
     } else {


### PR DESCRIPTION
Because of [this](https://github.com/ember-cli/ember-cli/commit/a3fef4e74091f05c95e92d5a72549047c4b38473#diff-392bb207fea8bcbeb4a084bb445f7cc7) change, we need to check for the presence of the `@ember/jquery` addon as well as `this.vendorFiles['jquery.js']` in order to determine if the project already has jQuery.