### PR TITLE
Fix jQuery detection when @ember/jquery is only an indirect dependency

### DIFF
--- a/addon/src/-private/helpers.js
+++ b/addon/src/-private/helpers.js
@@ -1,14 +1,10 @@
 import Ceibo from '@ro0gr/ceibo';
 import deprecate from './deprecate';
-import {
-  dependencySatisfies,
-  macroCondition,
-  importSync,
-} from '@embroider/macros';
+import { importSync } from '@embroider/macros';
 
 let jQuery;
 
-if (macroCondition(dependencySatisfies('@ember/jquery', '*'))) {
+if (window.jQuery) {
   jQuery = window.jQuery;
 } else {
   const jqueryImport = importSync('jquery');


### PR DESCRIPTION
We took [the advice](https://github.com/san650/ember-cli-page-object/issues/592#issuecomment-1301011970) to upgrade to v2.0.0-beta. Overall it seems pretty stable already :+1:. We're currently running into one issue, which is addressed in this PR.

---

This solves the following use case:

1. App A has a dependency on addon B.
2. App A does not have a direct dependency on @ember/jquery.
3. Addon B does have a direct dependency on @ember/jquery.

Previously, it was in this case incorrectly assumed that window.jQuery would be available when running app A.