### PR TITLE
Support plain arrays

### DIFF
--- a/addon/src/create.js
+++ b/addon/src/create.js
@@ -50,6 +50,12 @@ import { assignDescriptors } from './-private/helpers';
 function buildObject(node, blueprintKey, blueprint, defaultBuilder) {
   let definition;
 
+  // Preserve plain arrays, prevent `Error: string values are not supported in page object definitions Key: "0"` error
+  if (Array.isArray(blueprint)) {
+    node[blueprintKey] = blueprint;
+    return;
+  }
+
   // to allow page objects to exist in definitions, we store the definition that
   // created the page object, allowing us to substitute a page object with its
   // definition during creation

--- a/test-app/tests/integration/string-properties-test.ts
+++ b/test-app/tests/integration/string-properties-test.ts
@@ -89,4 +89,12 @@ Key: "stringProp"`)
 
     assert.strictEqual(po.items[0]?.foo, 'bar');
   });
+
+  test('allows plain arrays', function (assert) {
+    const po = create({
+      items: ['one', 'two', 'three'],
+    });
+
+    assert.deepEqual(po.items, ['one', 'two', 'three']);
+  });
 });


### PR DESCRIPTION
When having plain arrays defined on a PO, the string properties assertion would throw an error:
```
Error: string values are not supported in page object definitions Key: "0"`
```