### PR TITLE
Add typesVersions for resolving all type imports using legacy moduleResolution

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -41,7 +41,11 @@
       "types": "./types.d.ts"
     }
   },
-  "types": "types.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": ["./types.d.ts"]
+    }
+  },
   "files": [
     "addon-main.js",
     "dist",


### PR DESCRIPTION
When TS is set up to not use a `moduleResolution` of `node16` or `bundler` yet (like legacy `node`/`node10`), then TS would not look into `exports`.

There is `types`, but that only works when resolving the main index module, like `import from 'ember-cli-page-object'`, but all other submodules like `ember-cli-page-object/adapter` would fail to resolve to `types.d.ts`. 

This is removing `types` in favor of `typesVersions`, supporting the same wildcard-matching that `exports` does.