### PR TITLE
Better errors from visitable

### DIFF
--- a/addon/src/-private/better-errors.js
+++ b/addon/src/-private/better-errors.js
@@ -24,7 +24,7 @@ export function throwBetterError(node, key, error, { selector } = {}) {
 
   const wrapperError = new PageObjectError(message, {
     cause: {
-      message,
+      message: error.cause ? error.cause.toString() : message,
       key,
       node,
       selector,

--- a/addon/src/properties/visitable.js
+++ b/addon/src/properties/visitable.js
@@ -139,7 +139,9 @@ export function visitable(path) {
     return getAdapter()
       .visit(fullPath)
       .catch((e) => {
-        throw new Error(`Failed to visit URL '${fullPath}': ${e.message}`);
+        throw new Error(`Failed to visit URL '${fullPath}': ${e.toString()}`, {
+          cause: e,
+        });
       });
   });
 }

--- a/addon/src/properties/visitable.js
+++ b/addon/src/properties/visitable.js
@@ -138,8 +138,8 @@ export function visitable(path) {
 
     return getAdapter()
       .visit(fullPath)
-      .catch(() => {
-        throw new Error(`Failed to visit URL '${fullPath}'`);
+      .catch((e) => {
+        throw new Error(`Failed to visit URL '${fullPath}': ${e.message}`);
       });
   });
 }

--- a/test-app/tests/unit/-private/properties/visitable-test.ts
+++ b/test-app/tests/unit/-private/properties/visitable-test.ts
@@ -108,10 +108,15 @@ module('visitable', function (hooks) {
     } catch (e) {
       assert.strictEqual(
         e?.toString(),
-        `Error: Failed to visit URL '/non-existing-url/value': /non-existing-url/value
+        `Error: Failed to visit URL '/non-existing-url/value': UnrecognizedURLError: /non-existing-url/value
 
 PageObject: 'page.foo("[object Object]")'
   Selector: '.scope'`
+      );
+
+      assert.strictEqual(
+        (e as any).cause.message,
+        'UnrecognizedURLError: /non-existing-url/value'
       );
     }
   });

--- a/test-app/tests/unit/-private/properties/visitable-test.ts
+++ b/test-app/tests/unit/-private/properties/visitable-test.ts
@@ -108,7 +108,7 @@ module('visitable', function (hooks) {
     } catch (e) {
       assert.strictEqual(
         e?.toString(),
-        `Error: Failed to visit URL '/non-existing-url/value'
+        `Error: Failed to visit URL '/non-existing-url/value': /non-existing-url/value
 
 PageObject: 'page.foo("[object Object]")'
   Selector: '.scope'`

--- a/test-app/tsconfig.json
+++ b/test-app/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/ember/tsconfig.json",
   "compilerOptions": {
+    "target": "es2022",
     // The combination of `baseUrl` with `paths` allows Ember's classic package
     // layout, which is not resolvable with the Node resolution algorithm, to
     // work with TypeScript.


### PR DESCRIPTION
This adds the actual error message from Ember's router to the (too generic) message from `visitable`. This is especially important when your test needs to know what kind of error was triggered. For example some tests might want to handle `TransitionAborted` errors differently, see https://github.com/emberjs/ember-test-helpers/issues/332#issuecomment-414641697.