### PR TITLE
Enable page object composition via stored definitions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,3 +39,4 @@ Ruslan Grabovoy <kudgo.test@gmail.com> (https://github.com/ro0gr)
 Chris Garrett <me@pzuraq.com> (https://github.com/pzuraq)
 Anto Arun Dominic (antoarundominic@gmail.com) https://github.com/antoarundominic
 Ben Demboski <ben@turbopatent.com> https://github.com/bendemboski
+Will Henry (https://github.com/mistahenry)

--- a/addon-test-support/-private/helpers.js
+++ b/addon-test-support/-private/helpers.js
@@ -320,3 +320,24 @@ export function getProperty(object, pathToProp) {
 
   return typeof value === 'function' ? value.bind(propOwner) : value;
 }
+
+export function isPageObject(property){
+  if(property && typeof(property) === 'object'){
+    let meta = Ceibo.meta(property);
+    return (meta && meta.__poDef__)
+  } else{
+    return false;
+  } 
+}
+
+export function getPageObjectDefinition(node){
+  if(!isPageObject(node)){
+    throw new Error('cannot get the page object definition from a node that is not a page object');
+  }else{
+    return Ceibo.meta(node).__poDef__;
+  }
+}
+
+export function storePageObjectDefinition(node, definition){
+  Ceibo.meta(node).__poDef__ = definition;
+}

--- a/tests/acceptance/composition-test.js
+++ b/tests/acceptance/composition-test.js
@@ -1,0 +1,60 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../helpers/module-for-acceptance';
+
+import {
+  create,
+  collection,
+  visitable,
+  text,
+  clickable,
+  value,
+  fillable,
+  clickOnText
+} from 'ember-cli-page-object';
+
+let keyboard = create({
+  scope: '.keyboard',
+  numbers: collection(".numbers button", {
+    text: text(),
+    click: clickable()
+  }),
+  operators: collection(".operators button", {
+    text: text()
+  }),
+  clickOn: clickOnText('.numbers'),
+  sum: clickable('button', { scope: '.operators', at: 0 }),
+  equal: clickable('button', { scope: '.operators', at: 2 })
+});
+
+let screenPage = create({
+  value: value('.screen input'),
+  fillValue: fillable('.screen input')
+});
+let page = create({
+  visit: visitable('/calculator'),
+  keys: keyboard,
+  screen: screenPage  
+});
+
+moduleForAcceptance('Acceptance | composition');
+
+test('allows compose', async function(assert) {
+  await page
+    .visit()
+    .keys
+    .clickOn('1')
+    .clickOn('2')
+    .sum();
+  //click 3
+  await page.keys.numbers.objectAt(2).click()
+  //click =
+  await page.keys.operators.objectAt(3).click();
+  assert.equal(page.screen.value, '15');
+
+  await page.screen.fillValue('45')
+  //click 6
+  await page.keys.numbers.objectAt(5).click();
+  
+  assert.equal(page.screen.value, '456');
+});
+

--- a/tests/unit/-private/composition-test.js
+++ b/tests/unit/-private/composition-test.js
@@ -1,0 +1,358 @@
+import { test, module } from 'qunit';
+import { isPageObject, getPageObjectDefinition } from 'ember-cli-page-object/test-support/-private/helpers';
+import { moduleForProperty } from '../../helpers/properties';
+import {
+  create,
+  triggerable,
+  collection,
+  isVisible,
+  text,
+  value
+} from 'ember-cli-page-object';
+import {
+  alias,
+  getter
+} from 'ember-cli-page-object/macros';
+
+module('Unit | composition');
+
+test('each page object node stores its definition', function(assert) {
+  let definition = {
+    foo: {
+      bar: {
+        baz: "prop"
+      }
+    }
+  };
+
+  let page = create(definition);
+  let storedDef = getPageObjectDefinition(page);
+  assert.ok(storedDef);
+  assert.deepEqual(storedDef, definition);
+
+  let fooDef = getPageObjectDefinition(page.foo);
+  assert.ok(fooDef);
+  assert.deepEqual(fooDef, {
+    bar: {
+      baz: "prop"
+    }
+  });
+
+  let barDef = getPageObjectDefinition(page.foo.bar);
+  assert.ok(barDef);
+  assert.deepEqual(barDef, {
+    baz: "prop"
+  });
+});
+
+test('page objects can be composed from other page objects', function(assert) {
+  let definition = {
+    foo: {
+      bar: {
+        baz: "prop"
+      }
+    }
+  };
+
+  let page = create(definition);
+  let pageComposer = create({
+    somePage: page
+  });
+  assert.ok(pageComposer);
+  assert.ok(pageComposer.somePage);
+
+  let pageComposerDef = getPageObjectDefinition(pageComposer);
+  assert.ok(pageComposerDef);
+  assert.ok(isPageObject(pageComposerDef.somePage));
+  // we cant deep equal the definition since it contains a page object so we check the keys instead
+  assert.deepEqual(Object.keys(pageComposerDef), ['somePage']);
+  let somePageStoredDef = getPageObjectDefinition(pageComposerDef.somePage);
+  assert.deepEqual(somePageStoredDef, definition);
+});
+
+test('page objects can be used as the definition to create', function(assert){
+  let definition = {
+    foo: "prop"
+  };
+
+  let page = create(definition);
+
+  let pageComposer = create(page);
+  assert.ok(pageComposer);
+  assert.ok(pageComposer.foo);
+
+  assert.deepEqual(getPageObjectDefinition(pageComposer), definition);
+});
+test('page object composition supports many levels deep', function(assert){
+  let definition = {
+    foo: {
+      bar: {
+        baz: "prop"
+      }
+    }
+  };
+
+  let page = create(definition);
+
+  let pageComposer = create({
+    bar: {
+      baz: page
+    }
+  });
+  assert.ok(pageComposer);
+  assert.ok(pageComposer.bar.baz);
+
+  // test that the definition is stored "as is"
+  let pageComposerDef = getPageObjectDefinition(pageComposer);
+  assert.ok(pageComposerDef);
+  assert.ok(pageComposerDef.bar);
+  assert.notOk(isPageObject(pageComposerDef.bar));
+  assert.ok(pageComposer.bar.baz);
+  assert.ok(isPageObject(pageComposerDef.bar.baz));
+
+  let bazDefiniton = getPageObjectDefinition(pageComposerDef.bar.baz);
+  assert.ok(bazDefiniton);
+  pageComposerDef.bar.baz = bazDefiniton;
+  // cant do a true deep equal without firing of page object selectors
+  assert.deepEqual(Object.keys(pageComposerDef), ["bar"]);
+  assert.deepEqual(bazDefiniton, definition);
+});
+
+test('can compose from page object nested within another page object', function(assert){
+  const { foo } = create({
+    foo: {
+      scope: '.foo'
+    }
+  });
+
+  assert.ok(foo);
+  assert.deepEqual(getPageObjectDefinition(foo), { scope: '.foo'}, "nested stores definition");
+
+  const bar = create({ foo });
+  assert.ok(bar);
+
+  let barDefinition = getPageObjectDefinition(bar);
+  assert.ok(barDefinition);
+  assert.ok(barDefinition.foo);
+  assert.ok(isPageObject(barDefinition.foo));
+
+  let fooDefFromBar = getPageObjectDefinition(bar.foo);
+  assert.ok(fooDefFromBar);
+  
+  // cannot do a true deep equal since foo is a page object 
+  assert.deepEqual(Object.keys(barDefinition), ["foo"]);
+  assert.deepEqual(fooDefFromBar, {
+    scope: '.foo' 
+  });
+});
+
+test('getPageObjectDefinition errors if node is not a page object', function(assert){
+  assert.throws(
+    function() { return getPageObjectDefinition({}) },
+    'cannot get the page object definition from a node that is not a page object'
+  );
+});
+moduleForProperty('all properties via compsition', function(test){
+  test('can alias through composition', async function(assert) {
+    assert.expect(1);
+  
+    const aliasPage = create({
+      isButtonVisible: isVisible('button'),
+      aliasedIsButtonVisible: alias('isButtonVisible')
+    });
+  
+  
+    let page = create({
+      scope: '.container',
+      aliasPage: aliasPage
+    });
+    await this.adapter.createTemplate(this, page, '<div class="container"><button>Look at me</button></div>');
+  
+    assert.ok(page.aliasPage.aliasedIsButtonVisible);
+  });
+  test('new pages can be composed from pages containing collections', async function(assert) {
+    let collectionPage = create({
+      foo: collection('span', {
+        text: text()
+      })
+    });
+
+    let page = create({
+      scope: '.container',
+      collectionPage: collectionPage
+    })
+    await this.adapter.createTemplate(this, page, `
+      <div class="container">
+        <span>Lorem</span>
+        <span>Ipsum</span>
+      </div>
+    `);
+    assert.equal(page.collectionPage.foo.objectAt(0).text, 'Lorem');
+    assert.equal(page.collectionPage.foo.objectAt(1).text, 'Ipsum');
+  });
+
+  test('collection supports taking a page object directly as its definition', async function(assert){
+    const textPage = create({
+      spanText: text("span")
+    });
+    let page = create({
+      scope: '.container',
+      collection: collection("li", textPage)
+    });
+
+    await this.adapter.createTemplate(this, page, `
+      <ul class="container">
+        <li>Text <span>Lorem</span></li>
+        <li>Text <span>Ipsum</span><>li<
+      <ul>
+    `);
+
+    assert.equal(page.collection.objectAt(0).spanText, 'Lorem');
+    assert.equal(page.collection.objectAt(1).spanText, 'Ipsum');
+  });
+
+  test('the collection definition can be composed from page objects', async function(assert){
+    const textPage = create({
+      spanText: text("span")
+    });
+    let page = create({
+      scope: '.container',
+      collection: collection("li", {
+        textPage: textPage
+      })
+    });
+    await this.adapter.createTemplate(this, page, `
+      <ul class="container">
+        <li>Text <span>Lorem</span></li>
+        <li>Text <span>Ipsum</span><>li<
+      <ul>
+    `);
+
+    assert.equal(page.collection.objectAt(0).textPage.spanText, 'Lorem');
+    assert.equal(page.collection.objectAt(1).textPage.spanText, 'Ipsum');
+  });
+
+  test("the composition of pages containing 'action' based descriptors is supported", async function(assert) {
+    assert.expect(1);
+
+    let expectedSelector = 'input';
+    let triggerPage = create({
+      foo: triggerable('focus', expectedSelector)
+    });
+
+    let page = create({
+      scope: '.container',
+      triggerPage: triggerPage
+    });
+    await this.adapter.createTemplate(this, page, '<div class="container"><input /></div>');
+
+    this.adapter.$(expectedSelector).on('focus', () => {
+      assert.ok(1);
+    });
+
+    await this.adapter.await(page.triggerPage.foo());
+  });
+  test('legacy collections support composition', async function(assert) {
+    let collectionPage = create({
+      foo: collection({
+        itemScope: 'span',
+
+        item: {
+          text: text()
+        }
+      })
+    });
+    let page = create({
+      scope: '.container',
+      collectionPage: collectionPage
+    });
+    await this.adapter.createTemplate(this, page, `
+      <div class="container">
+        <span>Lorem</span>
+        <span>Ipsum</span>
+      </div>
+    `);
+
+    assert.equal(page.collectionPage.foo(0).text, 'Lorem');
+    assert.equal(page.collectionPage.foo(1).text, 'Ipsum');
+  });
+  test('legacy collections support taking a page object as the "item" definition directly', async function(assert) {
+    let textPage = {
+      text: text()
+    };
+    let page = create({
+      foo: collection({
+        itemScope: 'span',
+
+        item: textPage
+      })
+    });
+    await this.adapter.createTemplate(this, page, `
+      <div class="container">
+        <span>Lorem</span>
+        <span>Ipsum</span>
+      </div>
+    `);
+
+    assert.equal(page.foo(0).text, 'Lorem');
+    assert.equal(page.foo(1).text, 'Ipsum');
+  });
+  test('legacy collections support an item definition that contains nested page objects', async function(assert) {
+    let textPage = {
+      text: text()
+    };
+    let page = create({
+      foo: collection({
+        itemScope: 'span',
+
+        item: {
+          textPage
+        }
+      })
+    });
+    await this.adapter.createTemplate(this, page, `
+      <div class="container">
+        <span>Lorem</span>
+        <span>Ipsum</span>
+      </div>
+    `);
+
+    assert.equal(page.foo(0).textPage.text, 'Lorem');
+    assert.equal(page.foo(1).textPage.text, 'Ipsum');
+  });
+
+  test('new pages can be composed from pages containing custom getters', function(assert) {
+    assert.expect(2);
+
+    const getterPage = create({
+      foo: getter(function() {
+        return 'lorem';
+      }),
+      bar: getter(function() {
+        return 'ipsum';
+      })
+    });
+    let page = create({
+      scope: '.container',
+      getterPage: getterPage
+    });
+    assert.equal(page.getterPage.foo, 'lorem');
+    assert.equal(page.getterPage.bar, 'ipsum');
+  });
+
+  test('the composition of pages containing a getter based attribute is supported', async function(assert) {
+    let inputPage = create({
+      foo: value('input')
+    });
+
+    let page = create({
+      scope: '.container',
+      input: inputPage
+    });
+    await this.adapter.createTemplate(this, page, '<div class="container"><input value="Lorem ipsum"></div>');
+
+    assert.equal(page.input.foo, 'Lorem ipsum');
+  });
+});
+
+


### PR DESCRIPTION
## Updated description
Edit: Originally this PR was an attempt to solve both composition and extension of page objects. During the course of review, the extension aspect was removed. While it no longer solves [#181](https://github.com/san650/ember-cli-page-object/issues/181) , the tools are in place for an extension approach via some sort of custom `merge` function should someone wish to write that in app space (or should such an approach be vetted and accepted here). 

Leveraging Ceibo's ability to take custom `buildObject` functions, the definitions for each page object are stored in the Ceibo metadata so that that during composition, the page object can be substituted with its definition. This is necessary since Page object's are "special" in that they fire functions expecting a test context and make assertions about the number of elements they select when accessed. Definition storing is preferable to a reflection-based approach in which we would extract the property descriptors and clone the getters since this can easily lead to closure scoping bugs without a great deal of care. See [this comment](https://github.com/san650/ember-cli-page-object/pull/430#issuecomment-439651083) for an example of this type of hard to track bug. 

Now, the following syntax is possible:
```javascript
let screenPage = create({
  value: value('.screen input'),
  fillValue: fillable('.screen input')
});
let page = create({
  visit: visitable('/calculator'),
  screen: screenPage  
});
```

Collections can also now take a page object as the definition directly

```javascript
test('collection supports taking a page object directly as its definition', async function(assert){
   const textPage = create({
     spanText: text("span")
   });
   let page = create({
     scope: '.container',
     collection: collection("li", textPage)
   });
    await this.adapter.createTemplate(this, page, `
     <ul class="container">
       <li>Text <span>Lorem</span></li>
       <li>Text <span>Ipsum</span><>li<
     <ul>
   `);
    assert.equal(page.collection.objectAt(0).spanText, 'Lorem');
    assert.equal(page.collection.objectAt(1).spanText, 'Ipsum');
  });
```

Besides unlocking the possibility to merge page objects (while accessing private members at ones own risk), which would allow users to only store page objects should they so wish, this PR removes a pitfall of page objects that I'm sure I wasn't the only one to run into. 

## Original Description
(since a lot of the subsequent conversation refers to these notions): This PR solves [#181](https://github.com/san650/ember-cli-page-object/issues/181) and enables page objects to be used directly within definitions as well as exposes an `extend` function to be used when creating new page objects from existing ones. The general idea was to store a sanitized version of the page object's definition within the page object itself in its Ceibo metadata. Sanitized in that if the definition contains page objects, it will replace the child page object with said object's definition before storing.

I'm happy to add documentation but wanted this approach to be finalized first.

An example of what's valid now:

```javascript
let keyboard = create({
  scope: '.keyboard',
  numbers: collection(".numbers button", {
    text: text(),
    click: clickable()
  })
});
let screenPage = create({
  value: value('.screen input'),
  fillValue: fillable('.screen input')
});
let page = create({
  visit: visitable('/calculator'),
  //extension
  keys: keyboard.extend({
    clickOn: clickOnText('.numbers'),
    sum: clickable('button', { scope: '.operators', at: 0 }),
    equal: clickable('button', { scope: '.operators', at: 2 })
  }),
   //composition
  screen: screenPage  
});
```