### PR TITLE
fix(ci) upgrade pnpm/action-setup to the current latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: 14.x
 
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v2.4.1
         with:
           version: 7.29.3
           run_install: false
@@ -61,7 +61,7 @@ jobs:
         with:
           node-version: 14.x
 
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v2.4.1
         with:
           version: 7.29.3
           run_install: false
@@ -90,7 +90,7 @@ jobs:
         with:
           node-version: 14.x
 
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v2.4.1
         with:
           version: 7.29.3
           run_install: false
@@ -128,7 +128,7 @@ jobs:
         with:
           node-version: 14.x
 
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v2.4.1
         with:
           version: 7.29.3
           run_install: false


### PR DESCRIPTION
it currently fails with the 
```
Running self-installer...
   WARN  GET https://registry.npmjs.org/pnpm error (ERR_INVALID_THIS). Will retry in 10 seconds. 2 retries left.
   WARN  GET https://registry.npmjs.org/pnpm error (ERR_INVALID_THIS). Will retry in 1 minute. 1 retries left.
   ERR_PNPM_META_FETCH_FAIL  GET https://registry.npmjs.org/pnpm: Value of "this" must be of type URLSearchParams
Error: Something went wrong, self-installer exits with code 1
```
https://github.com/san650/ember-cli-page-object/actions/runs/11084629777/job/30825358176?pr=642#step:4:13