### PR TITLE
fix: restore getter error details

### DIFF
--- a/addon/src/-private/better-errors.js
+++ b/addon/src/-private/better-errors.js
@@ -78,6 +78,7 @@ function buildPropertyNamesPath(node) {
     path.unshift(Ceibo.meta(current).key);
   }
 
+  // replace "root" with "page"
   path[0] = 'page';
 
   return path;

--- a/addon/src/macros/getter.js
+++ b/addon/src/macros/getter.js
@@ -49,8 +49,19 @@ export function getter(fn) {
         return fn.call(this, pageObjectKey);
       } catch (e) {
         if (e instanceof PageObjectError) {
-          if (!e.label) {
-            e.label = pageObjectKey;
+          if (!e.cause.key) {
+            // re-throw with a page object key to have a complete error message
+            const { message, node, selector } = e.cause;
+            const wrapperError = new PageObjectError(message, {
+              cause: {
+                key: pageObjectKey,
+                node,
+                selector,
+              },
+            });
+            wrapperError.stack = e.stack;
+
+            throw wrapperError;
           }
 
           throw e;

--- a/addon/src/macros/getter.js
+++ b/addon/src/macros/getter.js
@@ -50,13 +50,11 @@ export function getter(fn) {
       } catch (e) {
         if (e instanceof PageObjectError) {
           if (!e.cause.key) {
-            // re-throw with a page object key to have a complete error message
-            const { message, node, selector } = e.cause;
-            const wrapperError = new PageObjectError(message, {
+            // re-throw with a `pageObjectKey` to have a complete error message
+            const wrapperError = new PageObjectError(e.cause.message, {
               cause: {
+                ...e.cause,
                 key: pageObjectKey,
-                node,
-                selector,
               },
             });
             wrapperError.stack = e.stack;

--- a/test-app/tests/integration/comma-separated-selector-test.ts
+++ b/test-app/tests/integration/comma-separated-selector-test.ts
@@ -16,7 +16,7 @@ module('comma separated selectors', function (hooks) {
 
     assert.throws(
       () => page.isVisible,
-      new Error(
+      new RegExp(
         'Usage of comma separated selectors is not supported. Please make sure your selector targets a single selector.'
       )
     );
@@ -31,7 +31,7 @@ module('comma separated selectors', function (hooks) {
 
     assert.throws(
       () => page.text,
-      new Error(
+      new RegExp(
         'Usage of comma separated selectors is not supported. Please make sure your selector targets a single selector.'
       )
     );
@@ -50,7 +50,7 @@ module('comma separated selectors', function (hooks) {
 
     assert.throws(
       () => page.text,
-      new Error(
+      new RegExp(
         'Usage of comma separated selectors is not supported. Please make sure your selector targets a single selector.'
       )
     );

--- a/test-app/tests/unit/-private/properties/getter-test.ts
+++ b/test-app/tests/unit/-private/properties/getter-test.ts
@@ -89,7 +89,7 @@ module('getter', function (hooks) {
 
     try {
       page.foo;
-      assert.true(false);
+      assert.false(true, 'should not succeed');
     } catch (e) {
       assert.strictEqual(
         e?.toString(),
@@ -109,6 +109,14 @@ PageObject: 'page.foo'`
       }),
     });
 
-    assert.throws(() => page.foo, /Selector: '.non-existing-scope'/);
+    try {
+      page.foo;
+      assert.false(true, 'should not succeed');
+    } catch (e: any) {
+      assert.strictEqual(
+        e.toString(),
+        `Error: Element not found.\n\nPageObject: 'page.foo'\n  Selector: '.non-existing-scope'`
+      );
+    }
   });
 });

--- a/test-app/tests/unit/extend/find-one-test.ts
+++ b/test-app/tests/unit/extend/find-one-test.ts
@@ -40,13 +40,18 @@ module(`Extend | findOne`, function (hooks) {
   });
 
   test('throws error if 0 elements found', async function (assert) {
-    const page = create({});
+    const page = create({
+      child: {},
+    });
 
     await render(hbs`<span class="ipsum"></span>`);
 
     assert.throws(
-      () => findOne(page, '.unknown', {}),
-      /Error: Element not found./
+      () => findOne(page.child, '.unknown', {}),
+      new Error(`Element not found.
+
+PageObject: 'page.child'
+  Selector: '.unknown'`)
     );
   });
 


### PR DESCRIPTION
#596 broke QUnit error messages so they now miss contextual error info like page object path and selector. This info only remained as a part of the console output.

**Before:**
<img width="448" alt="Знімок екрана 2023-10-31 о 23 19 48" src="https://github.com/san650/ember-cli-page-object/assets/875361/32e26dcf-5e9b-4b02-a3ff-645921e59b4c">

This happened cause #596 relied on the `.toString()` method of the Error to build the final error message. However, that's not how the error message is supposed to be displayed in UI. 

Instead, we need the `Error.message` to be complete. Let's build it in the `Error` constructor then.

**After:**
<img width="448" alt="Знімок екрана 2023-10-31 о 23 20 48" src="https://github.com/san650/ember-cli-page-object/assets/875361/e96da2ea-6c64-4531-a0c3-bd9fa88e21a2">
