### PR TITLE
unpin jquery

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ember-cli-babel": "^6.16.0",
     "ember-cli-node-assets": "^0.2.2",
     "ember-native-dom-helpers": "^0.6.3",
-    "jquery": "3.4.1",
+    "jquery": "^3.4.1",
     "rsvp": "^4.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I think this was a mistake in https://github.com/san650/ember-cli-page-object/pull/490. This prevents us from getting the latest jquery without using yarn resolutions or forking.