### PR TITLE
Work-around failing engines for globby on CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,5 +106,8 @@
   "bugs": "https://github.com/san650/ember-cli-page-object/issues",
   "ember-addon": {
     "configPath": "tests/dummy/config"
+  },
+  "resolutions": {
+    "sort-package-json": "~1.40.0"
   }
 }


### PR DESCRIPTION
https://github.com/keithamus/sort-package-json/pull/161 upgraded globby which drops support for node@8