### PR TITLE
Fixup ts moduleResolution

### DIFF
--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -11,6 +11,7 @@
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": ".",
-    "downlevelIteration": true
+    "downlevelIteration": true,
+    "moduleResolution": "node"
   }
 }


### PR DESCRIPTION
After merged green https://github.com/san650/ember-cli-page-object/pull/458, CI failed with:

> Error: Errors in typescript@local for external dependencies:
../node_modules/@types/babel__core/index.d.ts(13,20): error TS2307: Cannot find module '@babel/types'.
../node_modules/@types/babel__core/index.d.ts(14,31): error TS2307: Cannot find module '@babel/parser'.
../node_modules/@types/babel__generator/index.d.ts(10,20): error TS2307: Cannot find module '@babel/types'.
../node_modules/@types/babel__template/index.d.ts(9,31): error TS2307: Cannot find module '@babel/parser'.
../node_modules/@types/babel__template/index.d.ts(10,54): error TS2307: Cannot find module '@babel/types'.

It started to fail locally as well for some reason. Have no idea why it didn't appear before.

got fix from https://github.com/babel/babel/issues/10237#issuecomment-513028440