### PR TITLE
Sync with master

### DIFF
--- a/addon-test-support/-private/deprecate.js
+++ b/addon-test-support/-private/deprecate.js
@@ -1,11 +1,13 @@
-import { deprecate as emberDeprecate } from '@ember/application/deprecations';
+import { deprecate } from '@ember/application/deprecations';
 
 const NAMESPACE = 'ember-cli-page-object';
 
-export default function deprecate(name, message, since, until) {
+// @todo: remove `_` after getting rid of the ember deprecate
+// for some reason renaming of the import leads to runrime issues
+export default function _deprecate(name, message, since, until) {
   const [major, minor] = since.split('.');
 
-  emberDeprecate(message, false, {
+  deprecate(message, false, {
     id: `${NAMESPACE}.${name}`,
     for: NAMESPACE,
     since: {

--- a/addon-test-support/-private/deprecate.js
+++ b/addon-test-support/-private/deprecate.js
@@ -1,0 +1,17 @@
+import { deprecate as emberDeprecate } from '@ember/application/deprecations';
+
+const NAMESPACE = 'ember-cli-page-object';
+
+export default function deprecate(name, message, since, until) {
+  const [major, minor] = since.split('.');
+
+  emberDeprecate(message, false, {
+    id: `${NAMESPACE}.${name}`,
+    for: NAMESPACE,
+    since: {
+      enabled: since
+    },
+    until,
+    url: `https://ember-cli-page-object.js.org/docs/v${major}.${minor}.x/deprecations#${name}`,
+  });
+}

--- a/addon-test-support/-private/helpers.js
+++ b/addon-test-support/-private/helpers.js
@@ -1,7 +1,7 @@
 export { assign } from '@ember/polyfills';
 import { get } from '@ember/object';
 import Ceibo from 'ceibo';
-import { deprecate } from '@ember/application/deprecations';
+import deprecate from './deprecate';
 export { default as $ } from 'jquery';
 
 function isPresent(value) {
@@ -26,14 +26,14 @@ class Selector {
       scope = this.calculateScope(this.targetNode, this.targetScope);
     }
 
-    deprecate(
-      'Usage of comma separated selectors is deprecated in ember-cli-page-object',
-      `${scope} ${this.targetSelector}`.indexOf(',') === -1, {
-        id: 'ember-cli-page-object.comma-separated-selectors',
-        until: "2.0.0",
-        url: 'https://ember-cli-page-object.js.org/docs/v1.16.x/deprecations/#comma-separated-selectors',
-      }
-    );
+    if (`${scope} ${this.targetSelector}`.indexOf(',') > -1) {
+      deprecate(
+        'comma-separated-selectors',
+        'Usage of comma separated selectors is deprecated in ember-cli-page-object',
+        '1.16.0',
+        '2.0.0',
+      );
+    }
 
     filters = this.calculateFilters(this.targetFilters);
 

--- a/addon-test-support/-private/helpers.js
+++ b/addon-test-support/-private/helpers.js
@@ -26,6 +26,15 @@ class Selector {
       scope = this.calculateScope(this.targetNode, this.targetScope);
     }
 
+    deprecate(
+      'Usage of comma separated selectors is deprecated in ember-cli-page-object',
+      `${scope} ${this.targetSelector}`.indexOf(',') === -1, {
+        id: 'ember-cli-page-object.comma-separated-selectors',
+        until: "2.0.0",
+        url: 'https://ember-cli-page-object.js.org/docs/v1.16.x/deprecations/#comma-separated-selectors',
+      }
+    );
+
     filters = this.calculateFilters(this.targetFilters);
 
     let selector = `${scope} ${this.targetSelector}${filters}`.trim();
@@ -35,14 +44,6 @@ class Selector {
       // testing container.
       selector = ':first';
     }
-
-    deprecate(
-      'Usage of comma separated selectors is deprecated in ember-cli-page-object', selector.indexOf(',') === -1, {
-        id: 'ember-cli-page-object.comma-separated-selectors',
-        until: "2.0.0",
-        url: 'https://ember-cli-page-object.js.org/docs/v1.16.x/deprecations/#comma-separated-selectors',
-      }
-    );
 
     return selector;
   }

--- a/addon-test-support/create.js
+++ b/addon-test-support/create.js
@@ -1,5 +1,5 @@
 import Ceibo from 'ceibo';
-import { deprecate } from '@ember/application/deprecations';
+import deprecate from './-private/deprecate';
 import { assign, getPageObjectDefinition, isPageObject, storePageObjectDefinition } from './-private/helpers';
 import { visitable } from './properties/visitable';
 import dsl from './-private/dsl';
@@ -72,14 +72,13 @@ function buildObject(node, blueprintKey, blueprint, defaultBuilder) {
             get
           }
         });
-      } else {
-        deprecate('do not use string values on definitions',
-          typeof value !== 'string' || ['scope', 'testContainer'].includes(key), {
-            id: 'ember-cli-page-object.string-properties-on-definition',
-            until: "2.0.0",
-            url: 'https://ember-cli-page-object.js.org/docs/v1.17.x/deprecations/#string-properties-on-definition',
-          }
-        )
+      } else if (typeof value === 'string' && !['scope', 'testContainer'].includes(key)) {
+        deprecate(
+          'string-properties-on-definition',
+          'do not use string values on definitions',
+          '1.17.0',
+          '2.0.0'
+        );
       }
     });
 
@@ -211,11 +210,14 @@ export function create(definitionOrUrl, definitionOrOptions, optionsOrNothing) {
     throw new Error('"context" key is not allowed to be passed at definition root.');
   }
 
-  deprecate('Passing an URL argument to `create()` is deprecated', typeof url !== 'string', {
-    id: 'ember-cli-page-object.create-url-argument',
-    until: "2.0.0",
-    url: 'https://ember-cli-page-object.js.org/docs/v1.17.x/deprecations/#create-url-argument',
-  });
+  if (typeof url === 'string') {
+    deprecate(
+      'create-url-argument',
+      'Passing an URL argument to `create()` is deprecated',
+      '1.17.0',
+      "2.0.0",
+    );
+  }
 
   if (url) {
     definition.visit = visitable(url);

--- a/test-support/page-object.js
+++ b/test-support/page-object.js
@@ -1,4 +1,4 @@
-import { deprecate } from '@ember/application/deprecations';
+import deprecate from 'ember-cli-page-object/test-support/-private/deprecate';
 
 import {
   alias,
@@ -78,8 +78,9 @@ export default {
 
 export { buildSelector, findElementWithAssert, findElement, getContext, fullScope } from 'ember-cli-page-object';
 
-deprecate(`Importing from "test-support" is now deprecated. Please import directly from the "ember-cli-page-object" module instead.`, false, {
-  id: 'ember-cli-page-object.import-from-test-support',
-  until: '2.0.0',
-  url: 'https://ember-cli-page-object.js.org/docs/v1.16.x/deprecations/#import-from-test-support',
-})
+deprecate(
+  'import-from-test-support',
+  `Importing from "test-support" is now deprecated. Please import directly from the "ember-cli-page-object" module instead.`,
+  '1.16.0',
+  '2.0.0',
+)

--- a/tests/integration/deprecations/comma-separated-selector-test.js
+++ b/tests/integration/deprecations/comma-separated-selector-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from '../../helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-import { create, text } from 'dummy/tests/page-object';
+import { create, text, clickOnText } from 'dummy/tests/page-object';
 
 import require from 'require';
 if (require.has('@ember/test-helpers')) {
@@ -66,6 +66,20 @@ if (require.has('@ember/test-helpers')) {
       </div>`);
 
       page.text;
+
+      assert.expectNoDeprecation();
+    });
+
+    test('don\'t show deprecation when the selector contains text with comma', async function(assert) {
+      let page = create({
+        clickOnButton: clickOnText('button')
+      });
+
+      await render(hbs`<fieldset>
+        <button>Lorem, Ipsum</button>
+      </fieldset>`);
+
+      page.clickOnButton('Lorem, Ipsum');
 
       assert.expectNoDeprecation();
     });


### PR DESCRIPTION
port of few fixes from master: 
- https://github.com/san650/ember-cli-page-object/pull/535
- https://github.com/san650/ember-cli-page-object/pull/521

ignore https://github.com/san650/ember-cli-page-object/pull/530 for now. Let's come back to it after dependency upgrades( https://github.com/san650/ember-cli-page-object/pull/528) is settled. There I'd like to remove old moduleFor adapters, so after that adding of the ember-qunit@5 should be just about adding an ember-try scenario 