### PR TITLE
restore RFC268 adapter as a default

### DIFF
--- a/addon-test-support/adapter.js
+++ b/addon-test-support/adapter.js
@@ -1,23 +1,23 @@
 export default class Adapter {
   get testContainer() {
-    throw new Error('`testContainer` is not implemented for the adater');
+    throw new Error('`testContainer` is not implemented for the adapter');
   }
   visit(/* path */) {
-    throw new Error('`visit` is not implemented for the adater');
+    throw new Error('`visit` is not implemented for the adapter');
   }
   click(/* element */) {
-    throw new Error('`click` is not implemented for the adater');
+    throw new Error('`click` is not implemented for the adapter');
   }
   fillIn(/*element, content*/) {
-    throw new Error('`fillIn` is not implemented for the adater');
+    throw new Error('`fillIn` is not implemented for the adapter');
   }
   triggerEvent(/*element, eventName, eventOptions*/) {
-    throw new Error('`triggerEvent` is not implemented for the adater');
+    throw new Error('`triggerEvent` is not implemented for the adapter');
   }
   focus(/* element */) {
-    throw new Error('`focus` is not implemented for the adater');
+    throw new Error('`focus` is not implemented for the adapter');
   }
   blur(/* element */) {
-    throw new Error('`blur` is not implemented for the adater');
+    throw new Error('`blur` is not implemented for the adapter');
   }
 }

--- a/addon-test-support/adapters/index.js
+++ b/addon-test-support/adapters/index.js
@@ -1,4 +1,5 @@
 import Adapter from '../adapter';
+import RFC268Adapter from './rfc268';
 
 let _adapter;
 
@@ -7,9 +8,7 @@ let _adapter;
  */
 export function getAdapter() {
   if (!_adapter) {
-    throw new Error(`Adapter is required.
-
-Please use \`setAdapter(\`, to instruct "ember-cli-page-object" about the adapter you want to use.`);
+    return new RFC268Adapter();
   }
 
   return _adapter;

--- a/tests/helpers/index.ts
+++ b/tests/helpers/index.ts
@@ -3,9 +3,6 @@ import {
   setupRenderingTest as upstreamSetupRenderingTest,
 } from 'ember-qunit';
 
-import { setAdapter } from 'ember-cli-page-object/adapters';
-import RFC268Adapter from 'ember-cli-page-object/adapters/rfc268';
-
 import hbs from 'htmlbars-inline-precompile';
 import require from 'require';
 import { TestContext as DefaultTestContext } from 'ember-test-helpers';
@@ -32,10 +29,6 @@ function render(...args: unknown[]) {
 export function setupApplicationTest(hooks: NestedHooks) {
   upstreamSetupApplicationTest(hooks);
 
-  hooks.beforeEach(function() {
-    setAdapter(new RFC268Adapter());
-  });
-
   hooks.afterEach(function() {
     document.getElementById('alternate-ember-testing')!.innerHTML = '';
   })
@@ -45,8 +38,6 @@ export function setupRenderingTest(hooks: NestedHooks) {
   upstreamSetupRenderingTest(hooks);
 
   hooks.beforeEach(function(this: TestContext) {
-    setAdapter(new RFC268Adapter());
-
     const testContext = this;
 
     this.createTemplate = function(template, options): Promise<unknown> {

--- a/tests/unit/-private/action-test.js
+++ b/tests/unit/-private/action-test.js
@@ -2,7 +2,10 @@ import { module, test } from 'qunit';
 import { create } from 'ember-cli-page-object';
 import action from 'ember-cli-page-object/test-support/-private/action';
 import { isPageObject } from 'ember-cli-page-object/test-support/-private/helpers';
-import { setAdapter } from 'ember-cli-page-object/test-support/adapters';
+import {
+  setAdapter,
+  getAdapter,
+} from 'ember-cli-page-object/test-support/adapters';
 import Adapter from 'ember-cli-page-object/test-support/adapter';
 
 class DummyAdapter extends Adapter {}
@@ -31,8 +34,16 @@ class Deferred {
 }
 
 module('Unit | action', function (hooks) {
+  let initialAdapter;
+
   hooks.beforeEach(function () {
+    initialAdapter = getAdapter();
+
     setAdapter(new DummyAdapter());
+  });
+
+  hooks.afterEach(function () {
+    setAdapter(initialAdapter);
   });
 
   let invoked, finished, executionContext;


### PR DESCRIPTION
This behavior has been removed in the daa0ba0efceacde6cc4eb8315a684b88472216fa
due to desire to support environments other than ember.
However, this is an ember specific addon, so it should not cause
issues to ember users.