### PR TITLE
Disable jquery in ember-try scenarios for modern Ember versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,13 +45,13 @@ jobs:
     - env: EMBER_TRY_SCENARIO=ember-lts-2.12
     - env: EMBER_TRY_SCENARIO=ember-lts-2.16
     - env: EMBER_TRY_SCENARIO=ember-lts-2.18
-    - env: EMBER_TRY_SCENARIO=ember-release COVERAGE=true # Only log coverage from release
+    # keep testing integration and acceptance contexts
+    - env: EMBER_TRY_SCENARIO=with-jquery COVERAGE=true
     - env: EMBER_TRY_SCENARIO=with-ember-test-helpers
     - env: EMBER_TRY_SCENARIO=with-@ember/test-helpers
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
-    - env: EMBER_TRY_SCENARIO=ember-default-without-jquery
 
 before_install:
   - npm config set spin false

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -162,10 +162,10 @@ module.exports = function() {
           }
         },
         {
-          name: 'ember-default-without-jquery',
+          name: 'with-jquery',
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({
-              'jquery-integration': false
+              'jquery-integration': true
             })
           }
         }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -80,6 +80,11 @@ module.exports = function() {
             devDependencies: {
               'ember-source': urls[0]
             }
+          },
+          env: {
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({
+              'jquery-integration': false
+            })
           }
         },
         {
@@ -88,6 +93,11 @@ module.exports = function() {
             devDependencies: {
               'ember-source': urls[1]
             }
+          },
+          env: {
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({
+              'jquery-integration': false
+            })
           }
         },
         {
@@ -96,6 +106,11 @@ module.exports = function() {
             devDependencies: {
               'ember-source': urls[2]
             }
+          },
+          env: {
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({
+              'jquery-integration': false
+            })
           }
         },
         {


### PR DESCRIPTION
ember@3.9-beta started to raise a deprecation when `Ember.$` is used, which leads to failures in some tests that [expect no deprectations](https://github.com/san650/ember-cli-page-object/blob/18817c709753ecfe2e6346ee7a9641d575dfe954/tests/integration/deprecations/comma-separated-selector-test.js#L74).