### PR TITLE
[v2] remove "mutliple" deprecation from finders

### DIFF
--- a/addon-test-support/extend/find-element-with-assert.js
+++ b/addon-test-support/extend/find-element-with-assert.js
@@ -1,5 +1,4 @@
 import { getExecutionContext } from '../-private/execution_context';
-import { deprecate } from '@ember/application/deprecations';
 
 /**
  * @public
@@ -37,12 +36,5 @@ import { deprecate } from '@ember/application/deprecations';
  * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function findElementWithAssert(pageObjectNode, targetSelector, options = {}) {
-  const shouldShowMutlipleDeprecation = 'multiple' in options;
-  deprecate('"multiple" property is deprecated', !shouldShowMutlipleDeprecation, {
-    id: 'ember-cli-page-object.multiple',
-    until: '2.0.0',
-    url: 'https://ember-cli-page-object.js.org/docs/v1.17.x/deprecations/#multiple',
-  });
-
   return getExecutionContext(pageObjectNode).findWithAssert(targetSelector, options);
 }

--- a/addon-test-support/extend/find-element.js
+++ b/addon-test-support/extend/find-element.js
@@ -1,5 +1,4 @@
 import { getExecutionContext } from '../-private/execution_context';
-import { deprecate } from '@ember/application/deprecations';
 
 /**
  * @public
@@ -35,12 +34,5 @@ import { deprecate } from '@ember/application/deprecations';
  * @throws Will throw an error if multiple elements are matched by selector and multiple option is not set
  */
 export function findElement(pageObjectNode, targetSelector, options = {}) {
-  const shouldShowMutlipleDeprecation = 'multiple' in options;
-  deprecate('"multiple" property is deprecated', !shouldShowMutlipleDeprecation, {
-    id: 'ember-cli-page-object.multiple',
-    until: '2.0.0',
-    url: 'https://ember-cli-page-object.js.org/docs/v1.17.x/deprecations/#multiple',
-  });
-
   return getExecutionContext(pageObjectNode).find(targetSelector, options);
 }

--- a/tests/unit/extend/find-element-test.ts
+++ b/tests/unit/extend/find-element-test.ts
@@ -174,8 +174,6 @@ if (require.has('@ember/test-helpers')) {
         findElement(page, '.lorem', { multiple: true }).toArray().map((el) => el.innerText),
         ['1', '2', '3']
       );
-
-      ( assert as any ).expectDeprecation('"multiple" property is deprecated');
     });
   });
 }

--- a/tests/unit/extend/find-element-with-assert-test.ts
+++ b/tests/unit/extend/find-element-with-assert-test.ts
@@ -176,8 +176,6 @@ if (require.has('@ember/test-helpers')) {
         findElementWithAssert(page, '.lorem', { multiple: true }).toArray().map((el) => el.innerText),
         ['1', '2', '3']
       );
-
-      ( assert as any ).expectDeprecation('"multiple" property is deprecated');
     });
   });
 }


### PR DESCRIPTION
since support for `findElement{WithAssert}` has been restored in v1(https://github.com/san650/ember-cli-page-object/pull/502), and the goal to deprecate the `multiple` option for attributes was achieved, we can un-deprecate multiple for finders only, and remove it together with  `findElement{WithAssert}` later.

this would also be backported to 1.17.