### PR TITLE
explicitly remove ember-source from ember-try scenarios that rely on bower

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -19,6 +19,11 @@ module.exports = function() {
             resolutions: {
               'ember': 'lts-2-4'
             }
+          },
+          npm: {
+            devDependencies: {
+              'ember-source': null
+            }
           }
         },
         {
@@ -29,6 +34,11 @@ module.exports = function() {
             },
             resolutions: {
               'ember': 'lts-2-8'
+            }
+          },
+          npm: {
+            devDependencies: {
+              'ember-source': null
             }
           }
         },


### PR DESCRIPTION
I opened up [234](https://github.com/ember-cli/ember-try/issues/234) in `ember-try` when exploring addon-docs for this library. No one's answered me yet, so I don't know what the consensus on this behavior is, but I think in the meantime we should drop this into our scenarios to ensure that we are in fact testing what we think we are testing.

I've checked and other libraries that test against ember < 2.12 where you must use bower and they also use the `ember-try` option that explicitly removes a package. [ember-bootstrap](https://github.com/kaliber5/ember-bootstrap/blob/master/config/ember-try.js), [ember-qunit](https://github.com/emberjs/ember-qunit/blob/master/config/ember-try.js), [ember-cli-mirage](https://github.com/samselikoff/ember-cli-mirage/blob/master/config/ember-try.js) to name a few of the bigger ones. 