### PR TITLE
Deprecate multiple

### DIFF
--- a/addon-test-support/-private/helpers.js
+++ b/addon-test-support/-private/helpers.js
@@ -94,7 +94,7 @@ class Selector {
 
 export function guardMultiple(items, selector, supportMultiple) {
   assert(
-    `"${selector}" matched more than one element. If this is not an error use { multiple: true }`,
+    `"${selector}" matched more than one element. If you want to select many elements, use collections instead.`,
     supportMultiple || items.length <= 1
   );
 }

--- a/addon-test-support/extend/find-many.js
+++ b/addon-test-support/extend/find-many.js
@@ -1,3 +1,4 @@
+import { deprecate } from '@ember/application/deprecations';
 import { getExecutionContext } from '../-private/execution_context';
 import { filterWhitelistedOption } from '../-private/helpers';
 /**
@@ -32,6 +33,12 @@ import { filterWhitelistedOption } from '../-private/helpers';
  * @return {Array} of Element
  */
 export function findMany(pageObjectNode, targetSelector, options = {}) {
+  deprecate('"multiple" property is deprecated', false === '__multiple__' in options , {
+    id: 'ember-cli-page-object.multiple',
+    until: '2.0.0',
+    url: 'https://ember-cli-page-object.js.org/docs/v1.16.x/deprecations/#multiple',
+  });
+
   const filteredOptions = filterWhitelistedOption(options, [
     'resetScope', 'visible', 'testContainer', 'contains', 'scope', 'at', 'last'
   ]);

--- a/addon-test-support/extend/find-many.js
+++ b/addon-test-support/extend/find-many.js
@@ -36,7 +36,7 @@ export function findMany(pageObjectNode, targetSelector, options = {}) {
   deprecate('"multiple" property is deprecated', false === '__multiple__' in options , {
     id: 'ember-cli-page-object.multiple',
     until: '2.0.0',
-    url: 'https://ember-cli-page-object.js.org/docs/v1.16.x/deprecations/#multiple',
+    url: 'https://ember-cli-page-object.js.org/docs/v1.17.x/deprecations/#multiple',
   });
 
   const filteredOptions = filterWhitelistedOption(options, [

--- a/addon-test-support/properties/attribute.js
+++ b/addon-test-support/properties/attribute.js
@@ -80,7 +80,7 @@ export function attribute(attributeName, selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key }, userOptions);
+      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
 
       if (options.multiple) {
         return findMany(this, selector, options).map(element => element.getAttribute(attributeName), options);

--- a/addon-test-support/properties/blurrable.js
+++ b/addon-test-support/properties/blurrable.js
@@ -69,7 +69,7 @@ export function blurrable(selector, userOptions = {}) {
     get(key) {
       return function() {
         const executionContext = getExecutionContext(this);
-        const options = assign({ pageObjectKey: `${key}()` }, userOptions);
+        const options = assign({ pageObjectKey: `${key}()`, __multiple__: true }, userOptions);
 
         return executionContext.runAsync((context) => {
           return context.blur(selector, options);

--- a/addon-test-support/properties/contains.js
+++ b/addon-test-support/properties/contains.js
@@ -96,7 +96,10 @@ export function contains(selector, userOptions = {}) {
 
     get(key) {
       return function(textToSearch) {
-        let options = assign({ pageObjectKey: `${key}("${textToSearch}")` }, userOptions);
+        let options = assign({
+          pageObjectKey: `${key}("${textToSearch}")`,
+          __multiple__: true
+        }, userOptions);
 
         let elements = options.multiple ? findMany(this, selector, options) : [findOne(this, selector, options)];
 

--- a/addon-test-support/properties/count.js
+++ b/addon-test-support/properties/count.js
@@ -88,8 +88,6 @@ export function count(selector, userOptions = {}) {
     get(key) {
       let options = assign({ pageObjectKey: key }, userOptions);
 
-      options = assign(options, { multiple: true });
-
       return findMany(this, selector, options).length;
     }
   };

--- a/addon-test-support/properties/has-class.js
+++ b/addon-test-support/properties/has-class.js
@@ -98,7 +98,7 @@ export function hasClass(cssClass, selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key }, userOptions);
+      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
 
       let elements = options.multiple ? findMany(this, selector, options) : [findOne(this, selector, options)];
 

--- a/addon-test-support/properties/is-hidden.js
+++ b/addon-test-support/properties/is-hidden.js
@@ -106,7 +106,7 @@ export function isHidden(selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key }, userOptions);
+      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
 
       let elements = findMany(this, selector, options);
 

--- a/addon-test-support/properties/is-present.js
+++ b/addon-test-support/properties/is-present.js
@@ -1,5 +1,5 @@
 import { findMany } from '../extend';
-import { guardMultiple } from "../-private/helpers";
+import { assign, guardMultiple } from '../-private/helpers';
 
 /**
  * Validates if any element matching the target selector is rendered in the DOM.
@@ -80,10 +80,12 @@ import { guardMultiple } from "../-private/helpers";
  *
  * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
-export function isPresent(selector, options = {}) {
+export function isPresent(selector, userOptions = {}) {
   return {
     isDescriptor: true,
-    get() {
+    get(key) {
+      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
+
       let elements = findMany(this, selector, options);
       guardMultiple(elements, selector, options.multiple);
       return elements.length > 0;

--- a/addon-test-support/properties/is-visible.js
+++ b/addon-test-support/properties/is-visible.js
@@ -112,7 +112,7 @@ export function isVisible(selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key }, userOptions);
+      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
 
       let elements = findMany(this, selector, options);
       guardMultiple(elements, selector, options.multiple);

--- a/addon-test-support/properties/is.js
+++ b/addon-test-support/properties/is.js
@@ -58,7 +58,7 @@ export function is(testSelector, targetSelector, userOptions = {}) {
         url: 'https://ember-cli-page-object.js.org/docs/v1.16.x/deprecations/#is-property',
       });
 
-      let options = assign({ pageObjectKey: key }, userOptions);
+      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
 
       let elements = findElementWithAssert(this, targetSelector, options);
 

--- a/addon-test-support/properties/not-has-class.js
+++ b/addon-test-support/properties/not-has-class.js
@@ -102,7 +102,7 @@ export function notHasClass(cssClass, selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key }, userOptions);
+      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
 
       let elements = options.multiple ? findMany(this, selector, options) : [findOne(this, selector, options)];
 

--- a/addon-test-support/properties/property.js
+++ b/addon-test-support/properties/property.js
@@ -65,7 +65,7 @@ export function property(propertyName, selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key }, userOptions);
+      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
 
       if (options.multiple) {
         return findMany(this, selector, options).map(element => $(element).prop(propertyName));

--- a/addon-test-support/properties/text.js
+++ b/addon-test-support/properties/text.js
@@ -105,7 +105,7 @@ export function text(selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key }, userOptions);
+      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
       let f = options.normalize === false ? identity : normalizeText;
 
       if (options.multiple) {

--- a/addon-test-support/properties/value.js
+++ b/addon-test-support/properties/value.js
@@ -92,7 +92,7 @@ export function value(selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key }, userOptions);
+      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
 
       const checkValue = (element) => element.hasAttribute('contenteditable') ? $(element).html() : $(element).val();
 

--- a/guides/deprecations.md
+++ b/guides/deprecations.md
@@ -5,6 +5,68 @@ title: Deprecations
 
 This is a list of deprecations introduced in 1.x cycle:
 
+## Multiple
+
+**ID**: ember-cli-page-object.multiple
+
+**Until**: 2.0.0
+
+`multiple` option makes our internals significantly more complex, and extends API surface for each attribute without big benefits.
+
+It can also confuse a consumer of page object which uses `multiple`, because when accessing an attribute one may expect to get a scalar value, rather than array.
+
+In order to migrate use collections please:
+
+Bad:
+
+```js
+import { create, is } from 'ember-cli-page-object';
+
+const page = create({
+  scope: 'div',
+
+  tags: text('.tag', { multiple: true }),
+});
+
+// usage
+assert.deepEqual(page.tags, ['one', 'two', 'three'])
+```
+
+Good:
+
+```js
+import { create, collection } from 'ember-cli-page-object';
+
+const page = create({
+  scope: 'div',
+
+  tags: collection('.tag'),
+});
+
+// usage
+assert.deepEqual(page.tags.map((t) => t.text), ['one', 'two', 'three'])
+```
+
+or, if you want to leave your tests unchanged:
+
+```js
+import { create, collection } from 'ember-cli-page-object';
+
+const page = create({
+  scope: 'div',
+
+  _tags: collection('.tag'),
+
+  get tags() {
+    return this._tags.map((t) => t.text);
+  }
+});
+
+// usage
+assert.deepEqual(page.tags, ['one', 'two', 'three'])
+```
+
+
 ## Is property
 
 **ID**: ember-cli-page-object.is-property

--- a/tests/integration/deprecations/multiple-test.js
+++ b/tests/integration/deprecations/multiple-test.js
@@ -1,0 +1,259 @@
+import { module, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+import {
+  attribute,
+  contains,
+  create,
+  hasClass,
+  is,
+  isHidden,
+  isPresent,
+  isVisible,
+  notHasClass,
+  property,
+  text,
+  value,
+} from 'ember-cli-page-object';
+
+import require from 'require';
+if (require.has('@ember/test-helpers')) {
+  const { render } = require('@ember/test-helpers');
+
+  module('Deprecation | multiple', function(hooks) {
+    setupRenderingTest(hooks);
+
+    test('attribute', async function(assert) {
+      let page = create({
+        foo: attribute('placeholder', ':input', { multiple: true })
+      });
+
+      await render(hbs`
+        <input placeholder="a value">
+        <input placeholder="other value">
+      `);
+
+      assert.deepEqual(page.foo, ['a value', 'other value']);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('value', async function(assert) {
+      let page = create({
+        foo: value('input', { multiple: true })
+      });
+
+      await render(hbs`
+        <input value="lorem">
+        <input value="ipsum">
+      `);
+
+      assert.deepEqual(page.foo, ['lorem', 'ipsum']);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('text: returns multiple values', async function(assert) {
+      let page = create({
+        foo: text('li', { multiple: true })
+      });
+
+      await render(hbs`
+        <ul>
+          <li>lorem</li>
+          <li> ipsum </li>
+          <li>dolor</li>
+        </ul>
+      `);
+
+      assert.deepEqual(page.foo, ['lorem', 'ipsum', 'dolor']);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('property: matches multiple elements', async function(assert) {
+      let page = create({
+        foo: property('checked', ':input', { multiple: true })
+      });
+
+      await render(hbs`
+        <input type="checkbox" checked>
+        <input type="checkbox" >
+      `);
+
+      assert.deepEqual(page.foo, [true, false]);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('notHasClass: matches multiple elements with multiple: true option, returns false if some elements have class', async function(assert) {
+      let page = create({
+        foo: notHasClass('lorem', 'span', { multiple: true })
+      });
+
+      await render(hbs`
+        <span class="lorem"></span>
+        <span class="ipsum"></span>
+      `);
+
+      assert.ok(!page.foo);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('notHasClass: matches multiple elements with multiple: true option, returns true if no elements have class', async function(assert) {
+      let page = create({
+        foo: notHasClass('other-class', 'span', { multiple: true })
+      });
+
+      await render(hbs`
+        <span class="lorem"></span>
+        <span class="ipsum"></span>
+      `);
+
+      assert.ok(page.foo);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('isPresent: matches multiple elements with multiple: true option', async function(assert) {
+      let page = create({
+        foo: isPresent('span', { multiple: true })
+      });
+
+      await render(hbs`
+        <span>lorem</span>
+        <span> ipsum </span>
+        <span>dolor</span>
+      `);
+
+      assert.ok(page.foo);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+
+    test('isVisible: return false if not all elements are visible', async function(assert) {
+      let page = create({
+        foo: isVisible('span', { multiple: true })
+      });
+
+      await render(hbs`
+        <span>lorem</span>
+        <span style="display:none"> ipsum </span>
+        <span>dolor</span>
+      `);
+
+      assert.ok(!page.foo);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('isVisible: return true if all elements are visible', async function(assert) {
+      let page = create({
+        foo: isVisible('span', { multiple: true })
+      });
+
+      await render(hbs`
+        <span>lorem</span>
+        <span>dolor</span>
+      `);
+
+      assert.ok(page.foo);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('isHidden: true option, returns false if some elements are visible', async function(assert) {
+      let page = create({
+        foo: isHidden('em', { multiple: true })
+      });
+
+      await render(hbs`
+        <em>ipsum</em>
+        <em style="display:none">dolor</em>
+      `);
+
+      assert.ok(!page.foo);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('isHidden: true option, returns true if all elements are hidden', async function(assert) {
+      let page = create({
+        foo: isHidden('em', { multiple: true })
+      });
+
+      await render(hbs`
+        <em style="display:none">ipsum</em>
+        <em style="display:none">dolor</em>
+      `);
+
+      assert.ok(page.foo);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('hasClass: true option returns true if all elements have class', async function(assert) {
+      let page = create({
+        foo: hasClass('lorem', 'span', { multiple: true })
+      });
+
+      await render(hbs`
+        <span class="lorem"></span>
+        <span class="lorem"></span>
+      `);
+
+      assert.ok(page.foo);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('hasClass: true option returns false if not all elements have class', async function(assert) {
+      let page = create({
+        foo: hasClass('lorem', 'span', { multiple: true })
+      });
+
+      await render(hbs`
+        <span class="lorem"></span>
+        <span class="ipsum"></span>
+      `);
+
+      assert.ok(!page.foo);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('contains: returns false if not all elements contain text', async function(assert) {
+      let page = create({
+        foo: contains('span', { multiple: true })
+      });
+
+      await render(hbs`
+        <span>lorem</span>
+        <span>ipsum</span>
+        <span>dolor</span>
+      `);
+
+      assert.ok(!page.foo('lorem'));
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('contains: returns true if all elements contain text', async function(assert) {
+      let page = create({
+        foo: contains('span', { multiple: true })
+      });
+
+      await render(hbs`
+        <span>lorem</span>
+        <span>lorem</span>
+      `);
+
+      assert.ok(page.foo('lorem'));
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+  });
+}

--- a/tests/integration/deprecations/multiple-test.js
+++ b/tests/integration/deprecations/multiple-test.js
@@ -7,7 +7,6 @@ import {
   contains,
   create,
   hasClass,
-  is,
   isHidden,
   isPresent,
   isVisible,

--- a/tests/unit/-private/properties/attribute-test.js
+++ b/tests/unit/-private/properties/attribute-test.js
@@ -97,19 +97,6 @@ moduleForProperty('attribute', function(test) {
       /matched more than one element. If this is not an error use { multiple: true }/);
   });
 
-  test('returns multiple values', async function(assert) {
-    let page = create({
-      foo: attribute('placeholder', ':input', { multiple: true })
-    });
-
-    await this.adapter.createTemplate(this, page, `
-      <input placeholder="a value">
-      <input placeholder="other value">
-    `);
-
-    assert.deepEqual(page.foo, ['a value', 'other value']);
-  });
-
   test('finds element by index', async function(assert) {
     let page = create({
       foo: attribute('placeholder', ':input', { at: 1 })

--- a/tests/unit/-private/properties/attribute-test.js
+++ b/tests/unit/-private/properties/attribute-test.js
@@ -94,7 +94,7 @@ moduleForProperty('attribute', function(test) {
     `);
 
     assert.throws(() => page.foo,
-      /matched more than one element. If this is not an error use { multiple: true }/);
+      /matched more than one element. If you want to select many elements, use collections instead./);
   });
 
   test('finds element by index', async function(assert) {

--- a/tests/unit/-private/properties/contains-test.ts
+++ b/tests/unit/-private/properties/contains-test.ts
@@ -92,33 +92,6 @@ moduleForProperty('contains', function(test) {
       /matched more than one element. If this is not an error use { multiple: true }/);
   });
 
-  test('matches multiple elements with multiple: true option, returns false if not all elements contain text', async function(assert) {
-    let page = create({
-      foo: contains('span', { multiple: true })
-    });
-
-    await this.adapter.createTemplate(this, page, `
-      <span>lorem</span>
-      <span>ipsum</span>
-      <span>dolor</span>
-    `);
-
-    assert.ok(!page.foo('lorem'));
-  });
-
-  test('matches multiple elements with multiple: true option, returns true if all elements contain text', async function(assert) {
-    let page = create({
-      foo: contains('span', { multiple: true })
-    });
-
-    await this.adapter.createTemplate(this, page, `
-      <span>lorem</span>
-      <span>lorem</span>
-    `);
-
-    assert.ok(page.foo('lorem'));
-  });
-
   test('finds element by index', async function(assert) {
     let page = create({
       foo: contains('span', { at: 1 })

--- a/tests/unit/-private/properties/contains-test.ts
+++ b/tests/unit/-private/properties/contains-test.ts
@@ -89,7 +89,7 @@ moduleForProperty('contains', function(test) {
     `);
 
     assert.throws(() => page.foo('lorem'),
-      /matched more than one element. If this is not an error use { multiple: true }/);
+      /matched more than one element. If you want to select many elements, use collections instead./);
   });
 
   test('finds element by index', async function(assert) {

--- a/tests/unit/-private/properties/has-class-test.ts
+++ b/tests/unit/-private/properties/has-class-test.ts
@@ -104,7 +104,7 @@ moduleForProperty('hasClass', function(test) {
     `);
 
     assert.throws(() => page.foo,
-      /matched more than one element. If this is not an error use { multiple: true }/);
+      /matched more than one element. If you want to select many elements, use collections instead./);
   });
 
   test('finds element by index', async function(assert) {

--- a/tests/unit/-private/properties/has-class-test.ts
+++ b/tests/unit/-private/properties/has-class-test.ts
@@ -107,32 +107,6 @@ moduleForProperty('hasClass', function(test) {
       /matched more than one element. If this is not an error use { multiple: true }/);
   });
 
-  test('matches multiple elements with multiple: true option returns false if not all elements have class', async function(assert) {
-    let page = create({
-      foo: hasClass('lorem', 'span', { multiple: true })
-    });
-
-    await this.adapter.createTemplate(this, page, `
-      <span class="lorem"></span>
-      <span class="ipsum"></span>
-    `);
-
-    assert.ok(!page.foo);
-  });
-
-  test('matches multiple elements with multiple: true option returns true if all elements have class', async function(assert) {
-    let page = create({
-      foo: hasClass('lorem', 'span', { multiple: true })
-    });
-
-    await this.adapter.createTemplate(this, page, `
-      <span class="lorem"></span>
-      <span class="lorem"></span>
-    `);
-
-    assert.ok(page.foo);
-  });
-
   test('finds element by index', async function(assert) {
     let page = create({
       foo: hasClass('ipsum', 'span', { at: 1 })

--- a/tests/unit/-private/properties/is-hidden-test.ts
+++ b/tests/unit/-private/properties/is-hidden-test.ts
@@ -92,32 +92,6 @@ moduleForProperty('isHidden', function(test) {
       /matched more than one element. If this is not an error use { multiple: true }/);
   });
 
-  test('matches multiple elements with multiple: true option, returns true if all elements are hidden', async function(assert) {
-    let page = create({
-      foo: isHidden('em', { multiple: true })
-    });
-
-    await this.adapter.createTemplate(this, page, `
-      <em style="display:none">ipsum</em>
-      <em style="display:none">dolor</em>
-    `);
-
-    assert.ok(page.foo);
-  });
-
-  test('matches multiple elements with multiple: true option, returns false if some elements are visible', async function(assert) {
-    let page = create({
-      foo: isHidden('em', { multiple: true })
-    });
-
-    await this.adapter.createTemplate(this, page, `
-      <em>ipsum</em>
-      <em style="display:none">dolor</em>
-    `);
-
-    assert.ok(!page.foo);
-  });
-
   test('finds element by index', async function(assert) {
     let page = create({
       foo: isHidden('em', { at: 2 })

--- a/tests/unit/-private/properties/is-hidden-test.ts
+++ b/tests/unit/-private/properties/is-hidden-test.ts
@@ -89,7 +89,7 @@ moduleForProperty('isHidden', function(test) {
     `);
 
     assert.throws(() => page.foo,
-      /matched more than one element. If this is not an error use { multiple: true }/);
+      /matched more than one element. If you want to select many elements, use collections instead./);
   });
 
   test('finds element by index', async function(assert) {

--- a/tests/unit/-private/properties/is-present-test.ts
+++ b/tests/unit/-private/properties/is-present-test.ts
@@ -87,7 +87,7 @@ moduleForProperty('isPresent', function(test) {
     `);
 
     assert.throws(() => page.foo,
-      /matched more than one element. If this is not an error use { multiple: true }/);
+      /matched more than one element. If you want to select many elements, use collections instead./);
   });
 
   test('finds element by index', async function(assert) {

--- a/tests/unit/-private/properties/is-present-test.ts
+++ b/tests/unit/-private/properties/is-present-test.ts
@@ -90,20 +90,6 @@ moduleForProperty('isPresent', function(test) {
       /matched more than one element. If this is not an error use { multiple: true }/);
   });
 
-  test('matches multiple elements with multiple: true option', async function(assert) {
-    let page = create({
-      foo: isPresent('span', { multiple: true })
-    });
-
-    await this.adapter.createTemplate(this, page, `
-      <span>lorem</span>
-      <span> ipsum </span>
-      <span>dolor</span>
-    `);
-
-    assert.ok(page.foo);
-  });
-
   test('finds element by index', async function(assert) {
     let page = create({
       foo: isPresent('em', { at: 0 }),

--- a/tests/unit/-private/properties/is-test.js
+++ b/tests/unit/-private/properties/is-test.js
@@ -103,7 +103,7 @@ moduleForProperty('is', function(test) {
     `);
 
     assert.throws(() => page.foo,
-      /matched more than one element. If this is not an error use { multiple: true }/);
+      /matched more than one element. If you want to select many elements, use collections instead./);
   });
 
   test('matches multiple elements', async function(assert) {

--- a/tests/unit/-private/properties/is-visible-test.ts
+++ b/tests/unit/-private/properties/is-visible-test.ts
@@ -87,7 +87,7 @@ moduleForProperty('isVisible', function(test) {
     `);
 
     assert.throws(() => page.foo,
-      /matched more than one element. If this is not an error use { multiple: true }/);
+      /matched more than one element. If you want to select many elements, use collections instead./);
   });
 
   test('finds element by index', async function(assert) {

--- a/tests/unit/-private/properties/is-visible-test.ts
+++ b/tests/unit/-private/properties/is-visible-test.ts
@@ -90,33 +90,6 @@ moduleForProperty('isVisible', function(test) {
       /matched more than one element. If this is not an error use { multiple: true }/);
   });
 
-  test('matches multiple elements with multiple: true option, return false if not all elements are visible', async function(assert) {
-    let page = create({
-      foo: isVisible('span', { multiple: true })
-    });
-
-    await this.adapter.createTemplate(this, page, `
-      <span>lorem</span>
-      <span style="display:none"> ipsum </span>
-      <span>dolor</span>
-    `);
-
-    assert.ok(!page.foo);
-  });
-
-  test('matches multiple elements with multiple: true option, return true if all elements are visible', async function(assert) {
-    let page = create({
-      foo: isVisible('span', { multiple: true })
-    });
-
-    await this.adapter.createTemplate(this, page, `
-      <span>lorem</span>
-      <span>dolor</span>
-    `);
-
-    assert.ok(page.foo);
-  });
-
   test('finds element by index', async function(assert) {
     let page = create({
       foo: isVisible('em', { at: 0 }),

--- a/tests/unit/-private/properties/not-has-class-test.ts
+++ b/tests/unit/-private/properties/not-has-class-test.ts
@@ -104,7 +104,7 @@ moduleForProperty('notHasClass', function(test) {
     `);
 
     assert.throws(() => page.foo,
-      /matched more than one element. If this is not an error use { multiple: true }/);
+      /matched more than one element. If you want to select many elements, use collections instead./);
   });
 
   test('finds element by index', async function(assert) {

--- a/tests/unit/-private/properties/not-has-class-test.ts
+++ b/tests/unit/-private/properties/not-has-class-test.ts
@@ -107,32 +107,6 @@ moduleForProperty('notHasClass', function(test) {
       /matched more than one element. If this is not an error use { multiple: true }/);
   });
 
-  test('matches multiple elements with multiple: true option, returns true if no elements have class', async function(assert) {
-    let page = create({
-      foo: notHasClass('other-class', 'span', { multiple: true })
-    });
-
-    await this.adapter.createTemplate(this, page, `
-      <span class="lorem"></span>
-      <span class="ipsum"></span>
-    `);
-
-    assert.ok(page.foo);
-  });
-
-  test('matches multiple elements with multiple: true option, returns false if some elements have class', async function(assert) {
-    let page = create({
-      foo: notHasClass('lorem', 'span', { multiple: true })
-    });
-
-    await this.adapter.createTemplate(this, page, `
-      <span class="lorem"></span>
-      <span class="ipsum"></span>
-    `);
-
-    assert.ok(!page.foo);
-  });
-
   test('finds element by index', async function(assert) {
     let page = create({
       foo: notHasClass('lorem', 'span', { at: 1 })

--- a/tests/unit/-private/properties/property-test.ts
+++ b/tests/unit/-private/properties/property-test.ts
@@ -100,7 +100,7 @@ moduleForProperty('property', function(test) {
     `);
 
     assert.throws(() => page.foo,
-      /matched more than one element. If this is not an error use { multiple: true }/);
+      /matched more than one element. If you want to select many elements, use collections instead./);
   });
 
   test('finds element by index', async function(assert) {

--- a/tests/unit/-private/properties/property-test.ts
+++ b/tests/unit/-private/properties/property-test.ts
@@ -103,19 +103,6 @@ moduleForProperty('property', function(test) {
       /matched more than one element. If this is not an error use { multiple: true }/);
   });
 
-  test('matches multiple elements', async function(assert) {
-    let page = create({
-      foo: property('checked', ':input', { multiple: true })
-    });
-
-    await this.adapter.createTemplate(this, page, `
-      <input type="checkbox" checked>
-      <input type="checkbox" >
-    `);
-
-    assert.deepEqual(page.foo, [true, false]);
-  });
-
   test('finds element by index', async function(assert) {
     let page = create({
       foo: property('checked', ':input', { at: 1 })

--- a/tests/unit/-private/properties/text-test.ts
+++ b/tests/unit/-private/properties/text-test.ts
@@ -175,22 +175,6 @@ moduleForProperty('text', function(test) {
       /matched more than one element. If this is not an error use { multiple: true }/);
   });
 
-  test('returns multiple values', async function(assert) {
-    let page = create({
-      foo: text('li', { multiple: true })
-    });
-
-    await this.adapter.createTemplate(this, page, `
-      <ul>
-        <li>lorem</li>
-        <li> ipsum </li>
-        <li>dolor</li>
-      </ul>
-    `);
-
-    assert.deepEqual(page.foo as any, ['lorem', 'ipsum', 'dolor']);
-  });
-
   test('looks for elements outside the testing container', async function(assert) {
     let page = create({
       foo: text('h1', { testContainer: '#alternate-ember-testing' })

--- a/tests/unit/-private/properties/text-test.ts
+++ b/tests/unit/-private/properties/text-test.ts
@@ -172,7 +172,7 @@ moduleForProperty('text', function(test) {
     `);
 
     assert.throws(() => page.foo,
-      /matched more than one element. If this is not an error use { multiple: true }/);
+      /matched more than one element. If you want to select many elements, use collections instead./);
   });
 
   test('looks for elements outside the testing container', async function(assert) {

--- a/tests/unit/-private/properties/value-test.ts
+++ b/tests/unit/-private/properties/value-test.ts
@@ -102,7 +102,7 @@ moduleForProperty('value', function(test) {
     `);
 
     assert.throws(() => page.foo,
-      /matched more than one element. If this is not an error use { multiple: true }/);
+      /matched more than one element. If you want to select many elements, use collections instead./);
   });
 
   test('finds element by index', async function(assert) {

--- a/tests/unit/-private/properties/value-test.ts
+++ b/tests/unit/-private/properties/value-test.ts
@@ -105,19 +105,6 @@ moduleForProperty('value', function(test) {
       /matched more than one element. If this is not an error use { multiple: true }/);
   });
 
-  test('matches multiple elements with multiple: true option', async function(assert) {
-    let page = create({
-      foo: value('input', { multiple: true })
-    });
-
-    await this.adapter.createTemplate(this, page, `
-      <input value="lorem">
-      <input value="ipsum">
-    `);
-
-    assert.deepEqual(page.foo as any, ['lorem', 'ipsum']);
-  });
-
   test('finds element by index', async function(assert) {
     let page = create({
       foo: value('input', { at: 1 })

--- a/tests/unit/extend/find-one-test.ts
+++ b/tests/unit/extend/find-one-test.ts
@@ -34,7 +34,7 @@ if (require.has('@ember/test-helpers')) {
       await this.render(hbs`<em class="lorem"></em><em class="lorem"></em><span class="ipsum"></span>`);
 
       assert.throws(() => findOne(page, '.lorem', {}),
-        /Error: Assertion Failed: ".lorem" matched more than one element. If this is not an error use { multiple: true }/);
+        /Error: Assertion Failed: ".lorem" matched more than one element. If you want to select many elements, use collections instead./);
     });
 
     test('throws error if 0 elements found', async function(assert) {


### PR DESCRIPTION
It unnecessarily complicates internals.

`collection` or `findMany` should be used instead.

todo:
 - [x] deprecation section
 - [x] update [`guardMultiple`](https://github.com/san650/ember-cli-page-object/blob/f999ebaa8425f9b075aa5ed37e9a24392b4beec5/addon-test-support/-private/helpers.js#L97) to not recommend using `multiple`