### PR TITLE
Do not warn when selecting a text with comma

### DIFF
--- a/addon-test-support/-private/helpers.js
+++ b/addon-test-support/-private/helpers.js
@@ -27,6 +27,15 @@ class Selector {
       scope = this.calculateScope(this.targetNode, this.targetScope);
     }
 
+    deprecate(
+      'Usage of comma separated selectors is deprecated in ember-cli-page-object',
+      `${scope} ${this.targetSelector}`.indexOf(',') === -1, {
+        id: 'ember-cli-page-object.comma-separated-selectors',
+        until: "2.0.0",
+        url: 'https://ember-cli-page-object.js.org/docs/v1.16.x/deprecations/#comma-separated-selectors',
+      }
+    );
+
     filters = this.calculateFilters(this.targetFilters);
 
     let selector = $.trim(`${scope} ${this.targetSelector}${filters}`);
@@ -36,14 +45,6 @@ class Selector {
       // testing container.
       selector = ':first';
     }
-
-    deprecate(
-      'Usage of comma separated selectors is deprecated in ember-cli-page-object', !this.isCommaSeparated(selector), {
-        id: 'ember-cli-page-object.comma-separated-selectors',
-        until: "2.0.0",
-        url: 'https://ember-cli-page-object.js.org/docs/v1.16.x/deprecations/#comma-separated-selectors',
-      }
-    );
 
     return selector;
   }
@@ -66,13 +67,6 @@ class Selector {
     }
 
     return filters.join('');
-  }
-
-  isCommaSeparated(selector) {
-    if (this.targetFilters.contains) {
-      selector = selector.replace(this.targetFilters.contains, '');
-    }
-    return selector.indexOf(',') > -1;
   }
 
   calculateScope(node, targetScope) {

--- a/addon-test-support/-private/helpers.js
+++ b/addon-test-support/-private/helpers.js
@@ -38,7 +38,7 @@ class Selector {
     }
 
     deprecate(
-      'Usage of comma separated selectors is deprecated in ember-cli-page-object', selector.indexOf(',') === -1, {
+      'Usage of comma separated selectors is deprecated in ember-cli-page-object', !this.isCommaSeparated(selector), {
         id: 'ember-cli-page-object.comma-separated-selectors',
         until: "2.0.0",
         url: 'https://ember-cli-page-object.js.org/docs/v1.16.x/deprecations/#comma-separated-selectors',
@@ -66,6 +66,13 @@ class Selector {
     }
 
     return filters.join('');
+  }
+
+  isCommaSeparated(selector) {
+    if (this.targetFilters.contains) {
+      selector = selector.replace(this.targetFilters.contains, '');
+    }
+    return selector.indexOf(',') > -1;
   }
 
   calculateScope(node, targetScope) {

--- a/tests/integration/deprecations/comma-separated-selector-test.js
+++ b/tests/integration/deprecations/comma-separated-selector-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-import { create, text } from 'dummy/tests/page-object';
+import { create, text, clickOnText } from 'dummy/tests/page-object';
 
 import require from 'require';
 if (require.has('@ember/test-helpers')) {
@@ -66,6 +66,20 @@ if (require.has('@ember/test-helpers')) {
       </div>`);
 
       page.text;
+
+      assert.expectNoDeprecation();
+    });
+
+    test('don\'t show deprecation when the selector contains text with comma', async function(assert) {
+      let page = create({
+        clickOnButton: clickOnText('button')
+      });
+
+      await render(hbs`<fieldset>
+        <button>Lorem, Ipsum</button>
+      </fieldset>`);
+
+      page.clickOnButton('Lorem, Ipsum');
 
       assert.expectNoDeprecation();
     });


### PR DESCRIPTION
When a text with comma is selected, the ember-cli-page-object produces a warning. Example:

```javascript
// <fieldset>
//  <button>Lorem, Ipsum</button>
// </fieldset>

import { create, clickOnText } from 'ember-cli-page-object';

const page = create({
  clickOnButton: clickOnText('button')
});

page.clickOnButton('Lorem, Ipsum'); // Usage of comma separated selectors is deprecated in ember-cli-page-object

```

Fixes https://github.com/san650/ember-cli-page-object/issues/518
Conflicts with https://github.com/san650/ember-cli-page-object/pull/494


