### PR TITLE
#619 chore: get rid of `$.param`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Inside any of the packages you can run:
 
 - `cd addon && pnpm start` – Builds the addon in "watch mode" so changes picked up by test app.
 - `pnpm test` – Runs the test suite on the current Ember version
-- `pnpm test --server` – Runs the test suite in "watch mode"
+- `pnpm test -- --server` – Runs the test suite in "watch mode"
 - `cd test-app && ember try:each` – Runs the test suite against multiple Ember versions
 
 ## Running the test application

--- a/test-app/tests/unit/-private/properties/visitable-test.ts
+++ b/test-app/tests/unit/-private/properties/visitable-test.ts
@@ -58,8 +58,30 @@ module('visitable', function(hooks) {
       foo: visitable('/users/:user_id/comments/:comment_id')
     });
 
-    await page.foo({ user_id: 5, comment_id: 1, hello: 'world', lorem: 'ipsum' });
-    assert.equal(currentURL(), '/users/5/comments/1?hello=world&lorem=ipsum');
+    await page.foo({
+      user_id: 5,
+      comment_id: 1,
+      hello: 'world',
+      lorem: 'ipsum',
+      reply_ids: [1, 2],
+      search: {
+        author: 'ember',
+        topic: 'lts',
+        deep: {
+          my_array: [99, 77],
+          my_value: true
+        }
+      }
+    });
+
+    assert.equal(
+      decodeURIComponent(currentURL()),
+      '/users/5/comments/1' +
+      '?hello=world&lorem=ipsum' +
+      '&reply_ids[]=1&reply_ids[]=2' +
+      '&search[author]=ember&search[topic]=lts' +
+      '&search[deep][my_array][]=99&search[deep][my_array][]=77&search[deep][my_value]=true'
+    );
   });
 
   test('fills in encoded dynamic segments', async function(assert) {


### PR DESCRIPTION
fixes https://github.com/san650/ember-cli-page-object/issues/619.


In order to remain backwards-compatible I implemented the Array and Object handler similar as $.param is doing. Could also only use 

`(new URLSearchParams(queryParams)).toString()`

but that is building array and object differently:
![Selection_463](https://github.com/san650/ember-cli-page-object/assets/6084030/eb93247c-ca9f-4e8e-ae24-5630065b93d2)

```
const params = {
  user_id: 5,
  comment_id: 1,
  hello: 'world',
  lorem: 'ipsum',
  reply_ids: [1, 2],
  search: {
    author: 'ember',
    topic: 'lts',
    deep: {
      my_array: [99, 77],
      my_value: true
    }
  }
};
const URLSearch = new URLSearchParams(params)
const jquery = $.param(params)
decodeURIComponent(URLSearch)
decodeURIComponent(jquery)