### PR TITLE
Restore IE compatibility

### DIFF
--- a/addon-test-support/-private/helpers.js
+++ b/addon-test-support/-private/helpers.js
@@ -173,13 +173,12 @@ export function every(jqArray, cb) {
  *
  */
 export function filterWhitelistedOption(options, whitelist) {
-  const result = {};
-  for (let [key, value] of Object.entries(options)) {
-    if(whitelist.includes(key)) {
-      result[key] = value;
+  return whitelist.reduce((whitelisted, knownKey) => {
+    if (knownKey in options) {
+        whitelisted[knownKey] = options[knownKey];
     }
-  }
-  return result;
+    return whitelisted;
+  }, {});
 }
 
 /**


### PR DESCRIPTION
With the recent finders implementation we involved `Object.entries(`, which isn't supported by IE

Since ember supports IE, we should also do it.

see:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in