### PR TITLE
feat: add helper for setting a page object in an integration test

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -24,6 +24,7 @@ import { visitable }   from './properties/visitable';     export { visitable };
 export { findElement } from './extend/find-element';
 export { findElementWithAssert } from './extend/find-element-with-assert';
 export { buildSelector, getContext } from './-private/helpers';
+export { default as setupPage } from './setup-page';
 
 export default {
   attribute,

--- a/addon-test-support/setup-page.js
+++ b/addon-test-support/setup-page.js
@@ -1,0 +1,11 @@
+import { create } from './create';
+
+/**
+ * Sets up a reference to `this.page` with the correct context set
+ */
+export default function(hooks, pageDefinition) {
+  hooks.beforeEach(function() {
+    this.page = create(pageDefinition);
+    this.page.setContext(this);
+  });
+}

--- a/tests/integration/hooks-test.js
+++ b/tests/integration/hooks-test.js
@@ -1,54 +1,65 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import { createCalculatorTemplate } from './test-helper';
 
-import PageObject from 'ember-cli-page-object';
+import PageObject, { setupPage } from 'ember-cli-page-object';
 
 const page = PageObject.create({});
 
-let firstThis;
-let secondThis;
+module('Integration | hooks', function(hooks) {
+  setupRenderingTest(hooks);
 
-moduleForComponent('calculating-device', 'Integration | hooks', {
-  integration: true,
+  module('manually setting up a page', function(hooks) {
+    let firstThis;
+    let secondThis;
 
-  beforeEach() {
-    page.setContext(this);
+    hooks.beforeEach(function() {
+      page.setContext(this);
 
-    if (!firstThis) {
-      firstThis = page.context;
-    } else {
-      secondThis = page.context;
-    }
-  },
+      if (!firstThis) {
+        firstThis = page.context;
+      } else {
+        secondThis = page.context;
+      }
+    });
 
-  afterEach() {
-    page.removeContext();
-  }
-});
+    hooks.afterEach(function() {
+      page.removeContext();
+    });
 
-test('When set in the `beforeEach()` qunit hook, test\'s `this` context\'s methods are accessible to the page object', function(assert) {
-  assert.expect(5);
+    test('When set in the `beforeEach()` qunit hook, test\'s `this` context\'s methods are accessible to the page object', function(assert) {
+      assert.expect(5);
 
-  assert.ok(page.context);
-  assert.deepEqual(this, page.context);
-  assert.equal(page.context, firstThis);
+      assert.ok(page.context);
+      assert.deepEqual(this, page.context);
+      assert.equal(page.context, firstThis);
 
-  this.render(createCalculatorTemplate());
+      this.render(createCalculatorTemplate());
 
-  assert.ok(page.context.$());
-  assert.deepEqual(page.context.$(), this.$());
-});
+      assert.ok(page.context.$());
+      assert.deepEqual(page.context.$(), this.$());
+    });
 
-test('Setting the page\'s context in `beforeEach()` assigns the correct context in each test', function(assert) {
-  assert.expect(6);
+    test('Setting the page\'s context in `beforeEach()` assigns the correct context in each test', function(assert) {
+      assert.expect(6);
 
-  assert.ok(page.context);
-  assert.deepEqual(this, page.context);
-  assert.equal(page.context, secondThis);
-  assert.notEqual(page.context, firstThis);
+      assert.ok(page.context);
+      assert.deepEqual(this, page.context);
+      assert.equal(page.context, secondThis);
+      assert.notEqual(page.context, firstThis);
 
-  this.render(createCalculatorTemplate());
+      this.render(createCalculatorTemplate());
 
-  assert.ok(page.context.$());
-  assert.deepEqual(page.context.$(), this.$());
+      assert.ok(page.context.$());
+      assert.deepEqual(page.context.$(), this.$());
+    });
+  });
+
+  module('using the `setupPage` helper', function(hooks) {
+    setupPage(hooks, {});
+
+    test('it sets the context of the page object', function(assert) {
+      assert.equal(this.page.context, this);
+    })
+  });
 });


### PR DESCRIPTION
I've found myself using this helper in our codebase at work pretty frequently, and figured it might be useful to other people as well

The API is intended to mirror that of other QUnit helpers, where you pass the `hooks` object into the function to add setup/teardown logic.

This has been really helpful for cases where we have a page object for a component and want to use it within its integration tests as well as composing it into other page objects for acceptance tests.