### PR TITLE
Widen ember-test-helpers peer range

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -85,7 +85,7 @@
   },
   "peerDependencies": {
     "@ember/jquery": "*",
-    "@ember/test-helpers": "^2.5.0"
+    "@ember/test-helpers": ">= 2.5.0"
   },
   "peerDependenciesMeta": {
     "@ember/jquery": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
       '@babel/plugin-proposal-class-properties': ^7.16.7
       '@babel/plugin-proposal-decorators': ^7.17.9
       '@ember/jquery': '*'
-      '@ember/test-helpers': ^2.5.0
+      '@ember/test-helpers': '>= 2.5.0'
       '@embroider/addon-dev': ^1.8.0
       '@embroider/addon-shim': ^1.8.0
       '@ro0gr/ceibo': ^2.2.0


### PR DESCRIPTION
Supports the v3.x series of ember-test-helpers so this addon can be installed in package managers where this range is enforced with the ember-cli 5.x blueprints which require v3 of test-helpers