### PR TITLE
Use node@10 on travis, to appease qunit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "8"
+  - "10"
 
 addons:
   chrome: stable


### PR DESCRIPTION
unsupported node versions were dropped by QUnit recently, see: https://github.com/qunitjs/qunit/pull/1464