### PR TITLE
fix: Contains should use synthetic -jquery over jquery import

### DIFF
--- a/addon-test-support/properties/contains.js
+++ b/addon-test-support/properties/contains.js
@@ -1,5 +1,6 @@
 import { A } from '@ember/array';
-import { assign } from '../-private/helpers';import { findMany, findOne } from '../extend';
+import { assign } from '../-private/helpers';
+import { findMany, findOne } from '../extend';
 import $ from '-jquery';
 
 /**


### PR DESCRIPTION
In my previous PR I accidentally imported native jquery.

This is incorrect as now apps will need to also have jquery as part of their bundle.

The fix is to use the synthetic `-jquery` import instead.