### PR TITLE
add a way to get native element

### DIFF
--- a/addon-test-support/create.js
+++ b/addon-test-support/create.js
@@ -2,6 +2,7 @@ import Ceibo from 'ceibo';
 import { render, setContext, removeContext } from './-private/context';
 import { assign, getPageObjectDefinition, isPageObject, storePageObjectDefinition } from './-private/helpers';
 import { visitable } from './properties/visitable';
+import { element } from './properties/element';
 import dsl from './-private/dsl';
 
 //
@@ -46,9 +47,9 @@ import dsl from './-private/dsl';
 function buildObject(node, blueprintKey, blueprint, defaultBuilder) {
   let definition;
 
-  // to allow page objects to exist in definitions, we store the definition that 
+  // to allow page objects to exist in definitions, we store the definition that
   // created the page object, allowing us to substitute a page object with its
-  // definition during creation 
+  // definition during creation
   if (isPageObject(blueprint)) {
     definition = getPageObjectDefinition(blueprint);
   } else {
@@ -65,7 +66,7 @@ function buildObject(node, blueprintKey, blueprint, defaultBuilder) {
 
   // persist definition once we have an instance
   storePageObjectDefinition(instance, blueprintToStore);
-  
+
   return [ instance, blueprintToApply ];
 }
 
@@ -193,6 +194,8 @@ export function create(definitionOrUrl, definitionOrOptions, optionsOrNothing) {
       return chainedTree;
     }
   };
+
+  definition.element = element();
 
   // Build the primary tree
   let builder = {

--- a/addon-test-support/properties/element.js
+++ b/addon-test-support/properties/element.js
@@ -1,0 +1,9 @@
+export function element(selector) {
+  return {
+    isDescriptor: true,
+
+    get() {
+      return document.querySelectorAll(selector);
+    }
+  }
+}

--- a/tests/acceptance/composition-test.js
+++ b/tests/acceptance/composition-test.js
@@ -33,7 +33,7 @@ let screenPage = create({
 let page = create({
   visit: visitable('/calculator'),
   keys: keyboard,
-  screen: screenPage  
+  screen: screenPage
 });
 
 moduleForAcceptance('Acceptance | composition');
@@ -45,6 +45,8 @@ test('allows compose', async function(assert) {
     .clickOn('1')
     .clickOn('2')
     .sum();
+  assert.equal(page.element.classNames.toString(), 'keyboard');
+
   //click 3
   await page.keys.numbers.objectAt(2).click()
   //click =
@@ -54,7 +56,7 @@ test('allows compose', async function(assert) {
   await page.screen.fillValue('45')
   //click 6
   await page.keys.numbers.objectAt(5).click();
-  
+
   assert.equal(page.screen.value, '456');
 });
 


### PR DESCRIPTION
This feels weird. Is there way a better way to get the native element?

The main thing I'm looking for is a way to integrate qunit-dom with page objects.
Right now, it feels like we have to either use ec-page-object or qunit-dom.... which makes me sad :(