### PR TITLE
Allow undefined urls to be undeprecated

### DIFF
--- a/addon-test-support/create.js
+++ b/addon-test-support/create.js
@@ -197,7 +197,6 @@ export function create(definitionOrUrl, definitionOrOptions, optionsOrNothing) {
     definition = definitionOrOptions || {};
     options = optionsOrNothing || {};
   } else {
-    url = false;
     definition = definitionOrUrl || {};
     options = definitionOrOptions || {};
   }
@@ -211,7 +210,7 @@ export function create(definitionOrUrl, definitionOrOptions, optionsOrNothing) {
 
   delete definition.context;
 
-  deprecate('Passing an URL argument to `create()` is deprecated', typeof url !== 'string', {
+  deprecate('Passing an URL argument to `create()` is deprecated', url !== undefined && typeof url !== 'string', {
     id: 'ember-cli-page-object.create-url-argument',
     until: "2.0.0",
     url: 'https://ember-cli-page-object.js.org/docs/v1.17.x/deprecations/#create-url-argument',


### PR DESCRIPTION
In https://github.com/san650/ember-cli-page-object/commit/7125ba813dc2ecac361828575ca2781cefa364c7 a deprecation was added for `create('')`, however it also logs an error when used with `create()`. At https://github.com/san650/ember-cli-page-object/commit/7125ba813dc2ecac361828575ca2781cefa364c7#diff-7e9135d873a4889a025f4ed419cf7d3025a1fc38f7ec08bb1c7b3800c55a3483L200 a value of `false` may be set to `url`, which means `create()` should *always* be firing a deprecation.

I see there is a test in that same patch, I haven't confirmed it is running or not running though https://github.com/san650/ember-cli-page-object/commit/7125ba813dc2ecac361828575ca2781cefa364c7#diff-3963c3a74ca7d2852220eb87172db93f91df773a766ea56f2d3c92a42df646c4R12