### PR TITLE
Support string getters within collections

### DIFF
--- a/addon/src/-private/helpers.js
+++ b/addon/src/-private/helpers.js
@@ -209,3 +209,13 @@ export function findClosestValue(node, property) {
     return findClosestValue(parent, property);
   }
 }
+
+export function assignDescriptors(target, source) {
+  Object.getOwnPropertyNames(source).forEach((key) => {
+    const descriptor = Object.getOwnPropertyDescriptor(source, key);
+
+    Object.defineProperty(target, key, descriptor);
+  });
+
+  return target;
+}

--- a/addon/src/create.js
+++ b/addon/src/create.js
@@ -6,16 +6,7 @@ import {
 } from './-private/meta';
 import dsl from './-private/dsl';
 import { getter } from './macros/index';
-
-function assignDescriptors(target, source) {
-  Object.getOwnPropertyNames(source).forEach((key) => {
-    const descriptor = Object.getOwnPropertyDescriptor(source, key);
-
-    Object.defineProperty(target, key, descriptor);
-  });
-
-  return target;
-}
+import { assignDescriptors } from './-private/helpers';
 
 //
 // When running RFC268 tests, we have to play some tricks to support chaining.

--- a/addon/src/properties/collection.js
+++ b/addon/src/properties/collection.js
@@ -1,5 +1,5 @@
 import Ceibo from '@ro0gr/ceibo';
-import { buildSelector } from '../-private/helpers';
+import { buildSelector, assignDescriptors } from '../-private/helpers';
 import { isPageObject, getPageObjectDefinition } from '../-private/meta';
 import { create } from '../create';
 import { count } from './count';
@@ -199,7 +199,7 @@ export class Collection {
       let { scope, definition, parent } = this;
       let itemScope = buildSelector({}, scope, { at: index });
 
-      let finalizedDefinition = { ...definition };
+      let finalizedDefinition = assignDescriptors({}, definition);
 
       finalizedDefinition.scope = itemScope;
 

--- a/test-app/tests/integration/string-properties-test.ts
+++ b/test-app/tests/integration/string-properties-test.ts
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { create } from 'ember-cli-page-object';
+import { collection, create } from 'ember-cli-page-object';
 
 module('string-properties', function () {
   test('throws in top-level string property', function (assert) {
@@ -25,6 +25,21 @@ Key: "stringProp"`)
     );
   });
 
+  test('throws in collection string property', function (assert) {
+    const po = create({
+      items: collection('.items', {
+        stringProp: '',
+      }),
+    });
+
+    assert.throws(
+      () => po.items[0]?.stringProp,
+      new Error(`string values are not supported in page object definitions
+
+Key: "stringProp"`)
+    );
+  });
+
   test('allows scope', function (assert) {
     create({
       scope: '',
@@ -39,5 +54,39 @@ Key: "stringProp"`)
     });
 
     assert.true(true);
+  });
+
+  test('allows native getter', function (assert) {
+    const po = create({
+      get foo() {
+        return 'bar';
+      },
+    });
+
+    assert.strictEqual(po.foo, 'bar');
+  });
+
+  test('allows nested native getter', function (assert) {
+    const po = create({
+      nested: {
+        get foo() {
+          return 'bar';
+        },
+      },
+    });
+
+    assert.strictEqual(po.nested.foo, 'bar');
+  });
+
+  test('allows native getter in collection', function (assert) {
+    const po = create({
+      items: collection('.items', {
+        get foo() {
+          return 'bar';
+        },
+      }),
+    });
+
+    assert.strictEqual(po.items[0]?.foo, 'bar');
   });
 });


### PR DESCRIPTION
Preserve getters within collections by applying their descriptors when cloning. 
Fixes #637