### PR TITLE
extract `deprecate(` utilility

### DIFF
--- a/addon-test-support/-private/context.js
+++ b/addon-test-support/-private/context.js
@@ -1,4 +1,4 @@
-import { deprecate } from '@ember/application/deprecations';
+import deprecate from './deprecate';
 
 /**
  * @public
@@ -19,11 +19,12 @@ import { deprecate } from '@ember/application/deprecations';
  * @return {PageObject} - the page object
  */
 export function render(template) {
-  deprecate('PageObject.render() is deprecated. Please use "htmlbars-inline-precompile" instead.', false, {
-    id: 'ember-cli-page-object.page-render',
-    until: '2.0.0',
-    url: 'https://ember-cli-page-object.js.org/docs/v1.16.x/deprecations/#page-render'
-  });
+  deprecate(
+    'page-render',
+    'PageObject.render() is deprecated. Please use "htmlbars-inline-precompile" instead.',
+    '1.16.0',
+    '2.0.0',
+  );
 
   if (!this.context) {
     let message = 'You must set a context on the page object before calling calling `render()`';
@@ -54,11 +55,12 @@ export function render(template) {
  * @return {PageObject} - the page object
  */
 export function setContext(context) {
-  deprecate('setContext() is deprecated. Please make sure you use "@ember/test-helpers" of v1 or higher.', false, {
-    id: 'ember-cli-page-object.set-context',
-    until: '2.0.0',
-    url: 'https://ember-cli-page-object.js.org/docs/v1.16.x/deprecations/#set-context',
-  });
+  deprecate(
+    'set-context',
+    'setContext() is deprecated. Please make sure you use "@ember/test-helpers" of v1 or higher.',
+    '1.16.0',
+    '2.0.0',
+  );
 
   if (context) {
     this.context = context;

--- a/addon-test-support/-private/deprecate.js
+++ b/addon-test-support/-private/deprecate.js
@@ -8,7 +8,9 @@ export default function deprecate(name, message, since, until) {
   emberDeprecate(message, false, {
     id: `${NAMESPACE}.${name}`,
     for: NAMESPACE,
-    since,
+    since: {
+      enabled: since
+    },
     until,
     url: `https://ember-cli-page-object.js.org/docs/v${major}.${minor}.x/deprecations#${name}`,
   });

--- a/addon-test-support/-private/deprecate.js
+++ b/addon-test-support/-private/deprecate.js
@@ -1,0 +1,15 @@
+import { deprecate as emberDeprecate } from '@ember/application/deprecations';
+
+const NAMESPACE = 'ember-cli-page-object';
+
+export default function deprecate(name, message, since, until) {
+  const [major, minor] = since.split('.');
+
+  emberDeprecate(message, false, {
+    id: `${NAMESPACE}.${name}`,
+    for: NAMESPACE,
+    since,
+    until,
+    url: `https://ember-cli-page-object.js.org/docs/v${major}.${minor}.x/deprecations#${name}`,
+  });
+}

--- a/addon-test-support/-private/helpers.js
+++ b/addon-test-support/-private/helpers.js
@@ -4,7 +4,7 @@ import { assert } from '@ember/debug';
 import { get } from '@ember/object';
 import { isPresent } from '@ember/utils';
 import Ceibo from 'ceibo';
-import { deprecate } from '@ember/application/deprecations';
+import deprecate from './deprecate';
 import { getContext as getEmberTestHelpersContext } from './compatibility';
 
 import $ from '-jquery';
@@ -27,14 +27,14 @@ class Selector {
       scope = this.calculateScope(this.targetNode, this.targetScope);
     }
 
-    deprecate(
-      'Usage of comma separated selectors is deprecated in ember-cli-page-object',
-      `${scope} ${this.targetSelector}`.indexOf(',') === -1, {
-        id: 'ember-cli-page-object.comma-separated-selectors',
-        until: "2.0.0",
-        url: 'https://ember-cli-page-object.js.org/docs/v1.16.x/deprecations/#comma-separated-selectors',
-      }
-    );
+    if (`${scope} ${this.targetSelector}`.indexOf(',') > -1) {
+      deprecate(
+        'comma-separated-selectors',
+        'Usage of comma separated selectors is deprecated in ember-cli-page-object',
+        '1.16.0',
+        '2.0.0',
+      );
+    }
 
     filters = this.calculateFilters(this.targetFilters);
 

--- a/addon-test-support/create.js
+++ b/addon-test-support/create.js
@@ -1,5 +1,5 @@
 import Ceibo from 'ceibo';
-import { deprecate } from '@ember/application/deprecations';
+import deprecate from './-private/deprecate';
 import { render, setContext, removeContext } from './-private/context';
 import { assign, getPageObjectDefinition, isPageObject, storePageObjectDefinition } from './-private/helpers';
 import { visitable } from './properties/visitable';
@@ -73,14 +73,13 @@ function buildObject(node, blueprintKey, blueprint, defaultBuilder) {
             get
           }
         });
-      } else {
-        deprecate('do not use string values on definitions',
-          typeof value !== 'string' || ['scope', 'testContainer'].includes(key), {
-            id: 'ember-cli-page-object.string-properties-on-definition',
-            until: "2.0.0",
-            url: 'https://ember-cli-page-object.js.org/docs/v1.17.x/deprecations/#string-properties-on-definition',
-          }
-        )
+      } else if (typeof value === 'string' && !['scope', 'testContainer'].includes(key)) {
+        deprecate(
+          'string-properties-on-definition',
+          'do not use string values on definitions',
+          '1.17.0',
+          '2.0.0'
+        );
       }
     });
 
@@ -211,11 +210,14 @@ export function create(definitionOrUrl, definitionOrOptions, optionsOrNothing) {
 
   delete definition.context;
 
-  deprecate('Passing an URL argument to `create()` is deprecated', typeof url !== 'string', {
-    id: 'ember-cli-page-object.create-url-argument',
-    until: "2.0.0",
-    url: 'https://ember-cli-page-object.js.org/docs/v1.17.x/deprecations/#create-url-argument',
-  });
+  if (typeof url === 'string') {
+    deprecate(
+      'create-url-argument',
+      'Passing an URL argument to `create()` is deprecated',
+      '1.17.0',
+      "2.0.0",
+    );
+  }
 
   if (url) {
     definition.visit = visitable(url);

--- a/addon-test-support/extend/find-many.js
+++ b/addon-test-support/extend/find-many.js
@@ -1,4 +1,4 @@
-import { deprecate } from '@ember/application/deprecations';
+import deprecate from '../-private/deprecate';
 import { getExecutionContext } from '../-private/execution_context';
 import { filterWhitelistedOption } from '../-private/helpers';
 /**
@@ -34,11 +34,9 @@ import { filterWhitelistedOption } from '../-private/helpers';
  */
 export function findMany(pageObjectNode, targetSelector, options = {}) {
   const shouldShowMutlipleDeprecation = 'multiple' in options;
-  deprecate('"multiple" property is deprecated', !shouldShowMutlipleDeprecation, {
-    id: 'ember-cli-page-object.multiple',
-    until: '2.0.0',
-    url: 'https://ember-cli-page-object.js.org/docs/v1.17.x/deprecations/#multiple',
-  });
+  if (shouldShowMutlipleDeprecation) {
+    deprecate('multiple', '"multiple" property is deprecated', '1.17.0', '2.0.0');
+  }
 
   const filteredOptions = filterWhitelistedOption(options, [
     'resetScope', 'visible', 'testContainer', 'contains', 'scope', 'at', 'last'

--- a/addon-test-support/properties/collection.js
+++ b/addon-test-support/properties/collection.js
@@ -1,4 +1,4 @@
-import { deprecate } from '@ember/application/deprecations';
+import deprecate from '../-private/deprecate';
 import { warn } from '@ember/debug';
 
 import { collection as mainCollection } from './collection/main';
@@ -152,11 +152,12 @@ export function collection(scopeOrDefinition, definitionOrNothing) {
     return mainCollection(scopeOrDefinition, definitionOrNothing);
   }
 
-  deprecate('You are currently using the legacy collection API, check the documentation to see how to upgrade to the new API.', false, {
-    id: 'ember-cli-page-object.old-collection-api',
-    until: '2.0.0',
-    url: 'https://ember-cli-page-object.js.org/docs/v1.16.x/deprecations/#old-collection-api'
-  });
+  deprecate(
+    'old-collection-api',
+    'You are currently using the legacy collection API, check the documentation to see how to upgrade to the new API.',
+    '1.16.0',
+    '2.0.0',
+  );
 
   warn(
     'Legacy page object collection definition is invalid. Please, make sure you include a `itemScope` selector.',

--- a/addon-test-support/properties/is.js
+++ b/addon-test-support/properties/is.js
@@ -1,4 +1,4 @@
-import { deprecate } from '@ember/application/deprecations';
+import deprecate from '../-private/deprecate';
 import { assign, every } from '../-private/helpers';
 import { findElementWithAssert } from '../extend';
 
@@ -52,11 +52,7 @@ export function is(testSelector, targetSelector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      deprecate(':is property is deprecated', false, {
-        id: 'ember-cli-page-object.is-property',
-        until: '2.0.0',
-        url: 'https://ember-cli-page-object.js.org/docs/v1.16.x/deprecations/#is-property',
-      });
+      deprecate('is-property', ':is property is deprecated', '1.16.0', '2.0.0');
 
       let options = assign({ pageObjectKey: key }, userOptions);
 

--- a/test-support/page-object.js
+++ b/test-support/page-object.js
@@ -1,4 +1,4 @@
-import { deprecate } from '@ember/application/deprecations';
+import deprecate from 'ember-cli-page-object/test-support/-private/deprecate';
 
 import {
   alias,
@@ -78,8 +78,9 @@ export default {
 
 export { buildSelector, findElementWithAssert, findElement, getContext, fullScope } from 'ember-cli-page-object';
 
-deprecate(`Importing from "test-support" is now deprecated. Please import directly from the "ember-cli-page-object" module instead.`, false, {
-  id: 'ember-cli-page-object.import-from-test-support',
-  until: '2.0.0',
-  url: 'https://ember-cli-page-object.js.org/docs/v1.16.x/deprecations/#import-from-test-support',
-})
+deprecate(
+  'import-from-test-support',
+  `Importing from "test-support" is now deprecated. Please import directly from the "ember-cli-page-object" module instead.`,
+  '1.16.0',
+  '2.0.0',
+)


### PR DESCRIPTION
Fixes https://github.com/san650/ember-cli-page-object/issues/525

this allows to control proper params in a single place

Also added support for `since` and `for` options of the Ember's `deprecate(`, see [Deprecation Staging RFC](https://github.com/emberjs/rfcs/blob/master/text/0649-deprecation-staging.md)

Note: the signature of the new util is different from the upstream
Ember's `deprecte(`:

    - it avoids the second condition param, so as of now, when it's
    invoked, the deprecation is immediately fired. If you need it to be
    run conditionally, please wrap it with a conditional statement on
    the invocation side.

    - there is no `options`, all the params are splatted as an utility's
    arguments, which means there are not optional params anymore.