### PR TITLE
Bump up ember-native-dom-helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ceibo": "~2.0.0",
     "ember-cli-babel": "^6.16.0",
     "ember-cli-node-assets": "^0.2.2",
-    "ember-native-dom-helpers": "^0.5.3",
+    "ember-native-dom-helpers": "^0.6.3",
     "jquery": "^3.2.1",
     "rsvp": "^4.7.0"
   },


### PR DESCRIPTION
Bump up ember-native-dom-helpers version to 0.6.x to avoid deprecation warnings because of using `merge` from @ember/polyfills