### PR TITLE
Pull v1

### DIFF
--- a/addon-test-support/-private/execution_context.js
+++ b/addon-test-support/-private/execution_context.js
@@ -28,13 +28,11 @@ export function getExecutionContext(pageObjectNode) {
   let contextName;
   if (integrationTestContext) {
     contextName = 'integration';
-  } else if (isAcceptanceTest()) {
-    contextName = 'acceptance';
   } else if (supportsRfc268()) {
     contextName = 'rfc268';
-  }
-
-  if (!contextName) {
+  } else if (isAcceptanceTest()) {
+    contextName = 'acceptance';
+  } else {
     throw new Error(`Looks like you attempt to access page object property outside of test context.
 If that's not the case, please make sure you use the latest version of "@ember/test-helpers".`);
   }

--- a/addon-test-support/-private/execution_context/acceptance.js
+++ b/addon-test-support/-private/execution_context/acceptance.js
@@ -18,13 +18,6 @@ export default function AcceptanceExecutionContext(pageObjectNode) {
 }
 
 AcceptanceExecutionContext.prototype = {
-  get testContainer() {
-    // @todo: fix usage of private `_element`
-    return this.testContext ?
-      this.testContext._element :
-      '#ember-testing';
-  },
-
   andThen(cb) {
     return window.wait().then(() => {
       cb(this);
@@ -103,6 +96,19 @@ AcceptanceExecutionContext.prototype = {
         { selector }
       );
     }
+  },
+
+  find(selector, options) {
+    let result;
+
+    selector = buildSelector(this.pageObjectNode, selector, options);
+
+    /* global find */
+    result = find(selector, options.testContainer || findClosestValue(this.pageObjectNode, 'testContainer'));
+
+    guardMultiple(result, selector, options.multiple);
+
+    return result;
   },
 
   findWithAssert(selector, options) {

--- a/addon-test-support/-private/execution_context/integration.js
+++ b/addon-test-support/-private/execution_context/integration.js
@@ -22,13 +22,6 @@ export default function IntegrationExecutionContext(pageObjectNode, testContext)
 }
 
 IntegrationExecutionContext.prototype = {
-  get testContainer() {
-    // @todo: fix usage of private `_element`
-    return this.testContext ?
-      this.testContext._element :
-      '#ember-testing';
-  },
-
   andThen(cb) {
     run(() => {
       cb(this)
@@ -120,6 +113,23 @@ IntegrationExecutionContext.prototype = {
         { selector }
       );
     }
+  },
+
+  find(selector, options) {
+    let result;
+    let container = options.testContainer || findClosestValue(this.pageObjectNode, 'testContainer');
+
+    selector = buildSelector(this.pageObjectNode, selector, options);
+
+    if (container) {
+      result = $(selector, container);
+    } else {
+      result = this.testContext.$(selector);
+    }
+
+    guardMultiple(result, selector, options.multiple);
+
+    return result;
   },
 
   findWithAssert(selector, options) {

--- a/addon-test-support/-private/execution_context/rfc268.js
+++ b/addon-test-support/-private/execution_context/rfc268.js
@@ -25,10 +25,6 @@ export default function ExecutionContext(pageObjectNode) {
 }
 
 ExecutionContext.prototype = {
-  get testContainer() {
-    return getRootElement();
-  },
-
   runAsync(cb) {
     return run(this.pageObjectNode, cb);
   },
@@ -78,6 +74,15 @@ ExecutionContext.prototype = {
     }
   },
 
+  find(selector, options) {
+    selector = buildSelector(this.pageObjectNode, selector, options);
+    let result = this.getElements(selector, options);
+
+    guardMultiple(result, selector, options.multiple);
+
+    return result;
+  },
+
   findWithAssert(selector, options) {
     selector = buildSelector(this.pageObjectNode, selector, options);
     let result = this.getElements(selector, options);
@@ -98,8 +103,11 @@ ExecutionContext.prototype = {
 
   getElements(selector, options) {
     let container = options.testContainer || findClosestValue(this.pageObjectNode, 'testContainer');
-
-    return $(selector, container || this.testContainer);
+    if (container) {
+      return $(selector, container);
+    } else {
+      return $(selector, getRootElement());
+    }
   },
 
   invokeHelper(selector, options, helper, ...args) {

--- a/addon-test-support/-private/helpers.js
+++ b/addon-test-support/-private/helpers.js
@@ -1,4 +1,5 @@
 export { assign } from '@ember/polyfills';
+import { A } from '@ember/array';
 import { assert } from '@ember/debug';
 import { get } from '@ember/object';
 import { isPresent } from '@ember/utils';
@@ -91,10 +92,10 @@ class Selector {
   }
 }
 
-export function guardMultiple(items, selector) {
+export function guardMultiple(items, selector, supportMultiple) {
   assert(
     `"${selector}" matched more than one element. If you want to select many elements, use collections instead.`,
-    items.length <= 1
+    supportMultiple || items.length <= 1
   );
 }
 
@@ -143,6 +144,26 @@ export function guardMultiple(items, selector) {
  */
 export function buildSelector(node, targetSelector, options) {
   return (new Selector(node, options.scope, targetSelector, options)).toString();
+}
+
+/**
+ * @private
+ *
+ * Trim whitespaces at both ends and normalize whitespaces inside `text`
+ *
+ * Due to variations in the HTML parsers in different browsers, the text
+ * returned may vary in newlines and other white space.
+ *
+ * @see http://api.jquery.com/text/
+ */
+export function normalizeText(text) {
+  return $.trim(text).replace(/\n/g, ' ').replace(/\s\s*/g, ' ');
+}
+
+export function every(jqArray, cb) {
+  let arr = jqArray.get();
+
+  return A(arr).every((element) => cb($(element)));
 }
 
 /**

--- a/addon-test-support/extend/find-element-with-assert.js
+++ b/addon-test-support/extend/find-element-with-assert.js
@@ -37,10 +37,12 @@ import { deprecate } from '@ember/application/deprecations';
  * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function findElementWithAssert(pageObjectNode, targetSelector, options = {}) {
-  deprecate('findElementWithAssert is deprecated, please use findOne or findMany instead', false, {
-    id: 'ember-cli-page-object.old-finders',
+  const shouldShowMutlipleDeprecation = 'multiple' in options;
+  deprecate('"multiple" property is deprecated', !shouldShowMutlipleDeprecation, {
+    id: 'ember-cli-page-object.multiple',
     until: '2.0.0',
-    url: 'https://ember-cli-page-object.js.org/docs/v1.16.x/deprecations/#old-finders'
+    url: 'https://ember-cli-page-object.js.org/docs/v1.17.x/deprecations/#multiple',
   });
+
   return getExecutionContext(pageObjectNode).findWithAssert(targetSelector, options);
 }

--- a/addon-test-support/extend/find-element.js
+++ b/addon-test-support/extend/find-element.js
@@ -35,10 +35,11 @@ import { deprecate } from '@ember/application/deprecations';
  * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function findElement(pageObjectNode, targetSelector, options = {}) {
-  deprecate('findElement is deprecated, please use findOne or findMany instead', false, {
-    id: 'ember-cli-page-object.old-finders',
+  const shouldShowMutlipleDeprecation = 'multiple' in options;
+  deprecate('"multiple" property is deprecated', !shouldShowMutlipleDeprecation, {
+    id: 'ember-cli-page-object.multiple',
     until: '2.0.0',
-    url: 'https://ember-cli-page-object.js.org/docs/v1.16.x/deprecations/#old-finders'
+    url: 'https://ember-cli-page-object.js.org/docs/v1.17.x/deprecations/#multiple',
   });
 
   return getExecutionContext(pageObjectNode).find(targetSelector, options);

--- a/addon-test-support/extend/find-element.js
+++ b/addon-test-support/extend/find-element.js
@@ -1,0 +1,45 @@
+import { getExecutionContext } from '../-private/execution_context';
+import { deprecate } from '@ember/application/deprecations';
+
+/**
+ * @public
+ *
+ * Returns a jQuery element (can be an empty jQuery result)
+ *
+ * @example
+ *
+ * import { findElement } from 'ember-cli-page-object/extend';
+ *
+ * export default function isDisabled(selector, options = {}) {
+ *   return {
+ *     isDescriptor: true,
+ *
+ *     get() {
+ *       return findElement(this, selector, options).is(':disabled');
+ *     }
+ *   };
+ * }
+ *
+ * @param {Ceibo} pageObjectNode - Node of the tree
+ * @param {string} targetSelector - Specific CSS selector
+ * @param {Object} options - Additional options
+ * @param {boolean} options.resetScope - Do not use inherited scope
+ * @param {string} options.contains - Filter by using :contains('foo') pseudo-class
+ * @param {number} options.at - Filter by index using :eq(x) pseudo-class
+ * @param {boolean} options.last - Filter by using :last pseudo-class
+ * @param {boolean} options.visible - Filter by using :visible pseudo-class
+ * @param {boolean} options.multiple - Specify if built selector can match multiple elements.
+ * @param {string} options.testContainer - Context where to search elements in the DOM
+ * @return {Object} jQuery object
+ *
+ * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
+ */
+export function findElement(pageObjectNode, targetSelector, options = {}) {
+  deprecate('findElement is deprecated, please use findOne or findMany instead', false, {
+    id: 'ember-cli-page-object.old-finders',
+    until: '2.0.0',
+    url: 'https://ember-cli-page-object.js.org/docs/v1.16.x/deprecations/#old-finders'
+  });
+
+  return getExecutionContext(pageObjectNode).find(targetSelector, options);
+}

--- a/addon-test-support/extend/find-many.js
+++ b/addon-test-support/extend/find-many.js
@@ -1,10 +1,6 @@
-import $ from '-jquery';
-import {
-  buildSelector,
-  findClosestValue,
-} from '../-private/helpers';
+import { deprecate } from '@ember/application/deprecations';
 import { getExecutionContext } from '../-private/execution_context';
-
+import { filterWhitelistedOption } from '../-private/helpers';
 /**
  * @public
  *
@@ -37,10 +33,15 @@ import { getExecutionContext } from '../-private/execution_context';
  * @return {Array} of Element
  */
 export function findMany(pageObjectNode, targetSelector, options = {}) {
-  const selector = buildSelector(pageObjectNode, targetSelector, options);
-  const container = options.testContainer
-    || findClosestValue(pageObjectNode, 'testContainer')
-    || getExecutionContext(pageObjectNode).testContainer;
+  deprecate('"multiple" property is deprecated', false === '__multiple__' in options , {
+    id: 'ember-cli-page-object.multiple',
+    until: '2.0.0',
+    url: 'https://ember-cli-page-object.js.org/docs/v1.17.x/deprecations/#multiple',
+  });
 
-  return $(selector, container).toArray();
+  const filteredOptions = filterWhitelistedOption(options, [
+    'resetScope', 'visible', 'testContainer', 'contains', 'scope', 'at', 'last'
+  ]);
+  const opts = Object.assign({}, filteredOptions, { multiple: true });
+  return getExecutionContext(pageObjectNode).find(targetSelector, opts).get();
 }

--- a/addon-test-support/extend/find-many.js
+++ b/addon-test-support/extend/find-many.js
@@ -33,7 +33,8 @@ import { filterWhitelistedOption } from '../-private/helpers';
  * @return {Array} of Element
  */
 export function findMany(pageObjectNode, targetSelector, options = {}) {
-  deprecate('"multiple" property is deprecated', false === '__multiple__' in options , {
+  const shouldShowMutlipleDeprecation = 'multiple' in options;
+  deprecate('"multiple" property is deprecated', !shouldShowMutlipleDeprecation, {
     id: 'ember-cli-page-object.multiple',
     until: '2.0.0',
     url: 'https://ember-cli-page-object.js.org/docs/v1.17.x/deprecations/#multiple',

--- a/addon-test-support/extend/index.js
+++ b/addon-test-support/extend/index.js
@@ -1,3 +1,4 @@
+export { findElement } from './find-element';
 export { findElementWithAssert } from './find-element-with-assert';
 export { findOne } from './find-one';
 export { findMany } from './find-many';

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -20,6 +20,7 @@ import { triggerable } from './properties/triggerable';   export { triggerable }
 import { value }       from './properties/value';         export { value };
 import { visitable }   from './properties/visitable';     export { visitable };
 
+export { findElement } from './extend/find-element';
 export { findElementWithAssert } from './extend/find-element-with-assert';
 export { buildSelector, getContext } from './-private/helpers';
 

--- a/addon-test-support/properties/attribute.js
+++ b/addon-test-support/properties/attribute.js
@@ -1,3 +1,4 @@
+import $ from '-jquery';
 import { assign } from '../-private/helpers';
 import { findMany, findOne } from '../extend';
 
@@ -80,12 +81,12 @@ export function attribute(attributeName, selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
+      let options = assign({ pageObjectKey: key }, userOptions);
 
       if (options.multiple) {
-        return findMany(this, selector, options).map(element => element.getAttribute(attributeName), options);
+        return findMany(this, selector, options).map(element => $(element).attr(attributeName));
       } else {
-        return findOne(this, selector, options).getAttribute(attributeName);
+        return $(findOne(this, selector, options)).attr(attributeName);
       }
     }
   };

--- a/addon-test-support/properties/attribute.js
+++ b/addon-test-support/properties/attribute.js
@@ -1,5 +1,5 @@
 import { assign } from '../-private/helpers';
-import { findOne } from '../extend';
+import { findMany, findOne } from '../extend';
 
 /**
  * @public
@@ -17,6 +17,19 @@ import { findOne } from '../extend';
  * });
  *
  * assert.equal(page.inputPlaceholder, 'a value');
+ *
+ * @example
+ *
+ * // <input placeholder="a value">
+ * // <input placeholder="other value">
+ *
+ * import { create, attribute } from 'ember-cli-page-object';
+ *
+ * const page = create({
+ *   inputPlaceholders: attribute('placeholder', ':input', { multiple: true })
+ * });
+ *
+ * assert.deepEqual(page.inputPlaceholders, ['a value', 'other value']);
  *
  * @example
  *
@@ -67,10 +80,13 @@ export function attribute(attributeName, selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key }, userOptions);
-      let element = findOne(this, selector, options);
+      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
 
-      return element.getAttribute(attributeName);
+      if (options.multiple) {
+        return findMany(this, selector, options).map(element => element.getAttribute(attributeName), options);
+      } else {
+        return findOne(this, selector, options).getAttribute(attributeName);
+      }
     }
   };
 }

--- a/addon-test-support/properties/blurrable.js
+++ b/addon-test-support/properties/blurrable.js
@@ -69,7 +69,7 @@ export function blurrable(selector, userOptions = {}) {
     get(key) {
       return function() {
         const executionContext = getExecutionContext(this);
-        const options = assign({ pageObjectKey: `${key}()`, __multiple__: true }, userOptions);
+        const options = assign({ pageObjectKey: `${key}()` }, userOptions);
 
         return executionContext.runAsync((context) => {
           return context.blur(selector, options);

--- a/addon-test-support/properties/blurrable.js
+++ b/addon-test-support/properties/blurrable.js
@@ -69,7 +69,7 @@ export function blurrable(selector, userOptions = {}) {
     get(key) {
       return function() {
         const executionContext = getExecutionContext(this);
-        const options = assign({ pageObjectKey: `${key}()` }, userOptions);
+        const options = assign({ pageObjectKey: `${key}()`, __multiple__: true }, userOptions);
 
         return executionContext.runAsync((context) => {
           return context.blur(selector, options);

--- a/addon-test-support/properties/click-on-text/helpers.js
+++ b/addon-test-support/properties/click-on-text/helpers.js
@@ -1,4 +1,3 @@
-import { findMany } from '../../extend'
 import {
   assign,
   buildSelector as originalBuildSelector
@@ -9,9 +8,9 @@ function childSelector(pageObjectNode, context, selector, options) {
   // In this case <form> and <button> elements contains "Submit" text, so, we'll
   // want to __always__ click on the __last__ element that contains the text.
   let selectorWithSpace = `${selector || ''} `;
-  let opts = assign({ last: true }, options);
+  let opts = assign({ last: true, multiple: true }, options);
 
-  if (findMany(pageObjectNode, selectorWithSpace, opts).length) {
+  if (context.find(selectorWithSpace, opts).length) {
     return originalBuildSelector(pageObjectNode, selectorWithSpace, opts);
   }
 }

--- a/addon-test-support/properties/contains.js
+++ b/addon-test-support/properties/contains.js
@@ -1,5 +1,6 @@
 import { assign } from '../-private/helpers';
-import { findOne } from '../extend';
+import { findMany, findOne } from '../extend';
+import { A } from '@ember/array';
 
 /**
  * Returns a boolean representing whether an element or a set of elements contains the specified text.
@@ -15,6 +16,33 @@ import { findOne } from '../extend';
  * });
  *
  * assert.ok(page.spanContains('ipsum'));
+ *
+ * @example
+ *
+ * // <span>lorem</span>
+ * // <span>ipsum</span>
+ * // <span>dolor</span>
+ *
+ * const page = PageObject.create({
+ *   spansContain: PageObject.contains('span', { multiple: true })
+ * });
+ *
+ * // not all spans contain 'lorem'
+ * assert.notOk(page.spansContain('lorem'));
+ *
+ * @example
+ *
+ * // <span>super text</span>
+ * // <span>regular text</span>
+ *
+ * import { create, contains } from 'ember-cli-page-object';
+ *
+ * const page = create({
+ *   spansContain: contains('span', { multiple: true })
+ * });
+ *
+ * // all spans contain 'text'
+ * assert.ok(page.spansContain('text'));
  *
  * @example
  *
@@ -70,9 +98,12 @@ export function contains(selector, userOptions = {}) {
       return function(textToSearch) {
         let options = assign({
           pageObjectKey: `${key}("${textToSearch}")`,
+          __multiple__: true
         }, userOptions);
 
-        return findOne(this, selector, options).innerText.indexOf(textToSearch) > -1;
+        let elements = options.multiple ? findMany(this, selector, options) : [findOne(this, selector, options)];
+
+        return A(elements).every((element) => element.innerText.indexOf(textToSearch) >= 0);
       };
     }
   };

--- a/addon-test-support/properties/contains.js
+++ b/addon-test-support/properties/contains.js
@@ -97,8 +97,7 @@ export function contains(selector, userOptions = {}) {
     get(key) {
       return function(textToSearch) {
         let options = assign({
-          pageObjectKey: `${key}("${textToSearch}")`,
-          __multiple__: true
+          pageObjectKey: `${key}("${textToSearch}")`
         }, userOptions);
 
         let elements = options.multiple ? findMany(this, selector, options) : [findOne(this, selector, options)];

--- a/addon-test-support/properties/has-class.js
+++ b/addon-test-support/properties/has-class.js
@@ -1,5 +1,6 @@
 import { assign } from '../-private/helpers';
-import { findOne } from '../extend';
+import { findOne, findMany } from '../extend';
+import { A } from '@ember/array';
 
 /**
  * Validates if an element or a set of elements have a given CSS class.
@@ -15,6 +16,32 @@ import { findOne } from '../extend';
  * });
  *
  * assert.ok(page.messageIsSuccess);
+ *
+ * @example
+ *
+ * // <span class="success"></span>
+ * // <span class="error"></span>
+ *
+ * import { create, hasClass } from 'ember-cli-page-object';
+ *
+ * const page = create({
+ *   messagesAreSuccessful: hasClass('success', 'span', { multiple: true })
+ * });
+ *
+ * assert.notOk(page.messagesAreSuccessful);
+ *
+ * @example
+ *
+ * // <span class="success"></span>
+ * // <span class="success"></span>
+ *
+ * import { create, hasClass } from 'ember-cli-page-object';
+ *
+ * const page = create({
+ *   messagesAreSuccessful: hasClass('success', 'span', { multiple: true })
+ * });
+ *
+ * assert.ok(page.messagesAreSuccessful);
  *
  * @example
  *
@@ -71,11 +98,11 @@ export function hasClass(cssClass, selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key }, userOptions);
+      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
 
-      let element = findOne(this, selector, options);
+      let elements = options.multiple ? findMany(this, selector, options) : [findOne(this, selector, options)];
 
-      return element.classList.contains(cssClass);
+      return A(elements).every((element) => element.classList.contains(cssClass));
     }
   };
 }

--- a/addon-test-support/properties/has-class.js
+++ b/addon-test-support/properties/has-class.js
@@ -98,7 +98,7 @@ export function hasClass(cssClass, selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
+      let options = assign({ pageObjectKey: key }, userOptions);
 
       let elements = options.multiple ? findMany(this, selector, options) : [findOne(this, selector, options)];
 

--- a/addon-test-support/properties/is-hidden.js
+++ b/addon-test-support/properties/is-hidden.js
@@ -1,5 +1,6 @@
 import { assign, guardMultiple } from '../-private/helpers';
 import { findMany } from '../extend';
+import { A } from '@ember/array';
 import $ from '-jquery';
 
 /**
@@ -16,6 +17,34 @@ import $ from '-jquery';
  * });
  *
  * assert.ok(page.spanIsHidden);
+ *
+ * @example
+ *
+ * // <span>ipsum</span>
+ * // <span style="display:none">dolor</span>
+ *
+ * import { create, isHidden } from 'ember-cli-page-object';
+ *
+ * const page = create({
+ *   spansAreHidden: isHidden('span', { multiple: true })
+ * });
+ *
+ * // not all spans are hidden
+ * assert.notOk(page.spansAreHidden);
+ *
+ * @example
+ *
+ * // <span style="display:none">dolor</span>
+ * // <span style="display:none">dolor</span>
+ *
+ * import { create, isHidden } from 'ember-cli-page-object';
+ *
+ * const page = create({
+ *   spansAreHidden: isHidden('span', { multiple: true })
+ * });
+ *
+ * // all spans are hidden
+ * assert.ok(page.spansAreHidden);
  *
  * @example
  *
@@ -77,13 +106,14 @@ export function isHidden(selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key }, userOptions);
+      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
 
       let elements = findMany(this, selector, options);
 
-      guardMultiple(elements, selector);
+      guardMultiple(elements, selector, options.multiple);
 
-      return elements.length === 0 || $(elements[0]).is(':hidden');
+      return elements.length === 0 ||
+        A(elements).every(element => $(element).is(':hidden'));
     }
   };
 }

--- a/addon-test-support/properties/is-hidden.js
+++ b/addon-test-support/properties/is-hidden.js
@@ -106,7 +106,7 @@ export function isHidden(selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
+      let options = assign({ pageObjectKey: key }, userOptions);
 
       let elements = findMany(this, selector, options);
 

--- a/addon-test-support/properties/is-present.js
+++ b/addon-test-support/properties/is-present.js
@@ -84,7 +84,7 @@ export function isPresent(selector, userOptions = {}) {
   return {
     isDescriptor: true,
     get(key) {
-      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
+      let options = assign({ pageObjectKey: key }, userOptions);
 
       let elements = findMany(this, selector, options);
       guardMultiple(elements, selector, options.multiple);

--- a/addon-test-support/properties/is-present.js
+++ b/addon-test-support/properties/is-present.js
@@ -27,6 +27,19 @@ import { assign, guardMultiple } from '../-private/helpers';
  *
  * @example
  *
+ * // <span>ipsum</span>
+ * // <span style="display:none">dolor</span>
+ *
+ * import { create, isPresent } from 'ember-cli-page-object';
+ *
+ * const page = create({
+ *   spanIsPresent: isPresent('span', { multiple: true })
+ * });
+ *
+ * assert.ok(page.spanIsPresent);
+ *
+ * @example
+ *
  * // <head>
  * //   <meta name='robots' content='noindex'>
  * // </head>
@@ -71,12 +84,11 @@ export function isPresent(selector, userOptions = {}) {
   return {
     isDescriptor: true,
     get(key) {
-      let options = assign({ pageObjectKey: key }, userOptions);
+      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
 
       let elements = findMany(this, selector, options);
-      guardMultiple(elements, selector);
-
-      return elements.length === 1;
+      guardMultiple(elements, selector, options.multiple);
+      return elements.length > 0;
     }
   };
 }

--- a/addon-test-support/properties/is-visible.js
+++ b/addon-test-support/properties/is-visible.js
@@ -1,5 +1,6 @@
 import { assign, guardMultiple } from '../-private/helpers';
 import { findMany } from '../extend';
+import { A } from '@ember/array';
 import $ from '-jquery';
 
 /**
@@ -16,6 +17,34 @@ import $ from '-jquery';
  * });
  *
  * assert.ok(page.spanIsVisible);
+ *
+ * @example
+ *
+ * // <span>ipsum</span>
+ * // <span style="display:none">dolor</span>
+ *
+ * import { create, isVisible } from 'ember-cli-page-object';
+ *
+ * const page = create({
+ *   spansAreVisible: isVisible('span', { multiple: true })
+ * });
+ *
+ * // not all spans are visible
+ * assert.notOk(page.spansAreVisible);
+ *
+ * @example
+ *
+ * // <span>ipsum</span>
+ * // <span>dolor</span>
+ *
+ * import { create, isVisible } from 'ember-cli-page-object';
+ *
+ * const page = create({
+ *   spansAreVisible: isVisible('span', { multiple: true })
+ * });
+ *
+ * // all spans are visible
+ * assert.ok(page.spansAreVisible);
  *
  * @example
  *
@@ -83,12 +112,16 @@ export function isVisible(selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key }, userOptions);
+      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
 
       let elements = findMany(this, selector, options);
       guardMultiple(elements, selector, options.multiple);
 
-      return elements.length === 1 && $(elements[0]).is(':visible');
+      if (elements.length === 0) {
+        return false;
+      }
+
+      return A(elements).every((element) => $(element).is(':visible'));
     }
   };
 }

--- a/addon-test-support/properties/is-visible.js
+++ b/addon-test-support/properties/is-visible.js
@@ -112,7 +112,7 @@ export function isVisible(selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
+      let options = assign({ pageObjectKey: key }, userOptions);
 
       let elements = findMany(this, selector, options);
       guardMultiple(elements, selector, options.multiple);

--- a/addon-test-support/properties/not-has-class.js
+++ b/addon-test-support/properties/not-has-class.js
@@ -102,7 +102,7 @@ export function notHasClass(cssClass, selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
+      let options = assign({ pageObjectKey: key }, userOptions);
 
       let elements = options.multiple ? findMany(this, selector, options) : [findOne(this, selector, options)];
 

--- a/addon-test-support/properties/not-has-class.js
+++ b/addon-test-support/properties/not-has-class.js
@@ -1,5 +1,6 @@
 import { assign } from '../-private/helpers';
-import { findOne } from '../extend';
+import { findOne, findMany } from '../extend';
+import { A } from '@ember/array';
 
 /**
  * @public
@@ -17,6 +18,34 @@ import { findOne } from '../extend';
  * });
  *
  * assert.ok(page.messageIsSuccess);
+ *
+ * @example
+ *
+ * // <span class="success"></span>
+ * // <span class="error"></span>
+ *
+ * import { create, notHasClass } from 'ember-cli-page-object';
+ *
+ * const page = create({
+ *   messagesAreSuccessful: notHasClass('error', 'span', { multiple: true })
+ * });
+ *
+ * // one span has error class
+ * assert.notOk(page.messagesAreSuccessful);
+ *
+ * @example
+ *
+ * // <span class="success"></span>
+ * // <span class="success"></span>
+ *
+ * import { create, notHasClass } from 'ember-cli-page-object';
+ *
+ * const page = create({
+ *   messagesAreSuccessful: notHasClass('error', 'span', { multiple: true })
+ * });
+ *
+ * // no spans have error class
+ * assert.ok(page.messagesAreSuccessful);
  *
  * @example
  *
@@ -73,11 +102,11 @@ export function notHasClass(cssClass, selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key }, userOptions);
+      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
 
-      let element = findOne(this, selector, options);
+      let elements = options.multiple ? findMany(this, selector, options) : [findOne(this, selector, options)];
 
-      return !element.classList.contains(cssClass);
+      return A(elements).every((element) => !element.classList.contains(cssClass));
     }
   };
 }

--- a/addon-test-support/properties/property.js
+++ b/addon-test-support/properties/property.js
@@ -65,7 +65,7 @@ export function property(propertyName, selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
+      let options = assign({ pageObjectKey: key }, userOptions);
 
       if (options.multiple) {
         return findMany(this, selector, options).map(element => $(element).prop(propertyName));

--- a/addon-test-support/properties/property.js
+++ b/addon-test-support/properties/property.js
@@ -1,5 +1,5 @@
 import { assign } from '../-private/helpers';
-import { findOne } from '../extend';
+import { findMany, findOne } from '../extend';
 import $ from '-jquery';
 
 /**
@@ -65,9 +65,13 @@ export function property(propertyName, selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key }, userOptions);
+      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
 
-      return $(findOne(this, selector, options)).prop(propertyName);
+      if (options.multiple) {
+        return findMany(this, selector, options).map(element => $(element).prop(propertyName));
+      } else {
+        return $(findOne(this, selector, options)).prop(propertyName);
+      }
     }
   };
 }

--- a/addon-test-support/properties/text.js
+++ b/addon-test-support/properties/text.js
@@ -1,5 +1,5 @@
-import { assign } from '../-private/helpers';
-import { findOne } from '../extend';
+import { assign, normalizeText } from '../-private/helpers';
+import { findMany, findOne } from '../extend';
 import $ from '-jquery';
 
 function identity(v) {
@@ -105,24 +105,14 @@ export function text(selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key }, userOptions);
+      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
       let f = options.normalize === false ? identity : normalizeText;
 
-      return f($(findOne(this, selector, options)).text());
+      if (options.multiple) {
+        return findMany(this, selector, options).map(element => f($(element).text()));
+      } else {
+        return f($(findOne(this, selector, options)).text());
+      }
     }
   };
-}
-
-/**
- * @private
- *
- * Trim whitespaces at both ends and normalize whitespaces inside `text`
- *
- * Due to variations in the HTML parsers in different browsers, the text
- * returned may vary in newlines and other white space.
- *
- * @see http://api.jquery.com/text/
- */
-function normalizeText(text) {
-  return text.trim().replace(/\n/g, ' ').replace(/\s\s*/g, ' ');
 }

--- a/addon-test-support/properties/text.js
+++ b/addon-test-support/properties/text.js
@@ -105,7 +105,7 @@ export function text(selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
+      let options = assign({ pageObjectKey: key }, userOptions);
       let f = options.normalize === false ? identity : normalizeText;
 
       if (options.multiple) {

--- a/addon-test-support/properties/value.js
+++ b/addon-test-support/properties/value.js
@@ -92,7 +92,7 @@ export function value(selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
+      let options = assign({ pageObjectKey: key }, userOptions);
 
       const checkValue = (element) => element.hasAttribute('contenteditable') ? $(element).html() : $(element).val();
 

--- a/addon-test-support/properties/value.js
+++ b/addon-test-support/properties/value.js
@@ -1,5 +1,5 @@
 import { assign } from '../-private/helpers';
-import { findOne } from '../extend';
+import { findMany, findOne } from '../extend';
 import $ from '-jquery';
 
 /**
@@ -32,6 +32,19 @@ import $ from '-jquery';
  * });
  *
  * assert.equal(page.value, '<b>Lorem ipsum</b>');
+ *
+ * @example
+ *
+ * // <input value="lorem">
+ * // <input value="ipsum">
+ *
+ * import { create, value } from 'ember-cli-page-object';
+ *
+ * const page = create({
+ *   value: value('input', { multiple: true })
+ * });
+ *
+ * assert.deepEqual(page.value, ['lorem', 'ipsum']);
  *
  * @example
  *
@@ -79,11 +92,15 @@ export function value(selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      let options = assign({ pageObjectKey: key }, userOptions);
+      let options = assign({ pageObjectKey: key, __multiple__: true }, userOptions);
 
-      const element = findOne(this, selector, options);
+      const checkValue = (element) => element.hasAttribute('contenteditable') ? $(element).html() : $(element).val();
 
-      return element.hasAttribute('contenteditable') ? $(element).html() : $(element).val();
+      if (options.multiple) {
+        return findMany(this, selector, options).map(checkValue);
+      } else {
+        return checkValue(findOne(this, selector, options));
+      }
     }
   };
 }

--- a/guides/deprecations.md
+++ b/guides/deprecations.md
@@ -355,35 +355,3 @@ test('renders component', function(assert) {
   this.render(hbs`{{foo}}`);
 });
 ```
-
-## Old finders
-
-**ID**: ember-cli-page-object.old-finders
-
-**Until**: 2.0.0
-
-Using `findElement` and `findElementWithAssert` is deprecated. Please use `findOne` or `findMany` instead.
-
-```js
-import { findOne, findMany } from 'ember-cli-page-object/extend';
-
-export default function isDisabled(selector, options = {}) {
-  return {
-    isDescriptor: true,
-
-    get() {
-      return findOne(this, selector, options).disabled;
-    }
-  };
-}
-
-export default function count(selector, options = {}) {
-  return {
-    isDescriptor: true,
-
-    get() {
-      return findMany(this, selector, options).length;
-    }
-  };
-}
-```

--- a/guides/extend.md
+++ b/guides/extend.md
@@ -11,6 +11,7 @@ You can create custom helpers by creating `Ceibo` descriptors. (`Ceibo` is a sma
 - [findOne](#findone)
 - [findMany](#findmany)
 - [findElementWithAssert](#findelementwithassert) **[Deprecated]**
+- [findElement](#findelement) **[Deprecated]**
 
 ## findOne
 
@@ -109,5 +110,51 @@ export default function isDisabled(selector, options = {}) {
   };
 }
 ```
+
+## findElement
+
+[addon/-private/extend/find-element.js:36-42](https://github.com/san650/ember-cli-page-object/blob/c521335ffba9955a6acaf1006ed503cbb61ba72d/addon/-private/extend/find-element.js#L36-L42 "Source code on GitHub")
+
+**Parameters**
+
+-   `pageObjectNode` **Ceibo** Node of the tree
+-   `targetSelector` **string** Specific CSS selector
+-   `options` **Object** Additional options
+    -   `options.resetScope` **boolean** Do not use inherited scope
+    -   `options.contains` **string** Filter by using :contains('foo') pseudo-class
+    -   `options.at` **number** Filter by index using :eq(x) pseudo-class
+    -   `options.last` **boolean** Filter by using :last pseudo-class
+    -   `options.visible` **boolean** Filter by using :visible pseudo-class
+    -   `options.multiple` **boolean** Specify if built selector can match multiple elements.
+    -   `options.testContainer` **String** Context where to search elements in the DOM
+
+**Examples**
+
+```javascript
+import { findElement } from 'ember-cli-page-object/extend';
+
+export default function isDisabled(selector, options = {}) {
+  return {
+    isDescriptor: true,
+
+    get() {
+      return findElement(this, selector, options).is(':disabled');
+    }
+  };
+}
+```
+
+Usage Example:
+
+```js
+const page = create({
+  scope: '.page',
+
+  isAdmin: disabled('#override-name')
+});
+```
+
+`page.isAdmin` will look for elements in the DOM that match ".page
+\#override-name" and check if they are disabled.
 
 {% endraw %}

--- a/guides/extend.md
+++ b/guides/extend.md
@@ -10,8 +10,8 @@ You can create custom helpers by creating `Ceibo` descriptors. (`Ceibo` is a sma
 
 - [findOne](#findone)
 - [findMany](#findmany)
-- [findElementWithAssert](#findelementwithassert) **[Deprecated]**
-- [findElement](#findelement) **[Deprecated]**
+- [findElementWithAssert](#findelementwithassert)
+- [findElement](#findelement)
 
 ## findOne
 
@@ -81,6 +81,10 @@ export default function count(selector, options = {}) {
 
 [addon/-private/extend/find-element-with-assert.js:38-44](https://github.com/san650/ember-cli-page-object/blob/c521335ffba9955a6acaf1006ed503cbb61ba72d/addon/-private/extend/find-element-with-assert.js#L38-L44 "Source code on GitHub")
 
+Note: in the v2 series we are going to deprecate `findElementWithAssert`. It's recommended to migrate to use `findOne` instead.
+
+In order to ease the migration, you may find useful the [`find-one`](https://github.com/ro0gr/ember-page-object-codemod/tree/master/transforms/find-one) codemod to perform the migration.
+
 **Parameters**
 
 -   `pageObjectNode` **Ceibo** Node of the tree
@@ -114,6 +118,8 @@ export default function isDisabled(selector, options = {}) {
 ## findElement
 
 [addon/-private/extend/find-element.js:36-42](https://github.com/san650/ember-cli-page-object/blob/c521335ffba9955a6acaf1006ed503cbb61ba72d/addon/-private/extend/find-element.js#L36-L42 "Source code on GitHub")
+
+Note: in the v2 series we are going to deprecate `findElement`. It's recommended to migrate to use `findMany` instead.
 
 **Parameters**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-page-object",
-  "version": "1.17.0",
+  "version": "1.17.2",
   "description": "This ember-cli addon eases the construction of page objects on your acceptance and integration tests",
   "keywords": [
     "acceptance",
@@ -45,7 +45,7 @@
     "ember-cli-babel": "^6.16.0",
     "ember-cli-node-assets": "^0.2.2",
     "ember-native-dom-helpers": "^0.6.3",
-    "jquery": "^3.2.1",
+    "jquery": "3.4.1",
     "rsvp": "^4.7.0"
   },
   "devDependencies": {
@@ -106,5 +106,8 @@
   "bugs": "https://github.com/san650/ember-cli-page-object/issues",
   "ember-addon": {
     "configPath": "tests/dummy/config"
+  },
+  "resolutions": {
+    "sort-package-json": "~1.40.0"
   }
 }

--- a/test-support/page-object.js
+++ b/test-support/page-object.js
@@ -76,7 +76,7 @@ export default {
   visitable
 };
 
-export { buildSelector, findElementWithAssert, getContext, fullScope } from 'ember-cli-page-object';
+export { buildSelector, findElementWithAssert, findElement, getContext, fullScope } from 'ember-cli-page-object';
 
 deprecate(`Importing from "test-support" is now deprecated. Please import directly from the "ember-cli-page-object" module instead.`, false, {
   id: 'ember-cli-page-object.import-from-test-support',

--- a/tests/acceptance/extension-helpers-test.ts
+++ b/tests/acceptance/extension-helpers-test.ts
@@ -6,6 +6,7 @@ import {
 } from 'ember-cli-page-object';
 
 import {
+  findElement,
   findElementWithAssert
 } from 'ember-cli-page-object/extend';
 
@@ -13,6 +14,10 @@ moduleForAcceptance('Acceptance | extends');
 
 let page = create({
   visit: visitable('/calculator'),
+
+  findElement(this: any, selector: string) {
+    return findElement(this, selector);
+  },
 
   findElementWithAssert(this: any, selector: string) {
     return findElementWithAssert(this, selector);
@@ -22,6 +27,9 @@ let page = create({
 test('finds an element in the DOM', async function(assert) {
   await page.visit();
 
-  let element = page.findElementWithAssert('.screen');
+  let element = page.findElement('.screen');
+  assert.ok(element.length);
+
+  element = page.findElementWithAssert('.screen');
   assert.ok(element.length);
 });

--- a/tests/acceptance/rfc268-extension-helpers-test.ts
+++ b/tests/acceptance/rfc268-extension-helpers-test.ts
@@ -5,6 +5,7 @@ import {
   visitable
 } from 'ember-cli-page-object';
 import {
+  findElement,
   findElementWithAssert
 } from 'ember-cli-page-object/extend';
 import require from 'require';
@@ -16,6 +17,10 @@ if (require.has('@ember/test-helpers')) {
     let page = create({
       visit: visitable('/calculator'),
 
+      findElement(this: any, selector: string) {
+        return findElement(this, selector);
+      },
+
       findElementWithAssert(this: any, selector: string) {
         return findElementWithAssert(this, selector);
       }
@@ -24,7 +29,10 @@ if (require.has('@ember/test-helpers')) {
     test('finds an element in the DOM', async function(assert) {
       await page.visit();
 
-      let element = page.findElementWithAssert('.screen');
+      let element = page.findElement('.screen');
+      assert.ok(element.length);
+
+      element = page.findElementWithAssert('.screen');
       assert.ok(element.length);
     });
   });

--- a/tests/integration/deprecations/multiple-test.js
+++ b/tests/integration/deprecations/multiple-test.js
@@ -149,6 +149,20 @@ if (require.has('@ember/test-helpers')) {
       assert.expectDeprecation('"multiple" property is deprecated');
     });
 
+    test('isVisible: does not trigger deprecation', async function(assert) {
+      const page = create({
+        foo: isVisible('span')
+      });
+
+      await render(hbs`
+        <span>lorem</span>
+      `);
+
+      assert.equal(page.foo, true)
+      assert.expectNoDeprecation();
+    });
+
+
     test('isVisible: return true if all elements are visible', async function(assert) {
       let page = create({
         foo: isVisible('span', { multiple: true })

--- a/tests/integration/deprecations/multiple-test.js
+++ b/tests/integration/deprecations/multiple-test.js
@@ -1,0 +1,258 @@
+import { module, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+import {
+  attribute,
+  contains,
+  create,
+  hasClass,
+  isHidden,
+  isPresent,
+  isVisible,
+  notHasClass,
+  property,
+  text,
+  value,
+} from 'ember-cli-page-object';
+
+import require from 'require';
+if (require.has('@ember/test-helpers')) {
+  const { render } = require('@ember/test-helpers');
+
+  module('Deprecation | multiple', function(hooks) {
+    setupRenderingTest(hooks);
+
+    test('attribute', async function(assert) {
+      let page = create({
+        foo: attribute('placeholder', ':input', { multiple: true })
+      });
+
+      await render(hbs`
+        <input placeholder="a value">
+        <input placeholder="other value">
+      `);
+
+      assert.deepEqual(page.foo, ['a value', 'other value']);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('value', async function(assert) {
+      let page = create({
+        foo: value('input', { multiple: true })
+      });
+
+      await render(hbs`
+        <input value="lorem">
+        <input value="ipsum">
+      `);
+
+      assert.deepEqual(page.foo, ['lorem', 'ipsum']);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('text: returns multiple values', async function(assert) {
+      let page = create({
+        foo: text('li', { multiple: true })
+      });
+
+      await render(hbs`
+        <ul>
+          <li>lorem</li>
+          <li> ipsum </li>
+          <li>dolor</li>
+        </ul>
+      `);
+
+      assert.deepEqual(page.foo, ['lorem', 'ipsum', 'dolor']);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('property: matches multiple elements', async function(assert) {
+      let page = create({
+        foo: property('checked', ':input', { multiple: true })
+      });
+
+      await render(hbs`
+        <input type="checkbox" checked>
+        <input type="checkbox" >
+      `);
+
+      assert.deepEqual(page.foo, [true, false]);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('notHasClass: matches multiple elements with multiple: true option, returns false if some elements have class', async function(assert) {
+      let page = create({
+        foo: notHasClass('lorem', 'span', { multiple: true })
+      });
+
+      await render(hbs`
+        <span class="lorem"></span>
+        <span class="ipsum"></span>
+      `);
+
+      assert.ok(!page.foo);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('notHasClass: matches multiple elements with multiple: true option, returns true if no elements have class', async function(assert) {
+      let page = create({
+        foo: notHasClass('other-class', 'span', { multiple: true })
+      });
+
+      await render(hbs`
+        <span class="lorem"></span>
+        <span class="ipsum"></span>
+      `);
+
+      assert.ok(page.foo);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('isPresent: matches multiple elements with multiple: true option', async function(assert) {
+      let page = create({
+        foo: isPresent('span', { multiple: true })
+      });
+
+      await render(hbs`
+        <span>lorem</span>
+        <span> ipsum </span>
+        <span>dolor</span>
+      `);
+
+      assert.ok(page.foo);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+
+    test('isVisible: return false if not all elements are visible', async function(assert) {
+      let page = create({
+        foo: isVisible('span', { multiple: true })
+      });
+
+      await render(hbs`
+        <span>lorem</span>
+        <span style="display:none"> ipsum </span>
+        <span>dolor</span>
+      `);
+
+      assert.ok(!page.foo);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('isVisible: return true if all elements are visible', async function(assert) {
+      let page = create({
+        foo: isVisible('span', { multiple: true })
+      });
+
+      await render(hbs`
+        <span>lorem</span>
+        <span>dolor</span>
+      `);
+
+      assert.ok(page.foo);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('isHidden: true option, returns false if some elements are visible', async function(assert) {
+      let page = create({
+        foo: isHidden('em', { multiple: true })
+      });
+
+      await render(hbs`
+        <em>ipsum</em>
+        <em style="display:none">dolor</em>
+      `);
+
+      assert.ok(!page.foo);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('isHidden: true option, returns true if all elements are hidden', async function(assert) {
+      let page = create({
+        foo: isHidden('em', { multiple: true })
+      });
+
+      await render(hbs`
+        <em style="display:none">ipsum</em>
+        <em style="display:none">dolor</em>
+      `);
+
+      assert.ok(page.foo);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('hasClass: true option returns true if all elements have class', async function(assert) {
+      let page = create({
+        foo: hasClass('lorem', 'span', { multiple: true })
+      });
+
+      await render(hbs`
+        <span class="lorem"></span>
+        <span class="lorem"></span>
+      `);
+
+      assert.ok(page.foo);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('hasClass: true option returns false if not all elements have class', async function(assert) {
+      let page = create({
+        foo: hasClass('lorem', 'span', { multiple: true })
+      });
+
+      await render(hbs`
+        <span class="lorem"></span>
+        <span class="ipsum"></span>
+      `);
+
+      assert.ok(!page.foo);
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('contains: returns false if not all elements contain text', async function(assert) {
+      let page = create({
+        foo: contains('span', { multiple: true })
+      });
+
+      await render(hbs`
+        <span>lorem</span>
+        <span>ipsum</span>
+        <span>dolor</span>
+      `);
+
+      assert.ok(!page.foo('lorem'));
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+
+    test('contains: returns true if all elements contain text', async function(assert) {
+      let page = create({
+        foo: contains('span', { multiple: true })
+      });
+
+      await render(hbs`
+        <span>lorem</span>
+        <span>lorem</span>
+      `);
+
+      assert.ok(page.foo('lorem'));
+
+      assert.expectDeprecation('"multiple" property is deprecated');
+    });
+  });
+}

--- a/tests/unit/-private/properties/attribute-test.js
+++ b/tests/unit/-private/properties/attribute-test.js
@@ -119,4 +119,28 @@ moduleForProperty('attribute', function(test) {
 
     assert.equal(page.foo, 'a value');
   });
+
+  test('normalizes value', async function(assert) {
+    let page = create({
+      foo: attribute('disabled', 'span'),
+      nonExisting: attribute('non-existing', 'span')
+    });
+
+    await this.adapter.createTemplate(this, page, '<span disabled>');
+
+    assert.equal(page.foo, 'disabled');
+    assert.strictEqual(page.nonExisting, undefined);
+  });
+
+  test('normalizes value with multiple', async function(assert) {
+    let page = create({
+      foo: attribute('disabled', 'span', { multiple: true }),
+      nonExisting: attribute('non-existing', 'span', { multiple: true })
+    });
+
+    await this.adapter.createTemplate(this, page, '<span disabled>');
+
+    assert.deepEqual(page.foo, ['disabled']);
+    assert.deepEqual(page.nonExisting, [undefined]);
+  });
 });

--- a/tests/unit/addon-exports-test.js
+++ b/tests/unit/addon-exports-test.js
@@ -32,6 +32,7 @@ const EXPECTED_METHODS = [
 const HELPER_METHODS = [
   'buildSelector',
   'getContext',
+  'findElement',
   'findElementWithAssert'
 ];
 

--- a/tests/unit/extend/find-element-test.ts
+++ b/tests/unit/extend/find-element-test.ts
@@ -1,0 +1,181 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { create } from 'ember-cli-page-object';
+import { findElement } from 'ember-cli-page-object/extend';
+import hbs from 'htmlbars-inline-precompile';
+import require from 'require';
+
+if (require.has('@ember/test-helpers')) {
+  module(`Extend | findElement`, function(hooks) {
+    setupRenderingTest(hooks);
+
+    test('finds by selector and returns jQuery elements collection', async function(assert) {
+      let page = create({});
+
+      await this.render(hbs`<em class="lorem">1</em><span class="ipsum">2</span>`);
+
+      const foundElements = findElement(page, '.lorem');
+
+      assert.equal(foundElements.length, 1);
+      assert.ok(foundElements.jquery);
+      assert.deepEqual(
+        foundElements.toArray().map((el) => el.innerText),
+        ['1']
+      );
+    });
+
+    test('finds deeper in scope', async function(assert) {
+      let page = create({ scope: '.lorem' });
+
+      await this.render(hbs`
+      <em class="lorem">
+        <span class="dolor">1</span>
+      </em>
+      <span class="ipsum">
+        <span class="dolor">2</span>
+      </span>
+    `);
+
+      const foundElements = findElement(page, '.dolor');
+      assert.equal(foundElements.length, 1);
+      assert.deepEqual(
+        foundElements.toArray().map((e) => e.innerText),
+        ['1']
+      );
+    });
+
+    test('returns empty list when no elements found', async function(assert) {
+      let page = create({});
+
+      await this.render(hbs`<em class="lorem"></em>`);
+
+      assert.deepEqual(findElement(page, '.ipsum', {}).length, 0);
+    });
+
+    test('testContainer param', async function(assert) {
+      let page = create({});
+
+      await this.render(hbs`
+        <span class="ipsum">1</span>
+        <div class="new-test-root">
+          <span class="ipsum">2</span>
+        </div>
+      `);
+
+      assert.deepEqual(
+        findElement(page, '.ipsum', {
+          testContainer: '.new-test-root'
+        }).toArray().map(e => e.innerText),
+        ['2']
+      );
+    });
+
+    test('resetScope param', async function(assert) {
+      let page = create({ scope: 'my-page' });
+
+      await this.render(hbs`
+        <span class="lorem">1</span>
+        <div class="my-page">
+          <span class="ipsum">2</span>
+          <span class="ipsum">3</span>
+        </div>
+      `);
+
+      assert.deepEqual(
+        findElement(page, '.lorem', { resetScope: true }).toArray().map((el) => el.innerText),
+        ['1']
+      );
+    });
+
+    test('contains param', async function(assert) {
+      let page = create({});
+
+      await this.render(hbs`
+        <span class="lorem" id="1"></span>
+        <span class="lorem" id="2">Word</span>
+      `);
+
+      assert.deepEqual(
+        findElement(page, '.lorem', { contains: 'Word' }).toArray().map((el) => el.id),
+        ['2']
+      );
+    });
+
+    test('scope param', async function(assert) {
+      let page = create({});
+
+      await this.render(hbs`
+        <span class="lorem">1</span>
+        <span class="ipsum">
+          <span class="lorem">2</span>
+        </span>
+      `);
+
+      assert.deepEqual(
+        findElement(page, '.lorem', { scope: '.ipsum' }).toArray().map((el) => el.innerText),
+        ['2']
+      );
+    });
+
+    test('visible param', async function(assert) {
+      let page = create({});
+
+      await this.render(hbs`
+        <span class="lorem" style="display:none">1</span>
+        <span class="lorem">2</span>
+      `);
+
+      assert.deepEqual(
+        findElement(page, '.lorem', { visible: true }).toArray().map((el) => el.innerText),
+        ['2']
+      );
+    });
+
+    test('at param', async function(assert) {
+      let page = create({});
+
+      await this.render(hbs`
+        <span class="lorem">1</span>
+        <span class="lorem">2</span>
+        <span class="lorem">3</span>
+      `);
+
+      assert.deepEqual(
+        findElement(page, '.lorem', { at: 1 }).toArray().map((el) => el.innerText),
+        ['2']
+      );
+    });
+
+    test('last param', async function(assert) {
+      let page = create({});
+
+      await this.render(hbs`
+        <span class="lorem">1</span>
+        <span class="lorem">2</span>
+        <span class="lorem">3</span>
+      `);
+
+      assert.deepEqual(
+        findElement(page, '.lorem', { last: true }).toArray().map((el) => el.innerText),
+        ['3']
+      );
+    });
+
+    test('multiple param', async function(assert) {
+      let page = create({});
+
+      await this.render(hbs`
+        <span class="lorem">1</span>
+        <span class="lorem">2</span>
+        <span class="lorem">3</span>
+      `);
+
+      assert.deepEqual(
+        findElement(page, '.lorem', { multiple: true }).toArray().map((el) => el.innerText),
+        ['1', '2', '3']
+      );
+
+      ( assert as any ).expectDeprecation('"multiple" property is deprecated');
+    });
+  });
+}

--- a/tests/unit/extend/find-element-with-assert-test.ts
+++ b/tests/unit/extend/find-element-with-assert-test.ts
@@ -1,0 +1,183 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { create } from 'ember-cli-page-object';
+import { findElementWithAssert } from 'ember-cli-page-object/extend';
+import hbs from 'htmlbars-inline-precompile';
+
+import require from 'require';
+
+if (require.has('@ember/test-helpers')) {
+  module(`Extend | findElementWithAssert`, function(hooks) {
+    setupRenderingTest(hooks);
+
+    test('finds by selector and returns jQuery elements collection', async function(assert) {
+      let page = create({});
+
+      await this.render(hbs`<em class="lorem">1</em><span class="ipsum">2</span>`);
+
+      const foundElements = findElementWithAssert(page, '.lorem');
+
+      assert.equal(foundElements.length, 1);
+      assert.ok(foundElements.jquery);
+      assert.deepEqual(
+        foundElements.toArray().map((el) => el.innerText),
+        ['1']
+      );
+    });
+
+    test('finds deeper in scope', async function(assert) {
+      let page = create({ scope: '.lorem' });
+
+      await this.render(hbs`
+      <em class="lorem">
+        <span class="dolor">1</span>
+      </em>
+      <span class="ipsum">
+        <span class="dolor">2</span>
+      </span>
+    `);
+
+      const foundElements = findElementWithAssert(page, '.dolor');
+      assert.equal(foundElements.length, 1);
+      assert.deepEqual(
+        foundElements.toArray().map((e) => e.innerText),
+        ['1']
+      );
+    });
+
+    test('throws error if more than 1 element found', async function(assert) {
+      let page = create({});
+
+      await this.render(hbs`<em class="lorem"></em><em class="lorem"></em><span class="ipsum"></span>`);
+
+      assert.throws(() => findElementWithAssert(page, '.lorem', {}),
+        /Error: Assertion Failed: ".lorem" matched more than one element. If you want to select many elements, use collections instead./);
+    });
+
+    test('testContainer param', async function(assert) {
+      let page = create({});
+
+      await this.render(hbs`
+        <span class="ipsum">1</span>
+        <div class="new-test-root">
+          <span class="ipsum">2</span>
+        </div>
+      `);
+
+      assert.deepEqual(
+        findElementWithAssert(page, '.ipsum', {
+          testContainer: '.new-test-root'
+        }).toArray().map(e => e.innerText),
+        ['2']
+      );
+    });
+
+    test('resetScope param', async function(assert) {
+      let page = create({ scope: 'my-page' });
+
+      await this.render(hbs`
+        <span class="lorem">1</span>
+        <div class="my-page">
+          <span class="ipsum">2</span>
+          <span class="ipsum">3</span>
+        </div>
+      `);
+
+      assert.deepEqual(
+        findElementWithAssert(page, '.lorem', { resetScope: true }).toArray().map((el) => el.innerText),
+        ['1']
+      );
+    });
+
+    test('contains param', async function(assert) {
+      let page = create({});
+
+      await this.render(hbs`
+        <span class="lorem" id="1"></span>
+        <span class="lorem" id="2">Word</span>
+      `);
+
+      assert.deepEqual(
+        findElementWithAssert(page, '.lorem', { contains: 'Word' }).toArray().map((el) => el.id),
+        ['2']
+      );
+    });
+
+    test('scope param', async function(assert) {
+      let page = create({});
+
+      await this.render(hbs`
+        <span class="lorem">1</span>
+        <span class="ipsum">
+          <span class="lorem">2</span>
+        </span>
+      `);
+
+      assert.deepEqual(
+        findElementWithAssert(page, '.lorem', { scope: '.ipsum' }).toArray().map((el) => el.innerText),
+        ['2']
+      );
+    });
+
+    test('visible param', async function(assert) {
+      let page = create({});
+
+      await this.render(hbs`
+        <span class="lorem" style="display:none">1</span>
+        <span class="lorem">2</span>
+      `);
+
+      assert.deepEqual(
+        findElementWithAssert(page, '.lorem', { visible: true }).toArray().map((el) => el.innerText),
+        ['2']
+      );
+    });
+
+    test('at param', async function(assert) {
+      let page = create({});
+
+      await this.render(hbs`
+        <span class="lorem">1</span>
+        <span class="lorem">2</span>
+        <span class="lorem">3</span>
+      `);
+
+      assert.deepEqual(
+        findElementWithAssert(page, '.lorem', { at: 1 }).toArray().map((el) => el.innerText),
+        ['2']
+      );
+    });
+
+    test('last param', async function(assert) {
+      let page = create({});
+
+      await this.render(hbs`
+        <span class="lorem">1</span>
+        <span class="lorem">2</span>
+        <span class="lorem">3</span>
+      `);
+
+      assert.deepEqual(
+        findElementWithAssert(page, '.lorem', { last: true }).toArray().map((el) => el.innerText),
+        ['3']
+      );
+    });
+
+    test('multiple param', async function(assert) {
+      let page = create({});
+
+      await this.render(hbs`
+        <span class="lorem">1</span>
+        <span class="lorem">2</span>
+        <span class="lorem">3</span>
+      `);
+
+      assert.deepEqual(
+        findElementWithAssert(page, '.lorem', { multiple: true }).toArray().map((el) => el.innerText),
+        ['1', '2', '3']
+      );
+
+      ( assert as any ).expectDeprecation('"multiple" property is deprecated');
+    });
+  });
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -61,6 +61,7 @@ declare module 'ember-cli-page-object/extend' {
   import 'jquery';
   import { Component, FindOptions, FindOneOptions } from 'ember-cli-page-object/-private';
 
+  function findElement(pageObject: Component, scope?: string, options?: FindOptions): JQuery;
   function findElementWithAssert(pageObject: Component, scope?: string, options?: FindOptions): JQuery;
 
   function findOne(pageObject: Component, scope?: string, options?: FindOneOptions): Element;


### PR DESCRIPTION
and revert removal of find-element, which is not deprecated in v1 anymore, and would be deprecated a bit later in scope of v2.