### PR TITLE
fix: Revert native contains property

### DIFF
--- a/addon-test-support/properties/contains.js
+++ b/addon-test-support/properties/contains.js
@@ -1,6 +1,5 @@
-import { assign } from '../-private/helpers';
-import { findMany, findOne } from '../extend';
-import { A } from '@ember/array';
+import { assign, every } from '../-private/helpers';
+import { findElementWithAssert } from '../extend';
 
 /**
  * Returns a boolean representing whether an element or a set of elements contains the specified text.
@@ -69,7 +68,6 @@ import { A } from '@ember/array';
  *
  * const page = create({
  *   scope: '.scope',
-
  *   spanContains: contains('span')
  * });
  *
@@ -96,13 +94,13 @@ export function contains(selector, userOptions = {}) {
 
     get(key) {
       return function(textToSearch) {
-        let options = assign({
-          pageObjectKey: `${key}("${textToSearch}")`
-        }, userOptions);
+        let options = assign({ pageObjectKey: `${key}("${textToSearch}")` }, userOptions);
 
-        let elements = options.multiple ? findMany(this, selector, options) : [findOne(this, selector, options)];
+        let elements = findElementWithAssert(this, selector, options);
 
-        return A(elements).every((element) => element.innerText.indexOf(textToSearch) >= 0);
+        return every(elements, function(element) {
+          return element.text().indexOf(textToSearch) >= 0;
+        });
       };
     }
   };


### PR DESCRIPTION
The change done in this PR: #466 caused a regression.

$.text() can find the text in `visibility: hidden` or `display: none` elements.

element.innerText does not return the text. 

Fixes: #514