### PR TITLE
empty create regression

### DIFF
--- a/addon-test-support/create.js
+++ b/addon-test-support/create.js
@@ -165,7 +165,7 @@ export function create(definitionOrUrl, definitionOrOptions, optionsOrNothing) {
     options = optionsOrNothing || {};
   } else {
     url = false;
-    definition = definitionOrUrl;
+    definition = definitionOrUrl || {};
     options = definitionOrOptions || {};
   }
 

--- a/tests/integration/default-properties-test.js
+++ b/tests/integration/default-properties-test.js
@@ -76,5 +76,13 @@ if (require.has('@ember/test-helpers')) {
       assert.equal(page.dummy.isVisible(), 'isVisible');
       assert.equal(page.dummy.text(), 'text');
     });
+
+    test('allows empty create', async function(assert) {
+      let page = create();
+
+      await render(createCalculatorTemplate());
+
+      assert.ok(page.isVisible, 'page rendered successfully');
+    });
   });
 }


### PR DESCRIPTION
Somewhere between 1.3.0 and 1.5.2, an empty create started failing.