### PR TITLE
fix: proper type declaration for `count` attribute

### DIFF
--- a/addon/types.d.ts
+++ b/addon/types.d.ts
@@ -24,7 +24,7 @@ declare module 'ember-cli-page-object' {
   export function hasClass(className: string, scope?: string, options?: FindOptions): GetterDescriptor<boolean>;
   export function notHasClass(className: string, scope?: string, options?: FindOptions): GetterDescriptor<boolean>;
   export function contains(scope?: string, options?: FindOptions): (text: string) => GetterDescriptor<boolean>;
-  export function count(scope?: string, options?: FindOptions): () => GetterDescriptor<boolean>;
+  export function count(scope?: string, options?: FindOptions): GetterDescriptor<number>;
 
   // Actions
   export function clickable(scope?: string, userOptions?: FindOptions): MethodDescriptor<<T>(this: T) => T>;


### PR DESCRIPTION
Hello!

I've found this small issue with return type declarations for `count` attribute while rewriting some of my tests to TS.

Link to the attribute source code for reference: https://github.com/san650/ember-cli-page-object/blob/master/addon/src/properties/count.js#L91