### PR TITLE
Extract run

### DIFF
--- a/addon-test-support/-private/action.js
+++ b/addon-test-support/-private/action.js
@@ -1,0 +1,97 @@
+import { resolve } from 'rsvp';
+import { getExecutionContext } from './execution_context';
+import { getRoot } from './helpers';
+import Ceibo from 'ceibo';
+
+/**
+ * Run action
+ *
+ * @param {Ceibo} node Page object node to run action on
+ * @param {Function} cb Some async activity callback
+ * @returns {Ceibo}
+ */
+export function run(node, cb) {
+  const adapter = getExecutionContext(node);
+  const chainedRoot = getRoot(node)._chainedTree;
+
+  if (typeof adapter.andThen === 'function') {
+    // With old ember-testing helpers, we don't make the difference between
+    // chanined VS independent action invocations. Awaiting for the previous
+    // action settlement, before invoke a new action, is a part of
+    // the legacy testing helpers adapters for backward compat reasons
+    chainedRoot._promise = adapter.andThen(cb);
+
+    return node;
+  } else if (!chainedRoot) {
+    // Our root is already the root of the chained tree,
+    // we need to wait on its promise if it has one so the
+    // previous invocations can resolve before we run ours.
+    let root = getRoot(node)
+    root._promise = resolve(root._promise).then(() => cb(adapter));
+
+    return node;
+  } else {
+    // Store our invocation result on the chained root
+    // so that chained calls can find it to wait on it.
+    chainedRoot._promise = cb(adapter);
+
+    return chainable(node);
+  }
+}
+
+export function chainable(branch) {
+  if (isChainedNode(branch)) {
+    return branch;
+  }
+
+  // See explanation in `create.js` -- here instead of returning the node on
+  // which our method was invoked, we find and return our node's mirror in the
+  // chained tree so calls to it can be recognized as chained calls, and
+  // trigger the chained-call waiting behavior.
+
+  // Collecting node keys to build a path to our node, and then use that
+  // to walk back down the chained tree to our mirror node.
+  let path = [];
+  let node;
+
+  for (node = branch; node; node = Ceibo.parent(node)) {
+    path.unshift(Ceibo.meta(node).key);
+  }
+  // The path will end with the root's key, 'root', so shift that back off
+  path.shift();
+
+  node = getRoot(branch)._chainedTree;
+  path.forEach((key) => {
+    node = getChildNode(node, key)
+  });
+
+  return node;
+}
+
+function isChainedNode(node) {
+  let root = getRoot(node);
+
+  return !root._chainedTree;
+}
+
+function getChildNode(node, key) {
+  // Normally an item's key is just its property name, but collection
+  // items' keys also include their index. Collection item keys look like
+  // `foo[2]` and legacy collection item keys look like `foo(2)`.
+  let match;
+  if ((match = /\[(\d+)\]$/.exec(key))) {
+    // This is a collection item
+    let [ indexStr, index ] = match;
+    let name = key.slice(0, -indexStr.length);
+
+    return node[name].objectAt(parseInt(index, 10));
+  } else if ((match = /\((\d+)\)$/.exec(key))) {
+    // This is a legacy collection item
+    let [ indexStr, index ] = match;
+    let name = key.slice(0, -indexStr.length);
+
+    return node[name](parseInt(index, 10));
+  } else {
+    return node[key];
+  }
+}

--- a/addon-test-support/-private/dsl.js
+++ b/addon-test-support/-private/dsl.js
@@ -12,20 +12,14 @@ import { text } from '../properties/text';
 import { value } from '../properties/value';
 
 import { getRoot } from './helpers';
-import { wait } from './compatibility';
 
 const thenDescriptor = {
   isDescriptor: true,
   value() {
-    // In RFC268 tests, we need to wait on the promise returned from the actual
-    // test helper, rather than a global method such as `wait`. So, we store the
-    // promise on the root of the (chained) tree so we can find it here and use
-    // it.
-    let promise = getRoot(this)._promise;
-    if (!promise) {
-      promise = (window.wait || wait)();
-    }
-    return promise.then(...arguments);
+    const root = getRoot(this);
+    const chainedRoot = root._chainedTree || root;
+
+    return chainedRoot._promise.then(...arguments);
   }
 };
 

--- a/addon-test-support/-private/execution_context/acceptance-native-events.js
+++ b/addon-test-support/-private/execution_context/acceptance-native-events.js
@@ -1,9 +1,6 @@
+import { visit } from 'ember-native-dom-helpers';
 import ExecutionContext from './native-events-context';
 import { wait } from '../compatibility';
-
-import {
-  visit
-} from 'ember-native-dom-helpers';
 
 export default function AcceptanceNativeEventsExecutionContext(pageObjectNode) {
   ExecutionContext.call(this, pageObjectNode);
@@ -13,13 +10,10 @@ AcceptanceNativeEventsExecutionContext.prototype = Object.create(ExecutionContex
 
 AcceptanceNativeEventsExecutionContext.prototype.visit = function() {
   visit(...arguments);
-  return this.pageObjectNode;
 };
 
-AcceptanceNativeEventsExecutionContext.prototype.runAsync = function(cb) {
-  (window.wait || wait)().then(() => {
+AcceptanceNativeEventsExecutionContext.prototype.andThen = function(cb) {
+  return (window.wait || wait)().then(() => {
     cb(this);
   });
-
-  return this.chainable();
-};
+}

--- a/addon-test-support/-private/execution_context/acceptance.js
+++ b/addon-test-support/-private/execution_context/acceptance.js
@@ -1,3 +1,4 @@
+import { run } from '../action';
 import {
   guardMultiple,
   buildSelector,
@@ -17,16 +18,14 @@ export default function AcceptanceExecutionContext(pageObjectNode) {
 }
 
 AcceptanceExecutionContext.prototype = {
-  runAsync(cb) {
-    window.wait().then(() => {
+  andThen(cb) {
+    return window.wait().then(() => {
       cb(this);
     });
-
-    return this.chainable();
   },
 
-  chainable() {
-    return this.pageObjectNode;
+  runAsync(cb) {
+    return run(this.pageObjectNode, cb);
   },
 
   visit(path) {

--- a/addon-test-support/-private/execution_context/integration-native-events.js
+++ b/addon-test-support/-private/execution_context/integration-native-events.js
@@ -1,5 +1,6 @@
 import { run } from '@ember/runloop';
 import ExecutionContext from './native-events-context';
+import wait from 'ember-test-helpers/wait';
 
 export default function IntegrationNativeEventsExecutionContext(pageObjectNode, testContext) {
   ExecutionContext.call(this, pageObjectNode, testContext);
@@ -9,10 +10,10 @@ IntegrationNativeEventsExecutionContext.prototype = Object.create(ExecutionConte
 
 IntegrationNativeEventsExecutionContext.prototype.visit = function() {};
 
-IntegrationNativeEventsExecutionContext.prototype.runAsync = function(cb) {
+IntegrationNativeEventsExecutionContext.prototype.andThen = function(cb) {
   run(() => {
     cb(this);
   });
 
-  return this.chainable();
+  return wait();
 };

--- a/addon-test-support/-private/execution_context/integration.js
+++ b/addon-test-support/-private/execution_context/integration.js
@@ -1,5 +1,6 @@
 import $ from '-jquery';
 import { run } from '@ember/runloop';
+import { run as runAction } from '../action';
 import {
   guardMultiple,
   buildSelector,
@@ -13,6 +14,7 @@ import {
   ELEMENT_NOT_FOUND,
   throwBetterError
 } from '../better-errors';
+import wait from 'ember-test-helpers/wait';
 
 export default function IntegrationExecutionContext(pageObjectNode, testContext) {
   this.pageObjectNode = pageObjectNode;
@@ -20,16 +22,16 @@ export default function IntegrationExecutionContext(pageObjectNode, testContext)
 }
 
 IntegrationExecutionContext.prototype = {
-  runAsync(cb) {
+  andThen(cb) {
     run(() => {
-      cb(this);
+      cb(this)
     });
 
-    return this.chainable();
+    return wait();
   },
 
-  chainable() {
-    return this.pageObjectNode;
+  runAsync(cb) {
+    return runAction(this.pageObjectNode, cb);
   },
 
   visit() {},

--- a/addon-test-support/-private/execution_context/native-events-context.js
+++ b/addon-test-support/-private/execution_context/native-events-context.js
@@ -8,6 +8,7 @@ import {
   blur
 } from 'ember-native-dom-helpers';
 
+import { run } from '../action';
 import {
   guardMultiple,
   buildSelector,
@@ -30,12 +31,8 @@ export default function ExecutionContext(pageObjectNode, testContext) {
 }
 
 ExecutionContext.prototype = {
-  runAsync() {
-    throw new Error('not implemented');
-  },
-
-  chainable() {
-    return this.pageObjectNode;
+  runAsync(cb) {
+    return run(this.pageObjectNode, cb);
   },
 
   click(selector, container) {

--- a/addon-test-support/-private/execution_context/rfc268.js
+++ b/addon-test-support/-private/execution_context/rfc268.js
@@ -1,10 +1,9 @@
 import $ from '-jquery';
-import { resolve } from 'rsvp';
+import { run } from '../action';
 import {
   guardMultiple,
   buildSelector,
   findClosestValue,
-  getRoot
 } from '../helpers';
 import {
   getRootElement,
@@ -20,7 +19,6 @@ import {
   ELEMENT_NOT_FOUND,
   throwBetterError
 } from '../better-errors';
-import Ceibo from 'ceibo';
 
 export default function ExecutionContext(pageObjectNode) {
   this.pageObjectNode = pageObjectNode;
@@ -28,70 +26,7 @@ export default function ExecutionContext(pageObjectNode) {
 
 ExecutionContext.prototype = {
   runAsync(cb) {
-    let root = getRoot(this.pageObjectNode);
-    let isChained = !root._chainedTree;
-
-    if (isChained) {
-      // Already chained, so our root is the root of the chained tree, and we
-      // need to wait on its promise if it has one so the previous call can
-      // resolve before we run ours.
-      root._promise = resolve(root._promise).then(() => cb(this));
-    } else {
-      // Not a chained call, so store our method's return on the chained root
-      // so that chained calls can find it to wait on it.
-      root._chainedTree._promise = cb(this);
-    }
-
-    return this.chainable();
-  },
-
-  chainable() {
-    // See explanation in `create.js` -- here instead of returning the node on
-    // which our method was invoked, we find and return our node's mirror in the
-    // chained tree so calls to it can be recognized as chained calls, and
-    // trigger the chained-call waiting behavior.
-    let root = getRoot(this.pageObjectNode);
-    let isChained = !root._chainedTree;
-
-    if (isChained) {
-      // Already chained, so our node is in the chained tree
-      return this.pageObjectNode;
-    } else {
-      // Not already chained, so we need to look up our equivalent node in the
-      // chained tree and return that. We do it by walking up the tree
-      // collecting node keys to build a path to our node, and then use that
-      // to walk back down the chained tree to our mirror node.
-      let path = [];
-      let node;
-
-      for (node = this.pageObjectNode; node; node = Ceibo.parent(node)) {
-        path.unshift(Ceibo.meta(node).key);
-      }
-      // The path will end with the root's key, 'root', so shift that back off
-      path.shift();
-
-      node = root._chainedTree;
-      path.forEach((key) => {
-        // Normally an item's key is just its property name, but collection
-        // items' keys also include their index. Collection item keys look like
-        // `foo[2]` and legacy collection item keys look like `foo(2)`.
-        let match;
-        if ((match = /\[(\d+)\]$/.exec(key))) {
-          // This is a collection item
-          let [ indexStr, index ] = match;
-          let name = key.slice(0, -indexStr.length);
-          node = node[name].objectAt(parseInt(index, 10));
-        } else if ((match = /\((\d+)\)$/.exec(key))) {
-          // This is a legacy collection item
-          let [ indexStr, index ] = match;
-          let name = key.slice(0, -indexStr.length);
-          node = node[name](parseInt(index, 10));
-        } else {
-          node = node[key];
-        }
-      });
-      return node;
-    }
+    return run(this.pageObjectNode, cb);
   },
 
   visit(path) {

--- a/addon-test-support/macros/alias.js
+++ b/addon-test-support/macros/alias.js
@@ -3,7 +3,8 @@ import {
   getProperty,
   objectHasProperty
 } from '../-private/helpers';
-import { getExecutionContext } from '../-private/execution_context';
+import { chainable } from '../-private/action'
+import { getExecutionContext } from '../-private/execution_context'
 
 const ALIASED_PROP_NOT_FOUND = 'PageObject does not contain aliased property';
 
@@ -97,7 +98,10 @@ export function alias(pathToProp, options = {}) {
         // to a property on a child node, then the return value would be that
         // child node rather than this node.
         value(...args);
-        return getExecutionContext(this).chainable();
+
+        return (typeof getExecutionContext(this).andThen === 'function')
+          ? this
+          : chainable(this);
       };
     }
   };

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "ember-load-initializers": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-maybe-import-regenerator-for-testing": "^1.0.0",
-    "ember-qunit": "^3.4.1",
+    "ember-qunit": "^4.5.1",
     "ember-qunit-assert-helpers": "^0.2.1",
     "ember-qunit-nice-errors": "^1.1.2",
     "ember-qunit-source-map": "1.1.0",

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,1 +1,3 @@
 {{outlet}}
+
+{{test-component}}

--- a/tests/integration/deprecations/comma-separated-selector-test.js
+++ b/tests/integration/deprecations/comma-separated-selector-test.js
@@ -13,7 +13,6 @@ if (require.has('@ember/test-helpers')) {
 
     test('usage of comma-separated selector in the scope leads to a deprecation', async function(assert) {
       let page = create({
-        context: this,
         scope: '.A, .B'
       });
 
@@ -26,7 +25,6 @@ if (require.has('@ember/test-helpers')) {
 
     test('usage of comma-separated selector in the property leads to a deprecation', async function(assert) {
       let page = create({
-        context: this,
         text: text('.A, .B')
       });
 
@@ -39,7 +37,6 @@ if (require.has('@ember/test-helpers')) {
 
     test('usage of comma-separated selector in the property\'s custom scope leads to a deprecation', async function(assert) {
       let page = create({
-        context: this,
         text: text('.root', {
           scope: '.A, .B'
         })
@@ -56,7 +53,6 @@ if (require.has('@ember/test-helpers')) {
 
     test('don\'t show deprecation when selector doesn\'t use comma-separated selectors', async function(assert) {
       let page = create({
-        context: this,
         scope: '.root',
         propText: text('.A', {
           scope: '.B'

--- a/tests/unit/-private/execution_context/acceptance-test.js
+++ b/tests/unit/-private/execution_context/acceptance-test.js
@@ -1,0 +1,76 @@
+import { test } from 'ember-qunit';
+import moduleForAcceptance from 'dummy/tests/helpers/module-for-acceptance';
+import { create, visitable } from 'ember-cli-page-object'
+import { createClickTrackerComponent, ClickTrackerDef } from './helpers';
+
+const node = create(
+  Object.assign({}, ClickTrackerDef, {
+    visit: visitable('/')
+  })
+);
+
+moduleForAcceptance('Acceptance | acceptance context | actions', {
+  beforeEach(assert) {
+    this.application.register(
+      'component:test-component',
+      createClickTrackerComponent(assert)
+    );
+
+    return node.visit();
+  }
+});
+
+test('async invocations', async function(assert) {
+  await node.click()
+  await node.click();
+
+  assert.verifySteps([
+    'begin #0',
+    'complete #0',
+    'begin #1',
+    'complete #1'
+  ])
+});
+
+test('sync invocations', async function(assert) {
+  node.click()
+  node.click();
+
+  return window.andThen(() => {
+    assert.verifySteps([
+      'begin #0',
+      'complete #0',
+      'begin #1',
+      'complete #1'
+    ])
+  });
+});
+
+test('sync chained invocations', async function(assert) {
+  node.click()
+    .click();
+
+  return window.andThen(() => {
+    assert.verifySteps([
+      'begin #0',
+      'complete #0',
+      'begin #1',
+      'complete #1',
+    ])
+  })
+});
+
+test('async chained invocations', async function(assert) {
+  await node.click()
+    .click();
+
+  return window.andThen(() => {
+    assert.verifySteps([
+      'begin #0',
+      'complete #0',
+      'begin #1',
+      'complete #1'
+    ])
+  })
+});
+

--- a/tests/unit/-private/execution_context/helpers.js
+++ b/tests/unit/-private/execution_context/helpers.js
@@ -1,0 +1,37 @@
+import Component from '@ember/component';
+import { later } from '@ember/runloop';
+import hbs from 'htmlbars-inline-precompile';
+
+function spyAction(assert) {
+  let i = 0;
+
+  return () => {
+    let id = i++;
+
+    assert.step(`begin #${id}`);
+
+    return later(() => {
+      assert.step(`complete #${id}`);
+    }, 10)
+  };
+}
+
+export function createClickTrackerComponent(assert) {
+  const trackAction = spyAction(assert);
+
+  const layout = hbs`<input onclick={{action "trackAction"}}>`
+
+  return Component.extend({
+    layout,
+
+    actions: {
+      trackAction() {
+        return trackAction();
+      }
+    }
+  });
+}
+
+export const ClickTrackerDef = {
+  scope: 'input'
+};

--- a/tests/unit/-private/execution_context/integration-native-test.js
+++ b/tests/unit/-private/execution_context/integration-native-test.js
@@ -1,0 +1,83 @@
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+import { moduleForComponent, test } from 'ember-qunit';
+import wait from 'ember-test-helpers/wait';
+import { create } from 'ember-cli-page-object'
+import { useNativeEvents } from 'ember-cli-page-object/extend'
+import { createClickTrackerComponent, ClickTrackerDef } from './helpers';
+
+const node = create(ClickTrackerDef);
+
+if (Ember.hasOwnProperty('$')) {
+  moduleForComponent('', 'Integration | integration context | actions [native-events]', {
+    integration: true,
+
+    beforeEach(assert) {
+      this.register('component:action-tracker', createClickTrackerComponent(assert))
+
+      node.setContext(this);
+
+      this.render(hbs`{{action-tracker}}`);
+    },
+
+    afterEach() {
+      node.removeContext();
+
+      useNativeEvents(false);
+    }
+  });
+
+  test('async invocations', async function(assert) {
+    await node.click()
+    await node.click();
+
+    assert.verifySteps([
+      'begin #0',
+      'complete #0',
+      'begin #1',
+      'complete #1'
+    ])
+  });
+
+  test('sync invocations', async function(assert) {
+    node.click()
+    node.click();
+
+    return wait().then(() => {
+      assert.verifySteps([
+        'begin #0',
+        'begin #1',
+        'complete #0',
+        'complete #1'
+      ])
+    });
+  });
+
+  test('chained sync invocations', async function(assert) {
+    node.click()
+      .click();
+
+    return wait().then(() => {
+      assert.verifySteps([
+        'begin #0',
+        'begin #1',
+        'complete #0',
+        'complete #1',
+      ])
+    })
+  });
+
+  test('async chained invocations', async function(assert) {
+    await node.click()
+      .click();
+
+    return wait().then(() => {
+      assert.verifySteps([
+        'begin #0',
+        'begin #1',
+        'complete #0',
+        'complete #1'
+      ])
+    })
+  });
+}

--- a/tests/unit/-private/execution_context/integration-test.js
+++ b/tests/unit/-private/execution_context/integration-test.js
@@ -1,0 +1,80 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import wait from 'ember-test-helpers/wait';
+import { create } from 'ember-cli-page-object'
+import hbs from 'htmlbars-inline-precompile';
+import { createClickTrackerComponent, ClickTrackerDef } from './helpers';
+
+if (Ember.hasOwnProperty('$')) {
+  const node = create(ClickTrackerDef);
+
+  moduleForComponent('', 'Integration | integration context | actions', {
+    integration: true,
+
+    beforeEach(assert) {
+      this.register('component:action-tracker', createClickTrackerComponent(assert))
+
+      node.setContext(this);
+
+      this.render(hbs`{{action-tracker}}`);
+    },
+
+    afterEach() {
+      node.removeContext();
+    }
+  });
+
+  test('async invocations', async function(assert) {
+    await node.click()
+    await node.click();
+
+    assert.verifySteps([
+      'begin #0',
+      'complete #0',
+      'begin #1',
+      'complete #1'
+    ])
+  });
+
+  test('sync invocations', async function(assert) {
+    node.click()
+    node.click();
+
+    return wait().then(() => {
+      assert.verifySteps([
+        'begin #0',
+        'begin #1',
+        'complete #0',
+        'complete #1'
+      ])
+    });
+  });
+
+  test('sync chained invocations', async function(assert) {
+    node.click()
+      .click();
+
+    return wait().then(() => {
+      assert.verifySteps([
+        'begin #0',
+        'begin #1',
+        'complete #0',
+        'complete #1',
+      ])
+    })
+  });
+
+  test('async chained invocations', async function(assert) {
+    await node.click()
+      .click();
+
+    return wait().then(() => {
+      assert.verifySteps([
+        'begin #0',
+        'begin #1',
+        'complete #0',
+        'complete #1'
+      ])
+    })
+  });
+}

--- a/tests/unit/-private/execution_context/rfc268-test.js
+++ b/tests/unit/-private/execution_context/rfc268-test.js
@@ -1,0 +1,74 @@
+import require from 'require';
+import { test, module } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { create } from 'ember-cli-page-object'
+import { createClickTrackerComponent, ClickTrackerDef } from './helpers';
+
+const node = create(ClickTrackerDef);
+
+if (require.has('@ember/test-helpers')) {
+  const { render, settled } = require('@ember/test-helpers');
+
+  module('Integration | rfc268 context | actions', function(hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function(assert) {
+      this.owner.register('component:action-tracker', createClickTrackerComponent(assert))
+
+      return render(hbs`{{action-tracker}}`);
+    })
+
+    test('sync invocations', async function(assert) {
+      node.click()
+      await node.click();
+
+      await settled();
+
+      assert.verifySteps([
+        'begin #0',
+        'begin #1',
+        'complete #0',
+        'complete #1'
+      ])
+    });
+
+    test('async invocations', async function(assert) {
+      await node.click()
+      await node.click();
+
+      assert.verifySteps([
+        'begin #0',
+        'complete #0',
+        'begin #1',
+        'complete #1'
+      ])
+    });
+
+    test('async chained invocations', async function(assert) {
+      await node.click().click();
+
+      assert.verifySteps([
+        'begin #0',
+        'complete #0',
+        'begin #1',
+        'complete #1'
+      ])
+    });
+
+    test('sync chained invocations', async function(assert) {
+      node.click().click();
+
+      await settled();
+      await settled();
+      await settled();
+
+      assert.verifySteps([
+        'begin #0',
+        'complete #0',
+        'begin #1',
+        'complete #1',
+      ])
+    });
+  });
+}


### PR DESCRIPTION
An original motivation for this change was a desire to learn of how do actions+chaining work here per each context. As a result knowledge about about chainability was extracted from execution contexts was extracted to a standalone `run` function. 

For the sake of keeping a backward compatibility in legacy contexts(moduleFor) a new `andThen` hook was added. For contexts that have `andThen`, `run` waiting for the previous action to be completed before invoking a new one. I believe we should remove `andThen` in the next major release.