### PR TITLE
docs: update properties which are async to be awaited in examples

### DIFF
--- a/addon-test-support/properties/blurrable.js
+++ b/addon-test-support/properties/blurrable.js
@@ -16,7 +16,7 @@ import { getExecutionContext } from '../-private/execution_context';
  * });
  *
  * // blurs on element with selector '.name'
- * page.blur();
+ * await page.blur();
  *
  * @example
  *
@@ -32,7 +32,7 @@ import { getExecutionContext } from '../-private/execution_context';
  * });
  *
  * // blurs on element with selector '.scope .name'
- * page.blur();
+ * await page.blur();
  *
  * @example
  *
@@ -49,7 +49,7 @@ import { getExecutionContext } from '../-private/execution_context';
  * });
  *
  * // blurs on element with selector '.scope .name'
- * page.blur();
+ * await page.blur();
  *
  * @public
  *

--- a/addon-test-support/properties/click-on-text.js
+++ b/addon-test-support/properties/click-on-text.js
@@ -23,10 +23,10 @@ import { buildSelector } from './click-on-text/helpers';
  * });
  *
  * // queries the DOM with selector 'fieldset :contains("Lorem"):last'
- * page.clickOnFieldset('Lorem');
+ * await page.clickOnFieldset('Lorem');
  *
  * // queries the DOM with selector 'button:contains("Ipsum")'
- * page.clickOnButton('Ipsum');
+ * await page.clickOnButton('Ipsum');
  *
  * @example
  *
@@ -45,7 +45,7 @@ import { buildSelector } from './click-on-text/helpers';
  * });
  *
  * // queries the DOM with selector '.scope fieldset :contains("Lorem"):last'
- * page.clickOnFieldset('Lorem');
+ * await page.clickOnFieldset('Lorem');
  *
  * // queries the DOM with selector '.scope button:contains("Ipsum")'
  * page.clickOnButton('Ipsum');
@@ -68,10 +68,10 @@ import { buildSelector } from './click-on-text/helpers';
  * });
  *
  * // queries the DOM with selector '.scope fieldset :contains("Lorem"):last'
- * page.clickOnFieldset('Lorem');
+ * await page.clickOnFieldset('Lorem');
  *
  * // queries the DOM with selector '.scope button:contains("Ipsum")'
- * page.clickOnButton('Ipsum');
+ * await page.clickOnButton('Ipsum');
  *
  * @public
  *

--- a/addon-test-support/properties/clickable.js
+++ b/addon-test-support/properties/clickable.js
@@ -19,7 +19,7 @@ import { getExecutionContext } from '../-private/execution_context';
  * });
  *
  * // clicks on element with selector 'button.continue'
- * page.continue();
+ * await page.continue();
  *
  * @example
  *
@@ -35,7 +35,7 @@ import { getExecutionContext } from '../-private/execution_context';
  * });
  *
  * // clicks on element with selector '.scope button.continue'
- * page.continue();
+ * await page.continue();
  *
  * @example
  *
@@ -52,7 +52,7 @@ import { getExecutionContext } from '../-private/execution_context';
  * });
  *
  * // clicks on element with selector '.scope button.continue'
- * page.continue();
+ * await page.continue();
  *
  * @public
  *

--- a/addon-test-support/properties/fillable.js
+++ b/addon-test-support/properties/fillable.js
@@ -38,7 +38,7 @@ import { getExecutionContext } from '../-private/execution_context';
  * });
  *
  * // result: <input value="John Doe">
- * page.fillIn('John Doe');
+ * await page.fillIn('John Doe');
  *
  * @example
  *
@@ -55,7 +55,7 @@ import { getExecutionContext } from '../-private/execution_context';
  *   fillInName: fillable('input', { scope: '.name' })
  * });
  *
- * page.fillInName('John Doe');
+ * await page.fillInName('John Doe');
  *
  * // result
  * // <div class="name">
@@ -78,7 +78,7 @@ import { getExecutionContext } from '../-private/execution_context';
  *   fillInName: fillable('input')
  * });
  *
- * page.fillInName('John Doe');
+ * await page.fillInName('John Doe');
  *
  * // result
  * // <div class="name">
@@ -98,7 +98,7 @@ import { getExecutionContext } from '../-private/execution_context';
  *   fillIn: fillable('input, textarea, [contenteditable]')
  * });
  *
- * page
+ * await page
  *   .fillIn('name', 'Doe')
  *   .fillIn('lastname', 'Doe')
  *   .fillIn('email', 'john@doe')

--- a/addon-test-support/properties/focusable.js
+++ b/addon-test-support/properties/focusable.js
@@ -16,7 +16,7 @@ import { getExecutionContext } from '../-private/execution_context';
  * });
  *
  * // focuses on element with selector '.name'
- * page.focus();
+ * await page.focus();
  *
  * @example
  *
@@ -32,7 +32,7 @@ import { getExecutionContext } from '../-private/execution_context';
  * });
  *
  * // focuses on element with selector '.scope .name'
- * page.focus();
+ * await page.focus();
  *
  * @example
  *
@@ -49,7 +49,7 @@ import { getExecutionContext } from '../-private/execution_context';
  * });
  *
  * // focuses on element with selector '.scope .name'
- * page.focus();
+ * await page.focus();
  *
  * @public
  *

--- a/addon-test-support/properties/triggerable.js
+++ b/addon-test-support/properties/triggerable.js
@@ -20,7 +20,7 @@ import { getExecutionContext } from '../-private/execution_context';
  * });
  *
  * // triggers keypress using enter key on element with selector '.name'
- * page.enter();
+ * await page.enter();
  *
  * @example
  *
@@ -34,7 +34,7 @@ import { getExecutionContext } from '../-private/execution_context';
  * });
  *
  * // triggers keypress using enter key on element with selector '.name'
- * page.keydown({ which: 13 });
+ * await page.keydown({ which: 13 });
  *
  * @example
  *
@@ -50,7 +50,7 @@ import { getExecutionContext } from '../-private/execution_context';
  * });
  *
  * // triggers keypress using enter key on element with selector '.name'
- * page.keydown({ which: 13 });
+ * await page.keydown({ which: 13 });
  *
  * @example
  *
@@ -67,7 +67,7 @@ import { getExecutionContext } from '../-private/execution_context';
  * });
  *
  * // triggers keypress using enter key on element with selector '.name'
- * page.keydown({ which: 13 });
+ * await page.keydown({ which: 13 });
  *
  * @public
  *

--- a/addon-test-support/properties/visitable.js
+++ b/addon-test-support/properties/visitable.js
@@ -48,7 +48,7 @@ function appendQueryParams(path, queryParams) {
  * });
  *
  * // visits '/users'
- * page.visit();
+ * await page.visit();
  *
  * @example
  *
@@ -59,7 +59,7 @@ function appendQueryParams(path, queryParams) {
  * });
  *
  * // visits '/users/10'
- * page.visit({ user_id: 10 });
+ * await page.visit({ user_id: 10 });
  *
  * @example
  *
@@ -70,7 +70,7 @@ function appendQueryParams(path, queryParams) {
  * });
  *
  * // visits '/users?name=john'
- * page.visit({ name: 'john' });
+ * await page.visit({ name: 'john' });
  *
  * @example
  *
@@ -81,7 +81,7 @@ function appendQueryParams(path, queryParams) {
  * });
  *
  * // visits '/users/1?name=john'
- * page.visit({ user_id: 1, name: 'john' });
+ * await page.visit({ user_id: 1, name: 'john' });
  *
  * @param {string} path - Full path of the route to visit
  * @return {Descriptor}


### PR DESCRIPTION
## What changed
For issue: https://github.com/san650/ember-cli-page-object/issues/603

Added in `await` for the following docs:
    http://ember-cli-page-object.js.org/docs/v1.17.x/api/blurrable
    http://ember-cli-page-object.js.org/docs/v1.17.x/api/click-on-text
    http://ember-cli-page-object.js.org/docs/v1.17.x/api/fillable
    http://ember-cli-page-object.js.org/docs/v1.17.x/api/focusable
    http://ember-cli-page-object.js.org/docs/v1.17.x/api/triggerable
    http://ember-cli-page-object.js.org/docs/v1.17.x/api/visitable
    
All of these properties are `async` and so should be `await` ed to work.


