### PR TITLE
fix: include blueprints when publishing

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -50,6 +50,7 @@
   },
   "files": [
     "addon-main.js",
+    "blueprints",
     "dist",
     "types.d.ts"
   ],


### PR DESCRIPTION
Closes https://github.com/san650/ember-cli-page-object/issues/641