### PR TITLE
deprecate `is` property

### DIFF
--- a/addon-test-support/properties/is.js
+++ b/addon-test-support/properties/is.js
@@ -1,3 +1,4 @@
+import { deprecate } from '@ember/application/deprecations';
 import { assign, every } from '../-private/helpers';
 import { findElementWithAssert } from '../extend';
 
@@ -51,6 +52,11 @@ export function is(testSelector, targetSelector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
+      deprecate(':is property is deprecated', false, {
+        id: 'ember-cli-page-object.is-property',
+        until: '2.0.0'
+      });
+
       let options = assign({ pageObjectKey: key }, userOptions);
 
       let elements = findElementWithAssert(this, targetSelector, options);

--- a/tests/unit/-private/properties/is-test.js
+++ b/tests/unit/-private/properties/is-test.js
@@ -12,6 +12,13 @@ moduleForProperty('is', function(test) {
     assert.equal(page.foo, true);
   });
 
+  test('throws deprecation warning', async function(assert) {
+    const page = create({ foo: is(':checked', ':input') });
+    await this.adapter.createTemplate(this, page, '<input type="checkbox" checked>');
+    page.foo;
+    assert.expectDeprecation(':is property is deprecated');
+  });
+
   test("raises an error when the element doesn't exist", async function(assert) {
     let page = create({
       foo: {


### PR DESCRIPTION
#442 - deprecate is 
#359 - v2 preparations