### PR TITLE
Deprecate setContext

### DIFF
--- a/addon-test-support/-private/context.js
+++ b/addon-test-support/-private/context.js
@@ -54,6 +54,12 @@ export function render(template) {
  * @return {PageObject} - the page object
  */
 export function setContext(context) {
+  deprecate('setContext() is deprecated. Please make sure you use "@ember/test-helpers" of v1 or higher.', false, {
+    id: 'ember-cli-page-object.set-context',
+    until: '2.0.0',
+    url: 'https://ember-cli-page-object.js.org/docs/v1.16.x/deprecations/#set-context',
+  });
+
   if (context) {
     this.context = context;
   }

--- a/addon-test-support/-private/execution_context.js
+++ b/addon-test-support/-private/execution_context.js
@@ -1,5 +1,5 @@
 import { getContext as getIntegrationTestContext } from './helpers';
-import { getContext, visit } from './compatibility';
+import { getContext as getEmberTestHelpersContext, visit } from './compatibility';
 import AcceptanceExecutionContext from './execution_context/acceptance';
 import IntegrationExecutionContext from './execution_context/integration';
 import Rfc268Context from './execution_context/rfc268';
@@ -28,13 +28,24 @@ export function getExecutionContext(pageObjectNode) {
   let contextName;
   if (integrationTestContext) {
     contextName = 'integration';
+  } else if (isAcceptanceTest()) {
+    contextName = 'acceptance';
   } else if (isRfc268Test()) {
     contextName = 'rfc268';
-  } else {
-    contextName = 'acceptance';
+  }
+
+  if (!contextName) {
+    throw new Error('Can not detect test type. Please make sure you use the latest version of "@ember/test-helpers".');
   }
 
   return new executioncontexts[contextName](pageObjectNode, integrationTestContext);
+}
+
+/**
+ * @private
+ */
+function isAcceptanceTest() {
+  return window.visit && window.andThen;
 }
 
 /**
@@ -53,7 +64,7 @@ export function isRfc268Test() {
   // Note that if `page.setContext(this)` has been called, we'll never get here
   // and will just be running with the integration context (even if the test is
   // an RFC268 test).
-  let hasValidTestContext = Boolean(getContext());
+  let hasValidTestContext = Boolean(getEmberTestHelpersContext());
   if (!hasValidTestContext) {
     return false;
   }

--- a/addon-test-support/-private/execution_context.js
+++ b/addon-test-support/-private/execution_context.js
@@ -30,7 +30,7 @@ export function getExecutionContext(pageObjectNode) {
     contextName = 'integration';
   } else if (isAcceptanceTest()) {
     contextName = 'acceptance';
-  } else if (isRfc268Test()) {
+  } else if (supportsRfc268()) {
     contextName = 'rfc268';
   }
 
@@ -51,7 +51,7 @@ function isAcceptanceTest() {
 /**
  * @private
  */
-export function isRfc268Test() {
+export function supportsRfc268() {
   // `getContext()` returns:
   //  - falsey, if @ember/test-helpers is not available (stubbed in
   //    compatibility.js)

--- a/addon-test-support/-private/helpers.js
+++ b/addon-test-support/-private/helpers.js
@@ -5,6 +5,7 @@ import { get } from '@ember/object';
 import { isPresent } from '@ember/utils';
 import Ceibo from 'ceibo';
 import { deprecate } from '@ember/application/deprecations';
+import { getContext as getEmberTestHelpersContext } from './compatibility';
 
 import $ from '-jquery';
 
@@ -196,20 +197,25 @@ export function getRoot(node) {
 /**
  * @public
  *
- * Return a test context if one was provided during `create()`
+ * Return a test context if one was provided during `create()` or via `setContext()`
  *
  * @param {Ceibo} node - Node of the tree
- * @return {?Object} The test's `this` context, or null
+ * @return {Object} `moduleForComponent` test's `this` context, or null
  */
 export function getContext(node) {
   let root = getRoot(node);
   let { context } = root;
 
-  if (typeof context === 'object' && typeof context.$ === 'function') {
+  if (typeof context === 'object' && context !== null && typeof context.$ === 'function') {
     return context;
-  } else {
-    return null;
   }
+
+  context = getEmberTestHelpersContext();
+  if (typeof context === 'object' && context !== null && typeof context.$ === 'function' && !context.element) {
+    return context
+  }
+
+  return null;
 }
 
 function getAllValuesForProperty(node, property) {

--- a/addon-test-support/create.js
+++ b/addon-test-support/create.js
@@ -46,9 +46,9 @@ import dsl from './-private/dsl';
 function buildObject(node, blueprintKey, blueprint, defaultBuilder) {
   let definition;
 
-  // to allow page objects to exist in definitions, we store the definition that 
+  // to allow page objects to exist in definitions, we store the definition that
   // created the page object, allowing us to substitute a page object with its
-  // definition during creation 
+  // definition during creation
   if (isPageObject(blueprint)) {
     definition = getPageObjectDefinition(blueprint);
   } else {
@@ -65,7 +65,7 @@ function buildObject(node, blueprintKey, blueprint, defaultBuilder) {
 
   // persist definition once we have an instance
   storePageObjectDefinition(instance, blueprintToStore);
-  
+
   return [ instance, blueprintToApply ];
 }
 
@@ -206,7 +206,9 @@ export function create(definitionOrUrl, definitionOrOptions, optionsOrNothing) {
     page.setContext = setContext;
     page.removeContext = removeContext;
 
-    page.setContext(context);
+    if (typeof context !== 'undefined') {
+      page.setContext(context);
+    }
   }
 
   return page;

--- a/guides/deprecations.md
+++ b/guides/deprecations.md
@@ -5,6 +5,27 @@ title: Deprecations
 
 This is a list of deprecations introduced in 1.x cycle:
 
+## Set context
+
+**ID**: ember-cli-page-object.set-context
+
+**Until**: 2.0.0
+
+With "@ember@test-helpers@1.0.0" or higher you don't need to set page object context anymore, it would be handled for you:
+
+Bad:
+
+```js
+  page.setContext(this);
+  page.removeContext(this);
+
+  const page = create({
+    context: this
+  });
+```
+
+Good: Make sure you are using the most recent version of "@ember/test-helpers" and remove setting of context from your test suite.
+
 ## Comma-separated Selectors
 
 **ID**: ember-cli-page-object.comma-separated-selectors

--- a/tests/helpers/properties/integration-adapter.js
+++ b/tests/helpers/properties/integration-adapter.js
@@ -3,6 +3,7 @@ import $ from '-jquery';
 export { moduleForComponent as moduleForIntegration, test as testForIntegration } from 'ember-qunit';
 import expectEmberError from '../../expect-ember-error';
 import hbs from 'htmlbars-inline-precompile';
+import { supportsRfc268 } from 'ember-cli-page-object/test-support/-private/execution_context';
 
 export function IntegrationAdapter(context) {
   this.context = context;
@@ -31,7 +32,9 @@ IntegrationAdapter.prototype = {
       test.set('raw', template);
     }
 
-    page.setContext(test);
+    if (!supportsRfc268()) {
+      page.setContext(test);
+    }
 
     this.context.render(hbs`{{html-render html=raw}}`);
   },

--- a/tests/integration/deprecations/legacy-collection-test.js
+++ b/tests/integration/deprecations/legacy-collection-test.js
@@ -1,38 +1,42 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'ember-qunit';
+import { setupTest } from 'ember-qunit';
 
 import { create, collection } from 'ember-cli-page-object';
 
-moduleForComponent('calculating-device', 'Deprecation | legacy collection', {
-  integration: true
-});
+import require from 'require';
+if (require.has('@ember/test-helpers')) {
+  module('Deprecation | legacy collection', function(hooks) {
+    setupTest(hooks);
 
-test('shows deprecation warning when first parameter is not a string', function(assert) {
-  let page = create({
-    foo: collection({
-      itemScope: 'li'
-    })
-  });
+    test('shows deprecation warning when first parameter is not a string', function(assert) {
+      let page = create({
+        foo: collection({
+          itemScope: 'li'
+        })
+      });
 
-  page.foo();
+      page.foo();
 
-  assert.expectDeprecation('You are currently using the legacy collection API, check the documentation to see how to upgrade to the new API.');
-});
-
-test("doesn't show a deprecation warning when first parameter is a string", function(assert) {
-  let page = create({
-    foo: collection('foo')
-  });
-
-  page.foo;
-
-  assert.expectNoDeprecation();
-});
-
-test('shows a warning on invalid legacy collection definitions', function(assert) {
-  assert.expectWarning(function() {
-    create({
-      foo: collection({
-      })
+      assert.expectDeprecation('You are currently using the legacy collection API, check the documentation to see how to upgrade to the new API.');
     });
-  }, 'Legacy page object collection definition is invalid. Please, make sure you include a `itemScope` selector.');
-});
+
+    test("doesn't show a deprecation warning when first parameter is a string", function(assert) {
+      let page = create({
+        foo: collection('foo')
+      });
+
+      page.foo;
+
+      assert.expectNoDeprecation();
+    });
+
+    test('shows a warning on invalid legacy collection definitions', function(assert) {
+      assert.expectWarning(function() {
+        create({
+          foo: collection({
+          })
+        });
+      }, 'Legacy page object collection definition is invalid. Please, make sure you include a `itemScope` selector.');
+    });
+  });
+}

--- a/tests/integration/deprecations/set-context-test.js
+++ b/tests/integration/deprecations/set-context-test.js
@@ -1,0 +1,23 @@
+import { module, test } from 'qunit';
+import { create } from 'ember-cli-page-object';
+import require from 'require';
+
+if (require.has('@ember/test-helpers')) {
+  const DEPRECATION_MESSAGE = 'setContext() is deprecated. Please make sure you use "@ember/test-helpers" of v1 or higher.';
+
+  module('Deprecation | setContext', function() {
+    test('passing page context to create is deprecated', function(assert) {
+      this.page = create().setContext(this);
+
+      assert.expectDeprecation(DEPRECATION_MESSAGE)
+    });
+
+    test('passing page context to create is deprecated', function(assert) {
+      this.page = create({
+        context: this
+      });
+
+      assert.expectDeprecation(DEPRECATION_MESSAGE)
+    });
+  });
+}

--- a/tests/unit/-private/execution_context/rfc268-test.js
+++ b/tests/unit/-private/execution_context/rfc268-test.js
@@ -1,6 +1,6 @@
 import require from 'require';
 import { test, module } from 'qunit';
-import { setupRenderingTest, setupTest } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { create } from 'ember-cli-page-object'
 import { createClickTrackerComponent, ClickTrackerDef } from './helpers';
@@ -10,97 +10,65 @@ const node = create(ClickTrackerDef);
 if (require.has('@ember/test-helpers')) {
   const { render, settled } = require('@ember/test-helpers');
 
-  module('Integration | rfc268 context', function() {
-    module('getExecutionContext', function(hooks) {
-      setupTest(hooks);
+  module('Integration | rfc268 context | actions', function(hooks) {
+    setupRenderingTest(hooks);
 
-      let origGetContext;
-      let compatModule;
+    hooks.beforeEach(function(assert) {
+      this.owner.register('component:action-tracker', createClickTrackerComponent(assert))
 
-      hooks.beforeEach(function() {
-        compatModule = require('ember-cli-page-object/test-support/-private/compatibility');
-        origGetContext = compatModule.getContext;
-      });
+      return render(hbs`{{action-tracker}}`);
+    })
 
-      hooks.afterEach(function() {
-        compatModule.getContext = origGetContext;
+    test('sync invocations', async function(assert) {
+      node.click()
+      await node.click();
 
-        // Make sure we don't leave this module in a mutated state
-        window.require.unsee('ember-cli-page-object/test-support/-private/execution_context');
-      });
+      await settled();
 
-      test(`fails if can't be used as a fallback context`, async function(assert) {
-        compatModule.getContext = () => null
-
-        const a = create();
-
-        assert.throws(
-          () => a.isVisible,
-          'Can not detect test type. Please make sure you use the latest version of "@ember/test-helpers"'
-        );
-      });
+      assert.verifySteps([
+        'begin #0',
+        'begin #1',
+        'complete #0',
+        'complete #1'
+      ])
     });
 
-    module('actions', function(hooks) {
-      setupRenderingTest(hooks);
+    test('async invocations', async function(assert) {
+      await node.click()
+      await node.click();
 
-      hooks.beforeEach(function(assert) {
-        this.owner.register('component:action-tracker', createClickTrackerComponent(assert))
+      assert.verifySteps([
+        'begin #0',
+        'complete #0',
+        'begin #1',
+        'complete #1'
+      ])
+    });
 
-        return render(hbs`{{action-tracker}}`);
-      })
+    test('async chained invocations', async function(assert) {
+      await node.click().click();
 
-      test('sync invocations', async function(assert) {
-        node.click()
-        await node.click();
+      assert.verifySteps([
+        'begin #0',
+        'complete #0',
+        'begin #1',
+        'complete #1'
+      ])
+    });
 
-        await settled();
+    test('sync chained invocations', async function(assert) {
+      node.click().click();
 
-        assert.verifySteps([
-          'begin #0',
-          'begin #1',
-          'complete #0',
-          'complete #1'
-        ])
-      });
+      await settled();
+      await settled();
+      await settled();
 
-      test('async invocations', async function(assert) {
-        await node.click()
-        await node.click();
-
-        assert.verifySteps([
-          'begin #0',
-          'complete #0',
-          'begin #1',
-          'complete #1'
-        ])
-      });
-
-      test('async chained invocations', async function(assert) {
-        await node.click().click();
-
-        assert.verifySteps([
-          'begin #0',
-          'complete #0',
-          'begin #1',
-          'complete #1'
-        ])
-      });
-
-      test('sync chained invocations', async function(assert) {
-        node.click().click();
-
-        await settled();
-        await settled();
-        await settled();
-
-        assert.verifySteps([
-          'begin #0',
-          'complete #0',
-          'begin #1',
-          'complete #1',
-        ])
-      });
+      assert.verifySteps([
+        'begin #0',
+        'complete #0',
+        'begin #1',
+        'complete #1',
+      ])
     });
   });
 }

--- a/tests/unit/-private/supports-rfc268-test.js
+++ b/tests/unit/-private/supports-rfc268-test.js
@@ -3,10 +3,10 @@ import { setupTest } from 'ember-qunit';
 import require from 'require';
 
 if (require.has('@ember/test-helpers')) {
-  module('Unit | is rfc268 test', function(hooks) {
-    function isRfc268Test() {
+  module('Unit | supports rfc268', function(hooks) {
+    function supportsRfc268() {
       window.require.unsee('ember-cli-page-object/test-support/-private/execution_context');
-      return require('ember-cli-page-object/test-support/-private/execution_context').isRfc268Test();
+      return require('ember-cli-page-object/test-support/-private/execution_context').supportsRfc268();
     }
 
     hooks.afterEach(function() {
@@ -30,18 +30,19 @@ if (require.has('@ember/test-helpers')) {
       });
 
       test('works', function(assert) {
-        assert.ok(isRfc268Test());
+        assert.ok(supportsRfc268());
       });
 
       test('throws without visit() present', function(assert) {
         compatModule.visit = undefined;
-        assert.throws(isRfc268Test);
+
+        assert.throws(() => supportsRfc268());
       });
     });
 
     module('without context', function() {
       test('works', function(assert) {
-        assert.notOk(isRfc268Test());
+        assert.notOk(supportsRfc268());
       });
     });
   });


### PR DESCRIPTION
Fixes #444 

`moduleForComponent` + `setContext` was a point  of much confusion for ages. With @ember/test-helpers we are able to auto-detect if it's `moduleForComponent` kind of test or not.