### PR TITLE
Remove findElement(withAssert) deprecations

### DIFF
--- a/addon-test-support/extend/find-element-with-assert.js
+++ b/addon-test-support/extend/find-element-with-assert.js
@@ -37,12 +37,6 @@ import { deprecate } from '@ember/application/deprecations';
  * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function findElementWithAssert(pageObjectNode, targetSelector, options = {}) {
-  deprecate('findElementWithAssert is deprecated, please use findOne or findMany instead', false, {
-    id: 'ember-cli-page-object.old-finders',
-    until: '2.0.0',
-    url: 'https://ember-cli-page-object.js.org/docs/v1.16.x/deprecations/#old-finders'
-  });
-
   const shouldShowMutlipleDeprecation = 'multiple' in options;
   deprecate('"multiple" property is deprecated', !shouldShowMutlipleDeprecation, {
     id: 'ember-cli-page-object.multiple',

--- a/addon-test-support/extend/find-element.js
+++ b/addon-test-support/extend/find-element.js
@@ -35,12 +35,6 @@ import { deprecate } from '@ember/application/deprecations';
  * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function findElement(pageObjectNode, targetSelector, options = {}) {
-  deprecate('findElement is deprecated, please use findOne or findMany instead', false, {
-    id: 'ember-cli-page-object.old-finders',
-    until: '2.0.0',
-    url: 'https://ember-cli-page-object.js.org/docs/v1.16.x/deprecations/#old-finders'
-  });
-
   const shouldShowMutlipleDeprecation = 'multiple' in options;
   deprecate('"multiple" property is deprecated', !shouldShowMutlipleDeprecation, {
     id: 'ember-cli-page-object.multiple',

--- a/guides/deprecations.md
+++ b/guides/deprecations.md
@@ -355,35 +355,3 @@ test('renders component', function(assert) {
   this.render(hbs`{{foo}}`);
 });
 ```
-
-## Old finders
-
-**ID**: ember-cli-page-object.old-finders
-
-**Until**: 2.0.0
-
-Using `findElement` and `findElementWithAssert` is deprecated. Please use `findOne` or `findMany` instead.
-
-```js
-import { findOne, findMany } from 'ember-cli-page-object/extend';
-
-export default function isDisabled(selector, options = {}) {
-  return {
-    isDescriptor: true,
-
-    get() {
-      return findOne(this, selector, options).disabled;
-    }
-  };
-}
-
-export default function count(selector, options = {}) {
-  return {
-    isDescriptor: true,
-
-    get() {
-      return findMany(this, selector, options).length;
-    }
-  };
-}
-```

--- a/guides/extend.md
+++ b/guides/extend.md
@@ -10,8 +10,8 @@ You can create custom helpers by creating `Ceibo` descriptors. (`Ceibo` is a sma
 
 - [findOne](#findone)
 - [findMany](#findmany)
-- [findElementWithAssert](#findelementwithassert) **[Deprecated]**
-- [findElement](#findelement) **[Deprecated]**
+- [findElementWithAssert](#findelementwithassert)
+- [findElement](#findelement)
 
 ## findOne
 
@@ -81,6 +81,8 @@ export default function count(selector, options = {}) {
 
 [addon/-private/extend/find-element-with-assert.js:38-44](https://github.com/san650/ember-cli-page-object/blob/c521335ffba9955a6acaf1006ed503cbb61ba72d/addon/-private/extend/find-element-with-assert.js#L38-L44 "Source code on GitHub")
 
+Note: in the v2 series we are going to remove `findElementWithAssert`. It's recommended to migrate to use `findOne` instead. In order to ease the migration, you can use a [`find-one`](https://github.com/ro0gr/ember-page-object-codemod/tree/master/transforms/find-one) codemod.
+
 **Parameters**
 
 -   `pageObjectNode` **Ceibo** Node of the tree
@@ -114,6 +116,8 @@ export default function isDisabled(selector, options = {}) {
 ## findElement
 
 [addon/-private/extend/find-element.js:36-42](https://github.com/san650/ember-cli-page-object/blob/c521335ffba9955a6acaf1006ed503cbb61ba72d/addon/-private/extend/find-element.js#L36-L42 "Source code on GitHub")
+
+Note: in the v2 series we are going to remove `findElement`. It's recommended to migrate to use `findMany` instead.
 
 **Parameters**
 

--- a/guides/extend.md
+++ b/guides/extend.md
@@ -81,7 +81,9 @@ export default function count(selector, options = {}) {
 
 [addon/-private/extend/find-element-with-assert.js:38-44](https://github.com/san650/ember-cli-page-object/blob/c521335ffba9955a6acaf1006ed503cbb61ba72d/addon/-private/extend/find-element-with-assert.js#L38-L44 "Source code on GitHub")
 
-Note: in the v2 series we are going to remove `findElementWithAssert`. It's recommended to migrate to use `findOne` instead. In order to ease the migration, you can use a [`find-one`](https://github.com/ro0gr/ember-page-object-codemod/tree/master/transforms/find-one) codemod.
+Note: in the v2 series we are going to deprecate `findElementWithAssert`. It's recommended to migrate to use `findOne` instead.
+
+In order to ease the migration, you may find useful the [`find-one`](https://github.com/ro0gr/ember-page-object-codemod/tree/master/transforms/find-one) codemod to perform the migration.
 
 **Parameters**
 
@@ -117,7 +119,7 @@ export default function isDisabled(selector, options = {}) {
 
 [addon/-private/extend/find-element.js:36-42](https://github.com/san650/ember-cli-page-object/blob/c521335ffba9955a6acaf1006ed503cbb61ba72d/addon/-private/extend/find-element.js#L36-L42 "Source code on GitHub")
 
-Note: in the v2 series we are going to remove `findElement`. It's recommended to migrate to use `findMany` instead.
+Note: in the v2 series we are going to deprecate `findElement`. It's recommended to migrate to use `findMany` instead.
 
 **Parameters**
 


### PR DESCRIPTION
The deprecation was a bit premature, since alternative finders has just appeared.

Raising a deprecation now means users will immediatelly get warnings, once update to 1.17, which is not friendly enough.

Instead of deprecation we now just recommend to migrate to `findOne`, and include a link to the codemod.

Let's deprecate it later, somewhere in scope of v2.