### PR TITLE
[doc] Rewrite Quickstart page

### DIFF
--- a/guides/quickstart.md
+++ b/guides/quickstart.md
@@ -110,13 +110,13 @@ And, the same result with chaining:
 
 For comprehensive testing of our application, we must rely on more than testing individual components in isolation (ie acceptance testing). We can map each "page" in our app (route + template) to a `page-object`, composing various `page-object-component`s together to form a complete representation of page.
 
-Let's take a look at how we might generate a page-object.
+Suppose we have a search page in our application. Let's generate a page-object for it.
 
 ```
-$ ember generate page-object my-page
+$ ember generate page-object search-page
 
 installing
-  create tests/pages/my-page.js
+  create tests/pages/search-page.js
 ```
 
 The generator created a file inside the directory `/tests/pages`. Using this directory allows us to more easily distinguish pages from components, which are located under `/tests/pages/components/`.
@@ -138,17 +138,19 @@ You also might have noticed that rather than exporting a plain definition, we ex
 
 We can include any number of nested components, attributes, or methods in the definition, just as we did for `page-object-component`s.
 
-Suppose we have a calculator on the page:
+Let's update the page object as follows:
 
 ```js
 // my-app/tests/pages/my-page.js
 import { create, visitable } from 'ember-cli-page-object';
-import Calculator from 'my-app/tests/pages/components/quickstart-calculator';
+import SearchForm from 'my-app/tests/pages/components/search-form';
 
 export default create({
   visit: visitable('/'),
 
-  calculator: Calculator
+  search: SearchForm,
+
+  results: collection('ol li article')
 });
 ```
 
@@ -158,11 +160,15 @@ A simple application test using a `page-object` might look like:
 // my-app/tests/acceptance/my-page-test.js
 import myPage from 'my-app/tests/pages/my-page';
 
-module('My Page', // ...
-  test('it renders a calculator', async function(assert) {
+module('Search Page', // ...
+  test('it works', async function(assert) {
     await myPage.visit();
 
-    assert.ok(myPage.calculator.isVisible);
+    await myPage.search.text.fillIn('some');
+    await myPage.search.submit();
+
+    assert.equal(myPage.results.length, 1);
+    assert.ok(myPage.results[0].contains('Awesome search result!'));
   })
 ```
 

--- a/guides/quickstart.md
+++ b/guides/quickstart.md
@@ -12,7 +12,7 @@ This is a short guide to get you started building powerful UI testing APIs using
 
 ## Basic Component
 
-The primary build block of page objects is a [component](./components). It consists of a [`scope`](./components#scopes), [`attributes`](./components#attributes), custom methods and nested components.
+The primary build block of page objects is a [component](./components). It consists of a [`scope`](./components#scopes), [`attributes`](./components#attributes), custom methods, and nested components.
 
 Assume there is a simple `<SearchForm />` component with a text field and a submit button on it.
 
@@ -25,7 +25,7 @@ __Example__
 </form>
 ```
 
-Let's generate a page object component definition for it with a help of corresponding generator:
+Let's generate a page object component definition for it with the help of the corresponding generator:
 
 ```bash
 $ ember generate page-object-component search-form
@@ -108,7 +108,7 @@ And, the same result with chaining:
 
 ## Pages
 
-For comprehensive testing of our application, we must rely on more than testing individual components in isolation (ie acceptance testing). We can map each "page" in our app (route + template) to a `page-object`, composing various `page-object-component`s together to form a complete representation of page.
+For comprehensive testing of our application, we must rely on more than testing individual components in isolation (ie acceptance testing). We can map each "page" in our app (route + template) to a `page-object`, composing various `page-object-component`s together to form a complete representation of the page.
 
 Suppose we have a search page in our application. Let's generate a page-object for it.
 
@@ -121,7 +121,7 @@ installing
 
 The generator created a file inside the directory `/tests/pages`. Using this directory allows us to more easily distinguish pages from components, which are located under `/tests/pages/components/`.
 
-A generated page output looks like the following:
+The generated page object looks like the following:
 
 ```js
 // my-app/tests/pages/my-page.js

--- a/guides/quickstart.md
+++ b/guides/quickstart.md
@@ -17,13 +17,22 @@ The primary build block of page objects is a [component](./components). It consi
 
 Let's [`create`](./api/create) a page object instance for a simple form:
 
+__Example__
+
+```html
+<form class="search-form">
+  <input type="search">
+  <button>Search</button>
+</form>
+```
+
 ```js
 import { create, triggerable } from 'ember-cli-page-object';
 
-const myForm = create({
-  scope: '.my-form',
+const searchForm = create({
+  scope: '.search-form',
 
-  datum: { scope: '[data-test-datum]' },
+  text: { scope: 'input[type="search"]' },
 
   submit: triggerable('submit')
 });
@@ -33,13 +42,13 @@ All the components are supplied with a set of [default attributes](./components#
 
 ```js
   test('it renders', async function(assert) {
-    await render(hbs`{{my-form value="initial value"}}`);
+    await render(hbs`{{search-form text="initial text"}}`);
 
-    // using the default `isVisible` attribute, checks that ".my-form" is displayed
-    assert.ok(myForm.isVisible);
+    // using the default `isVisible` attribute, checks that `.search-form` is displayed
+    assert.ok(searchForm.isVisible);
 
-    // using the default `value` attribute, check the input value of ".my-form [data-test-datum]"
-    assert.equal(myForm.datum.value, 'initial value');
+    // using the default `value` attribute, check the input value of `.search-form input[type=`search"]"
+    assert.equal(searchForm.text.value, 'initial text');
   });
 ```
 
@@ -47,17 +56,15 @@ All the action attributes are asynchronous:
 
 ```js
   test('using actions', async function(assert) {
-    let lastSaved;
-    this.save = (data) => lastSaved = data;
+    let lastSearched;
+    this.search = (text) => lastSearched = text;
 
-    await render(hbs`{{my-form onSave=(action save)}}`);
+    await render(hbs`{{search-form onSubmit=(action search)}}`);
 
-    await myForm.datum.fillIn('new value');
-    await myForm.submit();
+    await searchForm.datum.fillIn('new text');
+    await searchForm.submit();
 
-    assert.deepEqual(lastSaved, {
-      datum: 'new value'
-    })
+    assert.deepEqual(lastSearched,  'new text' )
   });
 ```
 
@@ -66,14 +73,14 @@ In addition, each action returns the invoked page object node, which allows for 
 For example. without chaining:
 
 ```js
-  await myForm.datum.fillIn('test')
-  await myForm.datum.blur()
+  await searchForm.text.fillIn('test')
+  await searchForm.text.blur()
 ```
 
 And, the same result with chaining:
 
 ```js
-  await myForm.datum
+  await searchForm.text
     .fillIn('test')
     .blur();
 ```

--- a/guides/quickstart.md
+++ b/guides/quickstart.md
@@ -11,9 +11,9 @@ This is a short guide to get you started building powerful UI testing APIs using
 - [Calculator](#calculator)
 - [Pages](#pages)
 
-## Basics
+## Components
 
-The primary build block of page objects is a [component](./components). It consists of a `scope`, attributes, methods and nested components.
+The primary build block of page objects is a [component](./components). It consists of a [`scope`](./components#scopes), [`attributes`](./components#attributes), methods and nested components.
 
 Let's [`create`](./api/create) a page object instance for a simple form:
 


### PR DESCRIPTION
Another attemp to refresh the guides. This time I've focused on the "Quickstart" page only.

In order to explain things I've leveraged a calculator idea which I find a great example of PO usage.

I expect there may be some clumsy turns of speech in the proposed document. Hints to improve are highly appreciated!

My next immediate plan is to refresh a components page, which promises not to be such a huge rewrite like this is.

Part of https://github.com/san650/ember-cli-page-object/issues/412
Partially replaces https://github.com/san650/ember-cli-page-object/pull/415