### PR TITLE
Set Node.js version to 10 in order to fix TravisCI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ env:
     # See https://git.io/vdao3 for details.
     - JOBS=1
 
+branches:
+  only:
+    - master
+
 jobs:
   fast_finish: true
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,6 @@ env:
     # See https://git.io/vdao3 for details.
     - JOBS=1
 
-branches:
-  only:
-    - master
-
 jobs:
   fast_finish: true
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "8"
+  - 12
 
 addons:
   chrome: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 12
+  - lts/*
 
 addons:
   chrome: stable
@@ -39,11 +39,16 @@ jobs:
     # as well as latest stable release (bonus points to beta/canary)
     - stage: "Additional Tests"
       env: EMBER_TRY_SCENARIO=node-tests
-    - env: EMBER_TRY_SCENARIO=ember-lts-2.4
-    - env: EMBER_TRY_SCENARIO=ember-lts-2.8
-    - env: EMBER_TRY_SCENARIO=ember-lts-2.12
-    - env: EMBER_TRY_SCENARIO=ember-lts-2.16
-    - env: EMBER_TRY_SCENARIO=ember-lts-2.18
+    - node_js: 6
+      env: EMBER_TRY_SCENARIO=ember-lts-2.4
+    - node_js: 0.12
+      env: EMBER_TRY_SCENARIO=ember-lts-2.8
+    - node_js: 7
+      env: EMBER_TRY_SCENARIO=ember-lts-2.12
+    - node_js: 8
+      env: EMBER_TRY_SCENARIO=ember-lts-2.16
+    - node_js: 9
+      env: EMBER_TRY_SCENARIO=ember-lts-2.18
     # keep testing integration and acceptance contexts
     - env: EMBER_TRY_SCENARIO=with-jquery COVERAGE=true
     - env: EMBER_TRY_SCENARIO=with-ember-test-helpers

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - lts/*
+  - 10
 
 addons:
   chrome: stable
@@ -35,16 +35,11 @@ jobs:
     # as well as latest stable release (bonus points to beta/canary)
     - stage: "Additional Tests"
       env: EMBER_TRY_SCENARIO=node-tests
-    - node_js: 6
-      env: EMBER_TRY_SCENARIO=ember-lts-2.4
-    - node_js: 0.12
-      env: EMBER_TRY_SCENARIO=ember-lts-2.8
-    - node_js: 7
-      env: EMBER_TRY_SCENARIO=ember-lts-2.12
-    - node_js: 8
-      env: EMBER_TRY_SCENARIO=ember-lts-2.16
-    - node_js: 9
-      env: EMBER_TRY_SCENARIO=ember-lts-2.18
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.4
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.8
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.12
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.16
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.18
     # keep testing integration and acceptance contexts
     - env: EMBER_TRY_SCENARIO=with-jquery COVERAGE=true
     - env: EMBER_TRY_SCENARIO=with-ember-test-helpers

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
----
 language: node_js
 node_js:
   - 12
@@ -6,7 +5,7 @@ node_js:
 addons:
   chrome: stable
 
-sudo: false
+os: linux
 dist: trusty
 
 cache:
@@ -22,7 +21,7 @@ branches:
     - master
 
 jobs:
-  fail_fast: true
+  fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
 


### PR DESCRIPTION
I’ve tried to follow [this guide](https://github.com/ember-cli/ember-cli/blob/master/docs/node-support.md#node-support) to set different Node versions according to the Ember CLI version but that didn’t work out so well ([here’s an example build](https://travis-ci.org/github/gnclmorais/ember-cli-page-object/builds/743370770)).

Setting the Node version to 10 [fixed the building process](https://travis-ci.org/github/gnclmorais/ember-cli-page-object/builds/743575169) (commit de132c2 allowed me to build branches that are not `master`).

This pull request’s commits can be squashed to only two: one sets the Node version to 10 and the other one (e8d872a) addresses a few issues with TravisCI configuration. Let me know what you think! 😃 

https://travis-ci.org/github/gnclmorais/ember-cli-page-object/builds/743575169