### PR TITLE
feat: Add ambient types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ LICENSE.md
 /docs
 /_site
 /yarn-error.log
+jsconfig.json
 
 # IDE/editor files
 /.idea/

--- a/.npmignore
+++ b/.npmignore
@@ -27,6 +27,9 @@
 /yarn.lock
 /package-lock.json
 .gitkeep
+/types/*
+!/types/index.d.ts
+/guides
 
 # ember-try
 /.node_modules.ember-try/

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ jobs:
       script:
         - npm run lint:hbs
         - npm run lint:js
+        - npm run lint:ts
         - npm test
 
     # we recommend new addons test the current and previous LTS

--- a/package.json
+++ b/package.json
@@ -29,12 +29,14 @@
     "build": "ember build",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
+    "lint:ts": "dtslint types",
     "start": "ember serve",
     "test": "ember test",
     "test:all": "ember try:each",
     "docs": "node ./docs",
     "nodetest": "mocha node-tests --recursive"
   },
+  "types": "types",
   "dependencies": {
     "broccoli-file-creator": "^2.1.1",
     "broccoli-merge-trees": "^2.0.0",
@@ -47,10 +49,12 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",
+    "@types/jquery": "^3.3.31",
     "broccoli-asset-rev": "^2.7.0",
     "chai": "^4.1.2",
     "coveralls": "^3.0.0",
     "documentation": "^5.3.3",
+    "dtslint": "^1.0.2",
     "ember-cli": "~3.5.1",
     "ember-cli-addon-tests": "^0.11.0",
     "ember-cli-blueprint-test-helpers": "^0.18.2",
@@ -86,6 +90,7 @@
     "ncp": "^2.0.0",
     "qunit-dom": "^0.8.0",
     "rimraf": "^2.5.2",
+    "typescript": "~3.3.3333",
     "walk-sync": "^0.3.2"
   },
   "engines": {

--- a/types/chaining-test.ts
+++ b/types/chaining-test.ts
@@ -1,0 +1,14 @@
+import { create, clickable } from "ember-cli-page-object";
+
+const a = create({
+  extraProp: clickable(),
+  number: 1
+});
+
+function chainingTest2(): typeof a {
+  return a.click().extraProp();
+}
+
+function thenableChainingTest(): typeof a {
+  return a.click().then((a) => a.extraProp());
+}

--- a/types/clickable-test.ts
+++ b/types/clickable-test.ts
@@ -1,0 +1,28 @@
+import { create, clickable } from 'ember-cli-page-object';
+
+function itWorks() {
+  const p = create({
+    default: clickable(),
+    withSelector: clickable('test-selector'),
+    withUserOptions: clickable('test-selector', {
+      pageObjectKey: '123',
+      resetScope: false,
+      testContainer: 'body',
+      contains: '123',
+      last: false,
+      at: 1,
+      multiple: false,
+      visible: true
+    }),
+  });
+
+  (): typeof p => p.click();
+  (): typeof p => p.default();
+  (): typeof p => p.withSelector();
+  (): typeof p => p.withUserOptions();
+}
+
+function userOptionsErrors() {
+  clickable('invalid type', { at: '1' }); // $ExpectError
+  clickable('unknown option', { unkown: '1' }); // $ExpectError
+}

--- a/types/collection-test.ts
+++ b/types/collection-test.ts
@@ -1,0 +1,42 @@
+import { create, clickable, collection } from "ember-cli-page-object";
+
+const a = create({
+  items: collection('.test', {
+    testAction: clickable(),
+
+    nestedItems: collection('', {
+      prop: 1
+    })
+  })
+});
+
+a.items.length; // $ExpectType number
+a.items[0].click().nestedItems[0].prop; // $ExpectType number
+a.items[0].testAction().nestedItems[0].prop; // $ExpectType number
+
+const b = create({
+  items: collection('.test', {
+    a: 1
+  })
+});
+
+b.items.objectAt(1); // $ExpectType Component<{ a: number; }> | undefined
+b.items.toArray(); // $ExpectType Component<{ a: number; }>[]
+b.items.map((i) => i.a); // $ExpectType number[]
+b.items.filter((i) => true); // $ExpectType Component<{ a: number; }>[]
+b.items.mapBy('a'); // $ExpectType any[]
+b.items.mapBy('text'); // $ExpectType any[]
+b.items.filterBy('a'); // $ExpectType Component<{ a: number; }>[]
+b.items.filterBy('value'); // $ExpectType Component<{ a: number; }>[]
+b.items.findOne((a) => a.a === 1); // $ExpectType Component<{ a: number; }>
+b.items.findOneBy('value', 1); // $ExpectType Component<{ a: number; }>
+b.items.forEach((node, _i: number) => {
+  node.a; // $ExpectType number
+});
+
+b.items.mapBy('undeclared'); // $ExpectError
+b.items.filterBy('undeclared'); // $ExpectError
+b.items.findOneBy('undeclared', 1); // $ExpectError
+
+const [ i1 ] = b.items;
+i1.a; // $ExpectType number

--- a/types/create-test.ts
+++ b/types/create-test.ts
@@ -1,0 +1,77 @@
+import { create } from "ember-cli-page-object";
+
+function selectorQuery() {
+  create(""); // $ExpectError
+  create({ scope: 1 }); // $ExpectError
+  create({ testContainer: 111 }); // $ExpectError
+  create({ resetScope: 111 }); // $ExpectError
+
+  create();
+  create({});
+  create({ scope: "" });
+  create({ testContainer: "" });
+  create({ testContainer: document.createElement('div') });
+  create({ resetScope: true });
+}
+
+function createDefault() {
+  const a = create({
+    uniqProp: 1
+  });
+
+  a.uniqProp;
+
+  a.isVisible!; // $ExpectType boolean
+  a.isPresent!; // $ExpectType boolean
+  a.isHidden!; // $ExpectType boolean
+
+  a.text!; // ExpectType string
+  a.value!; // ExpectType string
+
+  function contains() {
+    a.contains(); // $ExpectError
+    a.contains(1); // $ExpectError
+
+    (): boolean => a.contains('conained text');
+  }
+
+  function click() {
+    a.uniqProp;
+    a.click().click();
+    (): number => a.click().uniqProp;
+  }
+
+  function fillIn() {
+    a.fillIn(); // $ExpectError
+    a.fillIn(1); // $ExpectError
+
+    (): typeof a =>
+      a.fillIn('string')
+        .fillIn('clue', 'string');
+  }
+
+  function clickOn() {
+    a.clickOn(); // $ExpectError
+    a.clickOn(1); // $ExpectError
+
+    (): typeof a => a.clickOn('text');
+  }
+
+  function focus() {
+    (): typeof a => a.focus();
+  }
+
+  function blur() {
+    (): typeof a => a.blur();
+  }
+}
+
+function nestingTest() {
+  const nested = create({
+    b: {
+      prop: "1"
+    }
+  });
+
+  nested.b; // $ExpectType Component<{ prop: string; }>
+}

--- a/types/extend-test.ts
+++ b/types/extend-test.ts
@@ -1,0 +1,37 @@
+import "jquery";
+import { create } from 'ember-cli-page-object';
+import { findElement, findElementWithAssert } from 'ember-cli-page-object/extend';
+
+const node = create({});
+
+findElementWithAssert(); // $ExpectError
+findElementWithAssert(null); // $ExpectError
+findElementWithAssert({}); // $ExpectError
+findElementWithAssert(node, { at: 0 }); // $ExpectError
+findElementWithAssert(node, 'scope', { nonExisting: 0 }); // $ExpectError
+
+findElementWithAssert(node); // $ExpectType JQuery<HTMLElement>
+findElementWithAssert(node, 'scope'); // $ExpectType JQuery<HTMLElement>
+findElementWithAssert(node, 'scope', {
+  at: 0,
+  last: false,
+  pageObjectKey: 'test',
+  testContainer: '',
+  visible: false
+});
+
+findElement(); // $ExpectError
+findElement(null); // $ExpectError
+findElement({}); // $ExpectError
+findElement(node, { at: 0 }); // $ExpectError
+findElement(node, 'scope', { nonExisting: 0 }); // $ExpectError
+
+findElement(node); // $ExpectType JQuery<HTMLElement>
+findElement(node, 'scope'); // $ExpectType JQuery<HTMLElement>
+findElement(node, 'scope', {
+  at: 0,
+  last: false,
+  pageObjectKey: 'test',
+  testContainer: document.createElement('div'),
+  visible: false
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,161 @@
+// TypeScript Version: 3.3
+declare module 'ember-cli-page-object' {
+  import {
+    Component,
+    Definition,
+    FindOptions,
+    TriggerOptions,
+    GetterDescriptor,
+    MethodDescriptor,
+    DSL
+  } from 'ember-cli-page-object/-private';
+
+  function create<T extends Partial<Definition>>(definition?: T): Component<T>;
+  function collection<T extends Partial<Definition>>(scope: string, definition?: T): Collection<T>;
+
+  // Attributes
+  function attribute(attributeName: string, scope?: string): GetterDescriptor<string>;
+  function isVisible(scope?: string): GetterDescriptor<boolean>;
+  function isHidden(scope?: string): GetterDescriptor<boolean>;
+  function isPresent(scope?: string): GetterDescriptor<boolean>;
+  function text(scope?: string): GetterDescriptor<string>;
+  function value(scope?: string): GetterDescriptor<string>;
+  function property(name: string): GetterDescriptor<any>;
+  function property(scope: string, name: string): GetterDescriptor<any>;
+  function hasClass(className: string): GetterDescriptor<boolean>;
+  function hasClass(scope: string, className: string): GetterDescriptor<boolean>;
+  function notHasClass(className: string): GetterDescriptor<boolean>;
+  function notHasClass(scope: string, className: string): GetterDescriptor<boolean>;
+  function contains(scope?: string): (text: string) => GetterDescriptor<boolean>;
+  function count(scope?: string): () => GetterDescriptor<boolean>;
+
+  // Actions
+  function clickable(scope?: string, userOptions?: FindOptions): MethodDescriptor<<T>(this: T) => T>;
+  function clickOnText(scope?: string, userOptions?: FindOptions): MethodDescriptor<<T>(this: T, text: string) => T>;
+  function fillable(scope?: string, userOptions?: FindOptions): MethodDescriptor<<T>(this: T, clueOrContent: string, content?: string) => T>;
+  function triggerable(event: string, scope?: string, eventOptions?: TriggerOptions): MethodDescriptor<<T>(this: T) => T>;
+  function focusable(scope?: string): MethodDescriptor<<T>(this: T) => T>;
+  function blurrable(scope?: string): MethodDescriptor<<T>(this: T) => T>;
+  function visitable(path: string): MethodDescriptor<<T>(this: T, dynamicSegmentsAndQueryParams?: {}) => T>;
+
+  interface Collection<T> {
+    (scope: string, definition?: T): Array<Component<T>>;
+
+    [i: number]: Component<T>;
+    [Symbol.iterator](): Iterator<Component<T>>;
+
+    filter(callback: (c: Component<T>) => boolean): Array<Component<T>>;
+    filterBy(propName: keyof T | keyof DSL<T>): Array<Component<T>>;
+    findOne(callback: (c: Component<T>) => boolean): Component<T>;
+    findOneBy(propName: keyof T | keyof DSL<T>, value: any): Component<T>;
+    forEach(callback: (c: Component<T>, i: number) => void): void;
+    map<S>(callback: (c: Component<T>) => S): S[];
+    mapBy(propName: keyof T | keyof DSL<T>): any[];
+    objectAt(i: number): Component<T>|undefined;
+    toArray(): Array<Component<T>>;
+  }
+}
+
+declare module 'ember-cli-page-object/extend' {
+  import 'jquery';
+  import { Component, FindOptions } from 'ember-cli-page-object/-private';
+
+  function findElement(pageObject: Component, scope?: string, options?: FindOptions): JQuery;
+  function findElementWithAssert(pageObject: Component, scope?: string, options?: FindOptions): JQuery;
+}
+
+declare module 'ember-cli-page-object/macros' {
+  import { GetterDescriptor } from 'ember-cli-page-object/-private';
+
+  function getter<T>(body: () => T): GetterDescriptor<T>;
+  function alias(path: string): any;
+}
+
+declare module 'ember-cli-page-object/-private' {
+  import 'jquery';
+  import {
+    clickable,
+    clickOnText,
+    fillable,
+    focusable,
+    blurrable
+  } from 'ember-cli-page-object';
+
+  interface GetterDescriptor<T> {
+    isGetter: true;
+
+    get: T;
+  }
+
+  interface MethodDescriptor<T extends <S>(this: S, ...args: any[]) => S> {
+    isMethod: true;
+
+    (...args: Parameters<T>): ReturnType<T>;
+
+    get(): T;
+  }
+
+  type Component<T = Definition> = UnpackedDefinition<T> & DSL<T> & {
+    [s: string]: unknown;
+  };
+
+  type UnpackedDefinition<T> = {
+    [k in keyof T]:
+      T[k] extends GetterDescriptor<infer C> ? C
+      : T[k] extends MethodDescriptor<infer C> ? C
+      : T[k] extends Function | Component ? T[k]
+      : T[k] extends object ? Component<T[k]>
+      : T[k]
+  };
+
+  interface DSL<T> {
+    isHidden?: boolean;
+    isPresent?: boolean;
+    isVisible?: boolean;
+    text?: string;
+    value?: string;
+    contains(textToSearch: string): boolean;
+
+    blur(): Component<T>;
+    click(): Component<T>;
+    clickOn(text: string): Component<T>;
+    fillIn(clueOrContent: string, content?: string): Component<T>;
+    focus(): Component<T>;
+
+    then(
+      onfulfilled?: (value: any) => any,
+      onrejected?: (reason: any) => any
+    ): Component<T>;
+  }
+
+  interface Definition extends SelectorQueryOptions {
+    scope?: string;
+
+    [l: string]: unknown;
+  }
+
+  interface FindOptions extends DomElementQueryOptions {
+    contains?: string;
+
+    last?: boolean;
+
+    visible?: boolean;
+
+    multiple?: boolean;
+
+    at?: number;
+  }
+
+  interface TriggerOptions extends DomElementQueryOptions {
+    eventProperties: object;
+  }
+
+  interface DomElementQueryOptions extends SelectorQueryOptions {
+    pageObjectKey?: string;
+  }
+
+  interface SelectorQueryOptions {
+    resetScope?: boolean;
+    testContainer?: string|HTMLElement|JQuery;
+  }
+}

--- a/types/macros-test.ts
+++ b/types/macros-test.ts
@@ -1,0 +1,23 @@
+import { getter } from "ember-cli-page-object/macros";
+import { create } from "ember-cli-page-object";
+
+const a = create({
+  number: getter(function() {
+    return 1;
+  }),
+
+  // impossible to preserve this :(
+  numberExtra: getter(function(this: any): string {
+    return this.number;
+  }),
+
+  // we have to make sure objects returned from getter
+  // are not treated as page object configs
+  map: getter(function() {
+    return { a: 1 };
+  })
+});
+
+a.number; // $ExpectType number
+a.numberExtra; // $ExpectType string
+a.map; // $ExpectType { a: number; }

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "lib": ["es6", "dom"],
+    "module": "es6",
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "noEmit": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "baseUrl": ".",
+    "downlevelIteration": true
+  }
+}

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "dtslint/dtslint.json",
+  "rules": {
+    "unified-signatures": false,
+    "ban-types": false,
+    "only-arrow-functions": false
+  }
+}


### PR DESCRIPTION
It is a result of few iterations and testing against a real APP test suite.
It covers most of the current public APIs and provides you with auto-complete or errors when you mistype something.

Some of currently public APIs are intentionally ignored. For example, the current implementation of `create` supports the following signatures:

```js
  function create(definition) {}
  function create(definition, options) {}
  // not supported
  function create(url, definition) {}
  function create(url, definition, options) {}
```
I [believe](https://github.com/san650/ember-cli-page-object/issues/464), `url` in `create` should be avoided in favor of `visitable` action, so typings from this PR does only support 2 first signatures. This approach allows us to simplify typings and signal a user about a recommended way of doing stuff. 

Here is a list of all public API, which are currently exposed to the consumers, but don't have types:
 - `buildSelector`
 - `getContext`
 - `setContext`
 - `is` 

### Limitations

There are some hints for those who decide to write their page objects in TS.

#### alias

Typescript isn't able to follow nested string paths, like `a.path.to.some.deep.property`, so each `alias` returns `any`:

```ts
const page = create({
  doSomething: alias('nestedObject.click'),
  nestedObject: {}
});

page.doSomething(); // returns `any`
```

#### Custom methods

Because page object definitions are POJOs, which are static instances, in custom methods we can't have a valid `this` type. So for custom methods and getters we have to set `this` to `any`:

```ts
export default {
  something: getter(function(this: any) {
    return this.text as string; // but you can still provide a hint about your return value!
  })
}
``` 

the same is true for custom actions:

```ts
const page = create({
  doSomething(this: any) { 
    return this.click();
  }
})

page.doSomething(); // returns `any`
```

#### Documentation

It's missing because I didn't want to duplicate it by copy-pasting it from the JS source code. Someday I hope we would have a truly typed codebase, which would solve the documentation issue, but today I had few stoppers for doing this:
 - `create` - not sure if it's possible to type underlying `Ceibo`
 - code coverage doesn't work with ec-typescript@2 - https://github.com/kategengler/ember-cli-code-coverage/issues/213