### PR TITLE
Fix package.json exports for index modules

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -30,6 +30,21 @@
       "require": "./dist/index.js",
       "types": "./types.d.ts"
     },
+    "./adapters": {
+      "import": "./dist/adapters/index.js",
+      "require": "./dist/adapters/index.js",
+      "types": "./types.d.ts"
+    },
+    "./extend": {
+      "import": "./dist/extend/index.js",
+      "require": "./dist/extend/index.js",
+      "types": "./types.d.ts"
+    },
+    "./macros": {
+      "import": "./dist/macros/index.js",
+      "require": "./dist/macros/index.js",
+      "types": "./types.d.ts"
+    },
     "./*": {
       "import": "./dist/*",
       "require": "./dist/*",


### PR DESCRIPTION
An import like `import { alias } from 'ember-cli-page-object/macros';` was failing to build when using Vite. It turns out there are indeed exports entries missing for all imports that should resolve to an index.js module. The existing `./*` would not cover those correctly (there is no `./dist/macros.js`).

I _think_ this change here is correct, I wonder though why this didn't came up earlier, with ember-cli and ember-auto-import or Embroider, both using webpack which should also acknowledge package.json exports. 🤔 