### PR TITLE
Fix `Ember.emberDeprecate` is not a function

### DIFF
--- a/addon-test-support/-private/deprecate.js
+++ b/addon-test-support/-private/deprecate.js
@@ -1,4 +1,4 @@
-import { deprecate as emberDeprecate } from '@ember/application/deprecations';
+import { deprecate as emberDeprecate } from '@ember/debug';
 
 const NAMESPACE = 'ember-cli-page-object';
 

--- a/addon-test-support/-private/deprecate.js
+++ b/addon-test-support/-private/deprecate.js
@@ -1,11 +1,11 @@
-import { deprecate as emberDeprecate } from '@ember/debug';
+import { deprecate } from '@ember/debug';
 
 const NAMESPACE = 'ember-cli-page-object';
 
-export default function deprecate(name, message, since, until) {
+export default function deprecateWrapper(name, message, since, until) {
   const [major, minor] = since.split('.');
 
-  emberDeprecate(message, false, {
+  deprecate(message, false, {
     id: `${NAMESPACE}.${name}`,
     for: NAMESPACE,
     since: {


### PR DESCRIPTION
The internal `deprecate` wrapper imports Ember's deprecation utility from a different location than the documented one.

When running this addon against the latest version of Ember, a runtime error occurs where Ember's deprecation function is not defined.

`deprecate` documentation: https://api.emberjs.com/ember/3.24/functions/@ember%2Fdebug/deprecate